### PR TITLE
Add unit tests across auth utilities

### DIFF
--- a/tests/authMiddleware.test.js
+++ b/tests/authMiddleware.test.js
@@ -1,0 +1,55 @@
+import {expect, jest, test} from '@jest/globals';
+
+const verifyMock = jest.fn();
+const findByPkMock = jest.fn();
+
+jest.unstable_mockModule('jsonwebtoken', () => ({
+  __esModule: true,
+  default: { verify: verifyMock },
+  verify: verifyMock,
+}));
+
+jest.unstable_mockModule('../src/models/user.js', () => ({
+  __esModule: true,
+  default: { findByPk: findByPkMock },
+}));
+
+const { default: auth } = await import('../src/middlewares/auth.js');
+
+ test('valid token attaches user to request', async () => {
+  const req = { headers: { authorization: 'Bearer t' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  const user = { id: '1' };
+  verifyMock.mockReturnValue({ sub: '1' });
+  findByPkMock.mockResolvedValue(user);
+
+  await auth(req, res, next);
+
+  expect(req.user).toBe(user);
+  expect(next).toHaveBeenCalled();
+});
+
+ test('missing token returns 401', async () => {
+  const req = { headers: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+
+  await auth(req, res, next);
+
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(next).not.toHaveBeenCalled();
+});
+
+ test('user not found returns 401', async () => {
+  const req = { headers: { authorization: 'Bearer t' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  verifyMock.mockReturnValue({ sub: '1' });
+  findByPkMock.mockResolvedValue(null);
+
+  await auth(req, res, next);
+
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(next).not.toHaveBeenCalled();
+});

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -16,6 +16,7 @@ jest.unstable_mockModule('bcryptjs', () => ({
   compare: compareMock,
 }));
 
+// eslint-disable-next-line no-undef
 process.env.JWT_SECRET = 'secret';
 const { default: authService } = await import('../src/services/authService.js');
 import jwt from 'jsonwebtoken';

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,0 +1,70 @@
+import {expect, jest, test} from '@jest/globals';
+
+const compareMock = jest.fn();
+const findOneMock = jest.fn();
+const scopeMock = jest.fn(() => ({ findOne: findOneMock }));
+const findByPkMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/user.js', () => ({
+  __esModule: true,
+  default: { scope: scopeMock, findByPk: findByPkMock },
+}));
+
+jest.unstable_mockModule('bcryptjs', () => ({
+  __esModule: true,
+  default: { compare: compareMock },
+  compare: compareMock,
+}));
+
+process.env.JWT_SECRET = 'secret';
+const { default: authService } = await import('../src/services/authService.js');
+import jwt from 'jsonwebtoken';
+
+const user = { id: '1', password: 'hash' };
+
+ test('verifyCredentials returns user when valid', async () => {
+  findOneMock.mockResolvedValue(user);
+  compareMock.mockResolvedValue(true);
+  const res = await authService.verifyCredentials('a@b.c', 'pass');
+  expect(res).toBe(user);
+});
+
+ test('verifyCredentials throws for unknown email', async () => {
+  findOneMock.mockResolvedValue(null);
+  await expect(authService.verifyCredentials('a', 'b')).rejects.toThrow('invalid_credentials');
+});
+
+ test('verifyCredentials throws for bad password', async () => {
+  findOneMock.mockResolvedValue(user);
+  compareMock.mockResolvedValue(false);
+  await expect(authService.verifyCredentials('a', 'b')).rejects.toThrow('invalid_credentials');
+});
+
+ test('issueTokens creates valid JWTs', () => {
+  const tokens = authService.issueTokens({ id: '1' });
+  const p1 = jwt.verify(tokens.accessToken, 'secret');
+  const p2 = jwt.verify(tokens.refreshToken, 'secret');
+  expect(p1.sub).toBe('1');
+  expect(p2.sub).toBe('1');
+  expect(p2.type).toBe('refresh');
+});
+
+ test('rotateTokens returns new tokens and user', async () => {
+  findByPkMock.mockResolvedValue(user);
+  const { refreshToken } = authService.issueTokens(user);
+  const result = await authService.rotateTokens(refreshToken);
+  expect(result.user).toBe(user);
+  expect(result.accessToken).toBeDefined();
+  expect(result.refreshToken).toBeDefined();
+});
+
+ test('rotateTokens rejects token with wrong type', async () => {
+  const { accessToken } = authService.issueTokens(user);
+  await expect(authService.rotateTokens(accessToken)).rejects.toThrow('invalid_token');
+});
+
+ test('rotateTokens rejects missing user', async () => {
+  findByPkMock.mockResolvedValue(null);
+  const { refreshToken } = authService.issueTokens(user);
+  await expect(authService.rotateTokens(refreshToken)).rejects.toThrow('user_not_found');
+});

--- a/tests/cookie.test.js
+++ b/tests/cookie.test.js
@@ -1,0 +1,30 @@
+import {expect, test, jest} from '@jest/globals';
+import { setRefreshCookie, clearRefreshCookie } from '../src/utils/cookie.js';
+
+ test('setRefreshCookie calls res.cookie with options', () => {
+  const res = { cookie: jest.fn() };
+  setRefreshCookie(res, 'token');
+  expect(res.cookie).toHaveBeenCalledWith(
+    'refresh_token',
+    'token',
+    expect.objectContaining({
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: false,
+      maxAge: expect.any(Number),
+    })
+  );
+});
+
+ test('clearRefreshCookie calls res.clearCookie with options', () => {
+  const res = { clearCookie: jest.fn() };
+  clearRefreshCookie(res);
+  expect(res.clearCookie).toHaveBeenCalledWith(
+    'refresh_token',
+    expect.objectContaining({
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: false,
+    })
+  );
+});

--- a/tests/userMapper.test.js
+++ b/tests/userMapper.test.js
@@ -1,0 +1,16 @@
+import {expect, test} from '@jest/globals';
+import mapper from '../src/mappers/userMapper.js';
+
+test('toPublic unwraps user model', () => {
+  const user = { get: () => ({ id: '1', first_name: 'A' }) };
+  expect(mapper.toPublic(user)).toEqual({ id: '1', first_name: 'A' });
+});
+
+test('toPublic returns null for null input', () => {
+  expect(mapper.toPublic(null)).toBeNull();
+});
+
+test('toPublicArray maps array', () => {
+  const users = [ { get: () => ({ id: '1' }) }, { get: () => ({ id: '2' }) } ];
+  expect(mapper.toPublicArray(users)).toEqual([{ id: '1' }, { id: '2' }]);
+});

--- a/tests/utilsJwt.test.js
+++ b/tests/utilsJwt.test.js
@@ -1,0 +1,24 @@
+import {expect, test} from '@jest/globals';
+
+process.env.JWT_SECRET = 'secret';
+const { signAccessToken, signRefreshToken, verifyAccessToken, verifyRefreshToken } = await import('../src/utils/jwt.js');
+
+const user = { id: '42' };
+
+ test('access token round trip', () => {
+  const token = signAccessToken(user);
+  const payload = verifyAccessToken(token);
+  expect(payload.sub).toBe(user.id);
+});
+
+ test('refresh token round trip', () => {
+  const token = signRefreshToken(user);
+  const payload = verifyRefreshToken(token);
+  expect(payload.sub).toBe(user.id);
+  expect(payload.type).toBe('refresh');
+});
+
+ test('verifyRefreshToken rejects access token', () => {
+  const token = signAccessToken(user);
+  expect(() => verifyRefreshToken(token)).toThrow('invalid_token_type');
+});

--- a/tests/utilsJwt.test.js
+++ b/tests/utilsJwt.test.js
@@ -1,5 +1,6 @@
 import {expect, test} from '@jest/globals';
 
+// eslint-disable-next-line no-undef
 process.env.JWT_SECRET = 'secret';
 const { signAccessToken, signRefreshToken, verifyAccessToken, verifyRefreshToken } = await import('../src/utils/jwt.js');
 


### PR DESCRIPTION
## Summary
- add tests for JWT helpers
- add tests for cookie helpers
- cover user mapper utilities
- test auth service and middleware logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846c672f638832da34bf5ba8d4387a6