### PR TITLE
Fix duplicate code

### DIFF
--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -3,7 +3,6 @@ import { validationResult } from 'express-validator';
 import authService from '../services/authService.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie, clearRefreshCookie } from '../utils/cookie.js';
-import { signAccessToken, signRefreshToken } from '../utils/jwt.js';
 import { COOKIE_NAME } from '../config/auth.js';
 
 /* ---------- controller ---------------------------------------------------- */
@@ -19,8 +18,7 @@ export default {
 
     try {
       const user = await authService.verifyCredentials(email, password);
-      const accessToken = signAccessToken(user);
-      const refreshToken = signRefreshToken(user);
+      const { accessToken, refreshToken } = authService.issueTokens(user);
 
       setRefreshCookie(res, refreshToken);
 

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -1,6 +1,4 @@
-const SECURE_COOKIE = process.env.NODE_ENV === 'production';
-const COOKIE_NAME = 'refresh_token';
-const REFRESH_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+import { COOKIE_NAME, COOKIE_OPTIONS } from '../config/auth.js';
 
 /**
  * Set refresh-token cookie.
@@ -9,12 +7,7 @@ const REFRESH_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
  * @param {string} token
  */
 export function setRefreshCookie(res, token) {
-  res.cookie(COOKIE_NAME, token, {
-    httpOnly: true,
-    sameSite: 'strict',
-    secure: SECURE_COOKIE,
-    maxAge: REFRESH_MAX_AGE,
-  });
+  res.cookie(COOKIE_NAME, token, COOKIE_OPTIONS);
 }
 
 /**
@@ -23,9 +16,5 @@ export function setRefreshCookie(res, token) {
  * @param {import('express').Response} res
  */
 export function clearRefreshCookie(res) {
-  res.clearCookie(COOKIE_NAME, {
-    httpOnly: true,
-    sameSite: 'strict',
-    secure: SECURE_COOKIE,
-  });
+  res.clearCookie(COOKIE_NAME, COOKIE_OPTIONS);
 }

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,24 +1,24 @@
 import jwt from 'jsonwebtoken';
 
-const {
+import {
   JWT_SECRET,
-  JWT_ACCESS_TTL = '15m',
-  JWT_REFRESH_TTL = '30d',
-  JWT_ALG = 'HS256',
-} = process.env;
+  ACCESS_TTL,
+  REFRESH_TTL,
+  JWT_ALG,
+} from '../config/auth.js';
 
 /* ---------- sign helpers -------------------------------------------------- */
 export function signAccessToken(user) {
   return jwt.sign({ sub: user.id }, JWT_SECRET, {
     algorithm: JWT_ALG,
-    expiresIn: JWT_ACCESS_TTL,
+    expiresIn: ACCESS_TTL,
   });
 }
 
 export function signRefreshToken(user) {
   return jwt.sign({ sub: user.id, type: 'refresh' }, JWT_SECRET, {
     algorithm: JWT_ALG,
-    expiresIn: JWT_REFRESH_TTL,
+    expiresIn: REFRESH_TTL,
   });
 }
 

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -1,10 +1,11 @@
 import {expect, jest, test} from '@jest/globals';
 
 const verifyCredentialsMock = jest.fn();
+const issueTokensMock = jest.fn(() => ({ accessToken: 'access', refreshToken: 'refresh' }));
 
 jest.unstable_mockModule('../src/services/authService.js', () => ({
   __esModule: true,
-  default: { verifyCredentials: verifyCredentialsMock },
+  default: { verifyCredentials: verifyCredentialsMock, issueTokens: issueTokensMock },
 }));
 
 const setRefreshCookieMock = jest.fn();


### PR DESCRIPTION
## Summary
- centralize cookie options and JWT constants
- create tokens via authService.issueTokens
- update cookie/jwt helpers to reuse constants
- adjust tests for new authService API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e8d8a1b4832d9fbd81ede1602b81