### PR TITLE
Increase test coverage

### DIFF
--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -1,17 +1,22 @@
 import {expect, jest, test} from '@jest/globals';
 
 const verifyCredentialsMock = jest.fn();
+const rotateTokensMock = jest.fn();
 
 jest.unstable_mockModule('../src/services/authService.js', () => ({
   __esModule: true,
-  default: { verifyCredentials: verifyCredentialsMock },
+  default: {
+    verifyCredentials: verifyCredentialsMock,
+    rotateTokens: rotateTokensMock,
+  },
 }));
 
 const setRefreshCookieMock = jest.fn();
+const clearRefreshCookieMock = jest.fn();
 jest.unstable_mockModule('../src/utils/cookie.js', () => ({
   __esModule: true,
   setRefreshCookie: setRefreshCookieMock,
-  clearRefreshCookie: jest.fn(),
+  clearRefreshCookie: clearRefreshCookieMock,
 }));
 
 const signAccessTokenMock = jest.fn(() => 'access');
@@ -32,8 +37,12 @@ jest.unstable_mockModule('../src/mappers/userMapper.js', () => ({
   default: { toPublic: toPublicMock },
 }));
 
+let validationOk = true;
 jest.unstable_mockModule('express-validator', () => ({
-  validationResult: jest.fn(() => ({ isEmpty: () => true })),
+  validationResult: jest.fn(() => ({
+    isEmpty: () => validationOk,
+    array: () => [{ msg: 'bad' }],
+  })),
 }));
 
 const { default: authController } = await import('../src/controllers/authController.js');
@@ -58,4 +67,77 @@ test('login does not include password in response', async () => {
   expect(response.user.password).toBeUndefined();
   expect(verifyCredentialsMock).toHaveBeenCalledWith('a@b.c', 'pass');
   expect(setRefreshCookieMock).toHaveBeenCalledWith(res, 'refresh');
+});
+
+test('login validation failure returns 400', async () => {
+  validationOk = false;
+  const req = { body: {}, cookies: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await authController.login(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith({ errors: [{ msg: 'bad' }] });
+  validationOk = true;
+});
+
+test('logout clears refresh cookie', async () => {
+  const req = {};
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await authController.logout(req, res);
+
+  expect(clearRefreshCookieMock).toHaveBeenCalledWith(res);
+  expect(res.status).toHaveBeenCalledWith(200);
+  expect(res.json).toHaveBeenCalledWith({ message: 'Logged out' });
+});
+
+test('me returns sanitized user', async () => {
+  const req = { user: { id: '1', password: 'hash' } };
+  const res = { json: jest.fn() };
+
+  await authController.me(req, res);
+
+  expect(toPublicMock).toHaveBeenCalledWith(req.user);
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
+});
+
+test('refresh returns new tokens when valid', async () => {
+  const user = { id: '1' };
+  rotateTokensMock.mockResolvedValue({
+    user,
+    accessToken: 'a',
+    refreshToken: 'r',
+  });
+
+  const req = { cookies: { refresh_token: 'r' }, body: {} };
+  const res = { json: jest.fn() };
+
+  await authController.refresh(req, res);
+
+  expect(rotateTokensMock).toHaveBeenCalledWith('r');
+  expect(setRefreshCookieMock).toHaveBeenCalledWith(res, 'r');
+  expect(res.json).toHaveBeenCalledWith({
+    access_token: 'a',
+    user: { id: '1' },
+  });
+});
+
+test('refresh missing token returns 401', async () => {
+  const req = { cookies: {}, body: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await authController.refresh(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(401);
+});
+
+test('refresh invalid token returns 401', async () => {
+  rotateTokensMock.mockRejectedValue(new Error('bad'));
+  const req = { cookies: { refresh_token: 'x' }, body: {} };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await authController.refresh(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(401);
 });

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -1,0 +1,47 @@
+import {expect, jest, test} from '@jest/globals';
+
+const authenticateMock = jest.fn();
+const closeMock = jest.fn();
+const SequelizeMock = jest.fn(() => ({
+  authenticate: authenticateMock,
+  close: closeMock,
+}));
+
+jest.unstable_mockModule('sequelize', () => ({
+  __esModule: true,
+  Sequelize: SequelizeMock,
+}));
+
+jest.unstable_mockModule('dotenv', () => ({
+  __esModule: true,
+  default: { config: jest.fn() },
+}));
+
+process.env.DB_NAME = 'db';
+process.env.DB_USER = 'user';
+process.env.DB_PASS = 'pass';
+process.env.DB_HOST = 'localhost';
+process.env.DB_PORT = '5432';
+
+const {
+  connectToDatabase,
+  closeDatabase,
+} = await import('../src/config/database.js');
+
+test('connectToDatabase authenticates', async () => {
+  await connectToDatabase();
+  expect(authenticateMock).toHaveBeenCalled();
+});
+
+test('connectToDatabase exits on failure', async () => {
+  authenticateMock.mockRejectedValueOnce(new Error('fail'));
+  const exitMock = jest.spyOn(process, 'exit').mockImplementation(() => {});
+  await connectToDatabase();
+  expect(exitMock).toHaveBeenCalledWith(1);
+  exitMock.mockRestore();
+});
+
+test('closeDatabase closes connection', async () => {
+  await closeDatabase();
+  expect(closeMock).toHaveBeenCalled();
+});

--- a/tests/requestLogger.test.js
+++ b/tests/requestLogger.test.js
@@ -1,0 +1,59 @@
+import {expect, jest, test} from '@jest/globals';
+
+const createMock = jest.fn();
+const uuidMock = jest.fn(() => 'id');
+const onFinishedMock = jest.fn((res, cb) => cb());
+const warnMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/log.js', () => ({
+  __esModule: true,
+  default: { create: createMock },
+}));
+
+jest.unstable_mockModule('uuid', () => ({
+  __esModule: true,
+  v4: uuidMock,
+}));
+
+jest.unstable_mockModule('on-finished', () => ({
+  __esModule: true,
+  default: onFinishedMock,
+}));
+
+jest.unstable_mockModule('../logger.js', () => ({
+  __esModule: true,
+  default: { warn: warnMock },
+}));
+
+const { default: requestLogger } = await import('../src/middlewares/requestLogger.js');
+
+test('persists log entry on finish', async () => {
+  const req = { method: 'GET', originalUrl: '/x', ip: '::1', get: () => 'ua', body: {foo:'bar'} };
+  const res = { statusCode: 200, locals: { body: 'ok' } };
+  const next = jest.fn();
+
+  await requestLogger(req, res, next);
+
+  expect(next).toHaveBeenCalled();
+  expect(onFinishedMock).toHaveBeenCalledWith(res, expect.any(Function));
+  expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
+    id: 'id',
+    method: 'GET',
+    path: '/x',
+    status_code: 200,
+    ip: '::1',
+    user_agent: 'ua',
+    request_body: {foo:'bar'},
+    response_body: 'ok',
+  }));
+});
+
+test('logs warning when create fails', async () => {
+  createMock.mockRejectedValueOnce(new Error('fail'));
+  const req = { method: 'GET', originalUrl: '/x', ip: '::1', get: () => 'ua', body: {} };
+  const res = { statusCode: 200, locals: {} };
+
+  await requestLogger(req, res, () => {});
+
+  expect(warnMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- extend authController tests to cover validation, logout, me and token refresh flows
- add tests for DB connection logic
- add tests for request logging middleware

## Testing
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx jest --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6846e8f05034832d9dda2b1c9271be8c