### PR TITLE
Remove technical fields from API responses

### DIFF
--- a/src/mappers/userMapper.js
+++ b/src/mappers/userMapper.js
@@ -8,8 +8,27 @@ function sanitize(userObj) {
     phone,
     birth_date,
     status_id,
-    ...rest
+    ...technical
   } = userObj;
+
+  const {
+    password,
+    createdAt,
+    updatedAt,
+    deletedAt,
+    created_at,
+    updated_at,
+    deleted_at,
+    ...rest
+  } = technical;
+
+  void password;
+  void createdAt;
+  void updatedAt;
+  void deletedAt;
+  void created_at;
+  void updated_at;
+  void deleted_at;
 
   return {
     id,

--- a/tests/userMapper.test.js
+++ b/tests/userMapper.test.js
@@ -1,16 +1,35 @@
-import {expect, test} from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import mapper from '../src/mappers/userMapper.js';
 
-test('toPublic unwraps user model', () => {
-  const user = { get: () => ({ id: '1', first_name: 'A' }) };
-  expect(mapper.toPublic(user)).toEqual({ id: '1', first_name: 'A' });
-});
+describe('userMapper', () => {
+  test('toPublic unwraps user model', () => {
+    const user = { get: () => ({ id: '1', first_name: 'A' }) };
+    expect(mapper.toPublic(user)).toEqual({ id: '1', first_name: 'A' });
+  });
 
-test('toPublic returns null for null input', () => {
-  expect(mapper.toPublic(null)).toBeNull();
-});
+  test('toPublic removes technical fields', () => {
+    const user = {
+      get: () => ({
+        id: '1',
+        first_name: 'A',
+        password: 'x',
+        createdAt: 't',
+        updatedAt: 't',
+        deletedAt: null,
+      }),
+    };
+    expect(mapper.toPublic(user)).toEqual({ id: '1', first_name: 'A' });
+  });
 
-test('toPublicArray maps array', () => {
-  const users = [ { get: () => ({ id: '1' }) }, { get: () => ({ id: '2' }) } ];
-  expect(mapper.toPublicArray(users)).toEqual([{ id: '1' }, { id: '2' }]);
+  test('toPublic returns null for null input', () => {
+    expect(mapper.toPublic(null)).toBeNull();
+  });
+
+  test('toPublicArray maps array', () => {
+    const users = [
+      { get: () => ({ id: '1' }) },
+      { get: () => ({ id: '2' }) },
+    ];
+    expect(mapper.toPublicArray(users)).toEqual([{ id: '1' }, { id: '2' }]);
+  });
 });


### PR DESCRIPTION
## Summary
- filter out password and timestamp columns in userMapper
- adjust userMapper tests
- modernize authController tests and ensure sensitive fields are removed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847f382aa8c832d9fcab9e7ba4d56ea