### PR TITLE
Switch to phone number login

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -26,10 +26,14 @@ onMounted(fetchUser)
 </script>
 
 <template>
-  <div class="container mt-5">
-    <div v-if="user">
-      <h1 class="mb-4">Welcome {{ user.email }}</h1>
-      <button class="btn btn-secondary" @click="logout">Logout</button>
-    </div>
+  <div class="container mt-5" v-if="user">
+    <nav class="mb-3">
+      <!-- menu items will be added here -->
+      <ul class="nav">
+        <li class="nav-item"><a class="nav-link" href="#">Menu</a></li>
+      </ul>
+    </nav>
+    <h1 class="mb-4">Welcome {{ user.phone }}</h1>
+    <button class="btn btn-secondary" @click="logout">Logout</button>
   </div>
 </template>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -4,7 +4,7 @@ import { useRouter } from 'vue-router'
 import { apiFetch } from '../api.js'
 
 const router = useRouter()
-const email = ref('')
+const phone = ref('')
 const password = ref('')
 const error = ref('')
 
@@ -13,7 +13,7 @@ async function login() {
   try {
     const data = await apiFetch('/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ email: email.value, password: password.value })
+      body: JSON.stringify({ phone: phone.value, password: password.value })
     })
     localStorage.setItem('access_token', data.access_token)
     router.push('/')
@@ -30,8 +30,8 @@ async function login() {
       <div v-if="error" class="alert alert-danger">{{ error }}</div>
       <form @submit.prevent="login">
         <div class="mb-3">
-          <label class="form-label">Email</label>
-          <input v-model="email" type="email" class="form-control" required />
+          <label class="form-label">Phone</label>
+          <input v-model="phone" type="tel" class="form-control" required />
         </div>
         <div class="mb-3">
           <label class="form-label">Password</label>

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -14,10 +14,10 @@ export default {
       return res.status(400).json({ errors: errors.array() });
     }
 
-    const { email, password } = req.body;
+    const { phone, password } = req.body;
 
     try {
-      const user = await authService.verifyCredentials(email, password);
+      const user = await authService.verifyCredentials(phone, password);
       const { accessToken, refreshToken } = authService.issueTokens(user);
 
       setRefreshCookie(res, refreshToken);

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -18,10 +18,10 @@ const router = express.Router();
  *           schema:
  *             type: object
  *             required:
- *               - email
+ *               - phone
  *               - password
  *             properties:
- *               email:
+ *               phone:
  *                 type: string
  *               password:
  *                 type: string

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -8,8 +8,8 @@ import {
 } from '../utils/jwt.js';
 
 /* ------------------- service implementation ------------------------------ */
-async function verifyCredentials(email, password) {
-  const user = await User.scope('withPassword').findOne({ where: { email } });
+async function verifyCredentials(phone, password) {
+  const user = await User.scope('withPassword').findOne({ where: { phone } });
   if (!user) throw new Error('invalid_credentials');
 
   const ok = await bcrypt.compare(password, user.password);

--- a/src/validators/authValidators.js
+++ b/src/validators/authValidators.js
@@ -1,10 +1,13 @@
 import { body } from 'express-validator';
 
 /* --------------------------------------------------------------------------
- * /auth/login  – email + password
+ * /auth/login  – phone + password
  * -------------------------------------------------------------------------*/
 export const loginRules = [
-  body('email').isEmail().withMessage('Must be a valid email').normalizeEmail(),
+  body('phone')
+    .isMobilePhone()
+    .withMessage('Must be a valid phone number')
+    .trim(),
   body('password').isString().notEmpty().withMessage('Password is required'),
 ];
 

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -69,7 +69,7 @@ describe('authController', () => {
 test('login does not include sensitive fields in response', async () => {
   const user = {
     id: '1',
-    email: 'a@b.c',
+    phone: '123',
     password: 'hash',
     createdAt: 't',
     updatedAt: 't',
@@ -77,7 +77,7 @@ test('login does not include sensitive fields in response', async () => {
   };
   verifyCredentialsMock.mockResolvedValue(user);
 
-  const req = { body: { email: 'a@b.c', password: 'pass' }, cookies: {} };
+  const req = { body: { phone: '123', password: 'pass' }, cookies: {} };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
   await authController.login(req, res);
@@ -87,7 +87,7 @@ test('login does not include sensitive fields in response', async () => {
   expect(response.user.createdAt).toBeUndefined();
   expect(response.user.updatedAt).toBeUndefined();
   expect(response.user.deletedAt).toBeUndefined();
-  expect(verifyCredentialsMock).toHaveBeenCalledWith('a@b.c', 'pass');
+  expect(verifyCredentialsMock).toHaveBeenCalledWith('123', 'pass');
   expect(setRefreshCookieMock).toHaveBeenCalledWith(res, 'refresh');
 });
 

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -23,19 +23,19 @@ import jwt from 'jsonwebtoken';
 
 const user = { id: '1', password: 'hash' };
 
- test('verifyCredentials returns user when valid', async () => {
+test('verifyCredentials returns user when valid', async () => {
   findOneMock.mockResolvedValue(user);
   compareMock.mockResolvedValue(true);
-  const res = await authService.verifyCredentials('a@b.c', 'pass');
+  const res = await authService.verifyCredentials('123', 'pass');
   expect(res).toBe(user);
 });
 
- test('verifyCredentials throws for unknown email', async () => {
+test('verifyCredentials throws for unknown phone', async () => {
   findOneMock.mockResolvedValue(null);
   await expect(authService.verifyCredentials('a', 'b')).rejects.toThrow('invalid_credentials');
 });
 
- test('verifyCredentials throws for bad password', async () => {
+test('verifyCredentials throws for bad password', async () => {
   findOneMock.mockResolvedValue(user);
   compareMock.mockResolvedValue(false);
   await expect(authService.verifyCredentials('a', 'b')).rejects.toThrow('invalid_credentials');


### PR DESCRIPTION
## Summary
- login using phone number instead of email
- document phone based login route
- update validators, controller and service
- adjust frontend login form and home page menu placeholder
- update unit tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fe064b11c832d983cc740532a9079