### PR TITLE
Implement user info viewing

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,14 +1,19 @@
 import express from 'express';
 import swaggerUi from 'swagger-ui-express';
+import cors from 'cors';
 
 import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
 import swaggerSpec from './src/docs/swagger.js';
+import cookieParser from 'cookie-parser';
 
 const app = express();
 
+app.use(cors({ origin: true, credentials: true }));
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
+app.use(cookieParser());
 app.use(requestLogger);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@jest/globals": "^30.0.0-beta.3",
         "bcryptjs": "^3.0.2",
         "cookie-parser": "~1.4.4",
+        "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
@@ -3333,6 +3334,19 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -8892,6 +8906,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@jest/globals": "^30.0.0-beta.3",
     "bcryptjs": "^3.0.2",
     "cookie-parser": "~1.4.4",
+    "cors": "^2.8.5",
     "debug": "~2.6.9",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -3,6 +3,7 @@ import { validationResult } from 'express-validator';
 import authService from '../services/authService.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie, clearRefreshCookie } from '../utils/cookie.js';
+import { signAccessToken, signRefreshToken } from '../utils/jwt.js';
 import { COOKIE_NAME } from '../config/auth.js';
 
 /* ---------- controller ---------------------------------------------------- */
@@ -18,7 +19,8 @@ export default {
 
     try {
       const user = await authService.verifyCredentials(email, password);
-      const { accessToken, refreshToken } = authService.issueTokens(user);
+      const accessToken = signAccessToken(user);
+      const refreshToken = signRefreshToken(user);
 
       setRefreshCookie(res, refreshToken);
 

--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -1,0 +1,31 @@
+import User from '../models/user.js';
+import userMapper from '../mappers/userMapper.js';
+
+export default {
+  /**
+   * Get list of users
+   * @param {import('express').Request} _req
+   * @param {import('express').Response} res
+   */
+  async list(_req, res) {
+    const users = await User.findAll();
+    const sanitized = userMapper.toPublicArray(users);
+    res.locals.body = { users: sanitized };
+    return res.json({ users: sanitized });
+  },
+
+  /**
+   * Get user by id
+   * @param {import('express').Request} req
+   * @param {import('express').Response} res
+   */
+  async get(req, res) {
+    const user = await User.findByPk(req.params.id);
+    if (!user) {
+      return res.status(404).json({ error: 'User not found' });
+    }
+    const sanitized = userMapper.toPublic(user);
+    res.locals.body = { user: sanitized };
+    return res.json({ user: sanitized });
+  },
+};

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,5 +1,7 @@
 import express from 'express';
 
+import userController from '../controllers/userController.js';
+
 const router = express.Router();
 
 /**
@@ -11,10 +13,25 @@ const router = express.Router();
  *       200:
  *         description: Array of users
  */
-router.get('/', async (req, res) => {
-  const response = { users: [] }; // TODO: fetch from DB later
-  res.locals.body = response;
-  res.json(response);
-});
+router.get('/', userController.list);
+
+/**
+ * @swagger
+ * /users/{id}:
+ *   get:
+ *     summary: Get user by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: User details
+ *       404:
+ *         description: User not found
+ */
+router.get('/:id', userController.get);
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,6 +1,7 @@
 import express from 'express';
 
 import userController from '../controllers/userController.js';
+import auth from '../middlewares/auth.js';
 
 const router = express.Router();
 
@@ -13,7 +14,7 @@ const router = express.Router();
  *       200:
  *         description: Array of users
  */
-router.get('/', userController.list);
+router.get('/', auth, userController.list);
 
 /**
  * @swagger
@@ -32,6 +33,6 @@ router.get('/', userController.list);
  *       404:
  *         description: User not found
  */
-router.get('/:id', userController.get);
+router.get('/:id', auth, userController.get);
 
 export default router;

--- a/tests/userController.test.js
+++ b/tests/userController.test.js
@@ -1,0 +1,56 @@
+import { expect, jest, test } from '@jest/globals';
+
+const findAllMock = jest.fn();
+const findByPkMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/user.js', () => ({
+  __esModule: true,
+  default: { findAll: findAllMock, findByPk: findByPkMock },
+}));
+
+const toPublicArrayMock = jest.fn((u) => u);
+const toPublicMock = jest.fn((u) => u);
+
+jest.unstable_mockModule('../src/mappers/userMapper.js', () => ({
+  __esModule: true,
+  default: { toPublicArray: toPublicArrayMock, toPublic: toPublicMock },
+}));
+
+const { default: userController } = await import('../src/controllers/userController.js');
+
+ test('list returns mapped users', async () => {
+  const req = {};
+  const res = { json: jest.fn(), locals: {} };
+  findAllMock.mockResolvedValue([{ id: '1' }]);
+  toPublicArrayMock.mockReturnValue([{ id: '1' }]);
+
+  await userController.list(req, res);
+
+  expect(findAllMock).toHaveBeenCalled();
+  expect(toPublicArrayMock).toHaveBeenCalled();
+  expect(res.json).toHaveBeenCalledWith({ users: [{ id: '1' }] });
+});
+
+ test('get returns mapped user when found', async () => {
+  const req = { params: { id: '1' } };
+  const res = { json: jest.fn(), locals: {}, status: jest.fn().mockReturnThis() };
+  const user = { id: '1' };
+  findByPkMock.mockResolvedValue(user);
+  toPublicMock.mockReturnValue({ id: '1' });
+
+  await userController.get(req, res);
+
+  expect(findByPkMock).toHaveBeenCalledWith('1');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
+});
+
+ test('get returns 404 when missing', async () => {
+  const req = { params: { id: '1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  findByPkMock.mockResolvedValue(null);
+
+  await userController.get(req, res);
+
+  expect(res.status).toHaveBeenCalledWith(404);
+  expect(res.json).toHaveBeenCalledWith({ error: 'User not found' });
+});


### PR DESCRIPTION
## Summary
- allow retrieving user details via controller and routes
- expose new `/users/:id` endpoint and fetch user list from DB
- adjust login controller to generate tokens directly
- test user controller

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685019dc1a9c832db24c1528ca0765ca