### PR TITLE
Enhance navigation and footer UI

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,3 +1,12 @@
+<script setup>
+import NavBar from './components/NavBar.vue'
+import AppFooter from './components/AppFooter.vue'
+</script>
+
 <template>
-  <router-view />
+  <div class="d-flex flex-column min-vh-100">
+    <NavBar />
+    <router-view class="flex-grow-1" />
+    <AppFooter />
+  </div>
 </template>

--- a/client/src/components/AppFooter.vue
+++ b/client/src/components/AppFooter.vue
@@ -1,0 +1,11 @@
+<script setup>
+const year = new Date().getFullYear()
+</script>
+
+<template>
+  <footer class="bg-light text-center py-3 mt-auto">
+    <div class="container">
+      <small>&copy; {{ year }} FH Pulse</small>
+    </div>
+  </footer>
+</template>

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { useRouter } from 'vue-router'
+import { apiFetch } from '../api.js'
+import { computed } from 'vue'
+
+const router = useRouter()
+const isAuthenticated = computed(() => !!localStorage.getItem('access_token'))
+
+function logout() {
+  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
+    localStorage.removeItem('access_token')
+    router.push('/login')
+  })
+}
+</script>
+
+<template>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container-fluid">
+      <RouterLink class="navbar-brand" to="/">FH Pulse</RouterLink>
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#navbarNav"
+        aria-controls="navbarNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item">
+            <a class="nav-link" href="#">My appointments</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Reports</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Fees</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="#">Personal information</a>
+          </li>
+        </ul>
+        <button
+          v-if="isAuthenticated"
+          class="btn btn-outline-light ms-lg-3"
+          @click="logout"
+        >
+          Logout
+        </button>
+      </div>
+    </div>
+  </nav>
+</template>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -15,35 +15,11 @@ async function fetchUser() {
   }
 }
 
-function logout() {
-  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
-    localStorage.removeItem('access_token')
-    router.push('/login')
-  })
-}
-
 onMounted(fetchUser)
 </script>
 
 <template>
   <div class="container mt-5" v-if="user">
-    <nav class="mb-3">
-      <ul class="nav nav-pills gap-2 flex-wrap">
-        <li class="nav-item">
-          <a class="nav-link" href="#">My appointments</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Reports</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Fees</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Personal information</a>
-        </li>
-      </ul>
-    </nav>
     <h1 class="mb-4">Welcome {{ user.phone }}</h1>
-    <button class="btn btn-secondary" @click="logout">Logout</button>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- implement a responsive navbar with logout
- add a simple footer component
- wrap pages with navbar and footer
- clean up `Home` view

## Testing
- `npm ci`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68501efc9e28832d88db5d1135c749a4