### PR TITLE
Implement profile page for current user

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,9 +1,11 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Login from './views/Login.vue'
 import Home from './views/Home.vue'
+import Profile from './views/Profile.vue'
 
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true } },
+  { path: '/profile', component: Profile, meta: { requiresAuth: true } },
   { path: '/login', component: Login }
 ]
 

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -39,7 +39,7 @@ onMounted(fetchUser)
           <a class="nav-link" href="#">Fees</a>
         </li>
         <li class="nav-item">
-          <a class="nav-link" href="#">Personal information</a>
+          <RouterLink class="nav-link" to="/profile">Personal information</RouterLink>
         </li>
       </ul>
     </nav>

--- a/client/src/views/Profile.vue
+++ b/client/src/views/Profile.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { apiFetch } from '../api.js'
+
+const user = ref(null)
+
+async function fetchProfile() {
+  try {
+    const data = await apiFetch('/users/me')
+    user.value = data.user
+  } catch (_err) {
+    user.value = null
+  }
+}
+
+onMounted(fetchProfile)
+</script>
+
+<template>
+  <div class="container mt-5">
+    <h1 class="mb-4">Personal information</h1>
+    <table class="table table-striped" v-if="user">
+      <tbody>
+        <tr>
+          <th>Last name</th>
+          <td>{{ user.last_name }}</td>
+        </tr>
+        <tr>
+          <th>First name</th>
+          <td>{{ user.first_name }}</td>
+        </tr>
+        <tr>
+          <th>Patronymic</th>
+          <td>{{ user.patronymic }}</td>
+        </tr>
+        <tr>
+          <th>Birth date</th>
+          <td>{{ user.birth_date }}</td>
+        </tr>
+        <tr>
+          <th>Phone</th>
+          <td>{{ user.phone }}</td>
+        </tr>
+        <tr>
+          <th>Email</th>
+          <td>{{ user.email }}</td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else>No user data found.</p>
+  </div>
+</template>

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,18 +1,22 @@
 import express from 'express';
+import auth from '../middlewares/auth.js';
+import userMapper from '../mappers/userMapper.js';
 
 const router = express.Router();
 
 /**
  * @swagger
- * /users:
+ * /users/me:
  *   get:
- *     summary: List all users
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Get current user data
  *     responses:
  *       200:
- *         description: Array of users
+ *         description: Current user info
  */
-router.get('/', async (req, res) => {
-  const response = { users: [] }; // TODO: fetch from DB later
+router.get('/me', auth, (req, res) => {
+  const response = { user: userMapper.toPublic(req.user) };
   res.locals.body = response;
   res.json(response);
 });


### PR DESCRIPTION
## Summary
- add profile page to display authenticated user information
- update router and navigation to point to `/profile`
- expose `/users/me` API route for personal data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68501ef22ba8832d8e4c70859a582908