### PR TITLE
Add admin user management features

### DIFF
--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -1,0 +1,86 @@
+import { validationResult } from 'express-validator';
+
+import userService from '../services/userService.js';
+import userMapper from '../mappers/userMapper.js';
+
+export default {
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const user = await userService.createUser(req.body);
+    return res.status(201).json({ user: userMapper.toPublic(user) });
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const user = await userService.updateUser(req.params.id, req.body);
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async block(req, res) {
+    try {
+      const user = await userService.setStatus(req.params.id, 'INACTIVE');
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async unblock(req, res) {
+    try {
+      const user = await userService.setStatus(req.params.id, 'ACTIVE');
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async resetPassword(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const user = await userService.resetPassword(
+        req.params.id,
+        req.body.password
+      );
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async assignRole(req, res) {
+    try {
+      const user = await userService.assignRole(
+        req.params.id,
+        req.params.roleAlias
+      );
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async removeRole(req, res) {
+    try {
+      const user = await userService.removeRole(
+        req.params.id,
+        req.params.roleAlias
+      );
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+};

--- a/src/middlewares/authorize.js
+++ b/src/middlewares/authorize.js
@@ -1,0 +1,9 @@
+export default function authorize(roleAlias) {
+  return async function (req, res, next) {
+    const roles = await req.user.getRoles({ where: { alias: roleAlias } });
+    if (!roles || roles.length === 0) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,7 +1,10 @@
 import express from 'express';
 
 import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
 import userMapper from '../mappers/userMapper.js';
+import admin from '../controllers/userAdminController.js';
+import { createUserRules, updateUserRules, resetPasswordRules } from '../validators/userValidators.js';
 
 const router = express.Router();
 
@@ -21,5 +24,43 @@ router.get('/me', auth, (req, res) => {
   res.locals.body = response;
   res.json(response);
 });
+
+/**
+ * @swagger
+ * /users:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Create user
+ *     responses:
+ *       201:
+ *         description: Created user
+ */
+router.post('/', auth, authorize('ADMIN'), createUserRules, admin.create);
+
+/**
+ * @swagger
+ * /users/{id}:
+ *   put:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Update user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user
+ */
+router.put('/:id', auth, authorize('ADMIN'), updateUserRules, admin.update);
+
+router.post('/:id/block', auth, authorize('ADMIN'), admin.block);
+router.post('/:id/unblock', auth, authorize('ADMIN'), admin.unblock);
+router.post('/:id/reset-password', auth, authorize('ADMIN'), resetPasswordRules, admin.resetPassword);
+router.post('/:id/roles/:roleAlias', auth, authorize('ADMIN'), admin.assignRole);
+router.delete('/:id/roles/:roleAlias', auth, authorize('ADMIN'), admin.removeRole);
 
 export default router;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,64 @@
+import { User, Role, UserStatus } from '../models/index.js';
+
+async function createUser(data) {
+  const status = await UserStatus.findOne({ where: { alias: 'ACTIVE' } });
+  const user = await User.create({ ...data, status_id: status.id });
+  return user;
+}
+
+async function updateUser(id, data) {
+  const user = await User.findByPk(id);
+  if (!user) throw new Error('user_not_found');
+  await user.update(data);
+  return user;
+}
+
+async function setStatus(id, alias) {
+  const [user, status] = await Promise.all([
+    User.findByPk(id),
+    UserStatus.findOne({ where: { alias } }),
+  ]);
+  if (!user) throw new Error('user_not_found');
+  if (!status) throw new Error('status_not_found');
+  await user.update({ status_id: status.id });
+  return user;
+}
+
+async function resetPassword(id, password) {
+  const user = await User.scope('withPassword').findByPk(id);
+  if (!user) throw new Error('user_not_found');
+  user.password = password;
+  await user.save();
+  return user;
+}
+
+async function assignRole(userId, alias) {
+  const [user, role] = await Promise.all([
+    User.findByPk(userId),
+    Role.findOne({ where: { alias } }),
+  ]);
+  if (!user) throw new Error('user_not_found');
+  if (!role) throw new Error('role_not_found');
+  await user.addRole(role);
+  return user;
+}
+
+async function removeRole(userId, alias) {
+  const [user, role] = await Promise.all([
+    User.findByPk(userId),
+    Role.findOne({ where: { alias } }),
+  ]);
+  if (!user) throw new Error('user_not_found');
+  if (!role) throw new Error('role_not_found');
+  await user.removeRole(role);
+  return user;
+}
+
+export default {
+  createUser,
+  updateUser,
+  setStatus,
+  resetPassword,
+  assignRole,
+  removeRole,
+};

--- a/src/validators/userValidators.js
+++ b/src/validators/userValidators.js
@@ -1,0 +1,23 @@
+import { body } from 'express-validator';
+
+export const createUserRules = [
+  body('first_name').isString().notEmpty(),
+  body('last_name').isString().notEmpty(),
+  body('birth_date').isISO8601(),
+  body('phone').isMobilePhone(),
+  body('email').isEmail(),
+  body('password').isString().notEmpty(),
+];
+
+export const updateUserRules = [
+  body('first_name').optional().isString().notEmpty(),
+  body('last_name').optional().isString().notEmpty(),
+  body('patronymic').optional().isString(),
+  body('birth_date').optional().isISO8601(),
+  body('phone').optional().isMobilePhone(),
+  body('email').optional().isEmail(),
+];
+
+export const resetPasswordRules = [
+  body('password').isString().notEmpty(),
+];

--- a/tests/authorizeMiddleware.test.js
+++ b/tests/authorizeMiddleware.test.js
@@ -1,0 +1,27 @@
+import { jest, expect, test } from '@jest/globals';
+import authorize from '../src/middlewares/authorize.js';
+
+function makeReq(hasRole = true) {
+  return {
+    user: { getRoles: jest.fn(() => (hasRole ? [{}] : [])) },
+  };
+}
+
+test('allows request when user has role', async () => {
+  const req = makeReq(true);
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  const mw = authorize('ADMIN');
+  await mw(req, res, next);
+  expect(next).toHaveBeenCalled();
+});
+
+test('forbids request when user lacks role', async () => {
+  const req = makeReq(false);
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  const mw = authorize('ADMIN');
+  await mw(req, res, next);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(next).not.toHaveBeenCalled();
+});

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -1,0 +1,32 @@
+import { expect, jest, test } from '@jest/globals';
+
+const addRoleMock = jest.fn();
+const removeRoleMock = jest.fn();
+
+const user = { addRole: addRoleMock, removeRole: removeRoleMock };
+
+const findByPkMock = jest.fn();
+const findRoleMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  User: { findByPk: findByPkMock },
+  Role: { findOne: findRoleMock },
+  UserStatus: { findOne: jest.fn() },
+}));
+
+const { default: service } = await import('../src/services/userService.js');
+
+test('assignRole adds role to user', async () => {
+  findByPkMock.mockResolvedValue(user);
+  findRoleMock.mockResolvedValue({});
+  await service.assignRole('1', 'ADMIN');
+  expect(addRoleMock).toHaveBeenCalled();
+});
+
+test('removeRole removes role from user', async () => {
+  findByPkMock.mockResolvedValue(user);
+  findRoleMock.mockResolvedValue({});
+  await service.removeRole('1', 'ADMIN');
+  expect(removeRoleMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add admin controller for user actions
- create service layer and validators
- restrict admin routes using new `authorize` middleware
- document new routes in Swagger
- test role middleware and user service

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513a4d4fbc832d9204ad68bd1d5b80