### PR TITLE
Improve frontend layout with role-based menu

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -9,7 +9,11 @@ const showLayout = computed(() => route.path !== '/login')
 </script>
 
 <template>
-  <NavBar v-if="showLayout" />
-  <router-view />
-  <FooterBar v-if="showLayout" />
+  <div class="d-flex flex-column min-vh-100">
+    <NavBar v-if="showLayout" />
+    <main class="flex-grow-1 container py-3">
+      <router-view />
+    </main>
+    <FooterBar v-if="showLayout" />
+  </div>
 </template>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -1,3 +1,15 @@
+<script setup>
+import { computed } from 'vue'
+import { useRoute } from 'vue-router'
+import NavBar from './components/NavBar.vue'
+import FooterBar from './components/FooterBar.vue'
+
+const route = useRoute()
+const showLayout = computed(() => route.path !== '/login')
+</script>
+
 <template>
+  <NavBar v-if="showLayout" />
   <router-view />
+  <FooterBar v-if="showLayout" />
 </template>

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -1,0 +1,18 @@
+import { reactive } from 'vue'
+import { apiFetch } from './api.js'
+
+export const auth = reactive({
+  user: null,
+  roles: []
+})
+
+export async function fetchCurrentUser() {
+  const data = await apiFetch('/auth/me')
+  auth.user = data.user
+  auth.roles = data.roles || []
+}
+
+export function clearAuth() {
+  auth.user = null
+  auth.roles = []
+}

--- a/client/src/components/FooterBar.vue
+++ b/client/src/components/FooterBar.vue
@@ -1,7 +1,7 @@
 <template>
-  <footer class="footer mt-auto py-3 bg-light">
-    <div class="container text-center">
-      <span class="text-muted">&copy; 2024 FH Moscow</span>
+  <footer class="footer mt-auto py-2 bg-light fixed-bottom">
+    <div class="container text-center small">
+      <span class="text-muted">&copy; 2024 Федерация хоккея Москвы</span>
     </div>
   </footer>
 </template>

--- a/client/src/components/FooterBar.vue
+++ b/client/src/components/FooterBar.vue
@@ -1,0 +1,11 @@
+<template>
+  <footer class="footer mt-auto py-3 bg-light">
+    <div class="container text-center">
+      <span class="text-muted">&copy; 2024 FH Moscow</span>
+    </div>
+  </footer>
+</template>
+
+<script setup>
+// no logic
+</script>

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 <template>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+  <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     <div class="container-fluid">
-      <RouterLink class="navbar-brand" to="/">Pulse Panel</RouterLink>
+      <RouterLink class="navbar-brand" to="/">Федерация хоккея Москвы</RouterLink>
       <button
         class="navbar-toggler"
         type="button"

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,0 +1,64 @@
+<template>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container-fluid">
+      <RouterLink class="navbar-brand" to="/">Pulse Panel</RouterLink>
+      <button
+        class="navbar-toggler"
+        type="button"
+        data-bs-toggle="collapse"
+        data-bs-target="#navbarNav"
+        aria-controls="navbarNav"
+        aria-expanded="false"
+        aria-label="Toggle navigation"
+      >
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarNav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item" v-if="roles.includes('REFEREE') || roles.includes('ADMIN')">
+            <RouterLink class="nav-link" to="/">Назначения</RouterLink>
+          </li>
+          <li class="nav-item" v-if="roles.includes('ADMIN')">
+            <a class="nav-link" href="#">Отчеты</a>
+          </li>
+          <li class="nav-item" v-if="roles.includes('ADMIN')">
+            <a class="nav-link" href="#">Взносы</a>
+          </li>
+          <li class="nav-item">
+            <RouterLink class="nav-link" to="/profile">Профиль</RouterLink>
+          </li>
+        </ul>
+        <span class="navbar-text me-3" v-if="user">{{ user.phone }}</span>
+        <button class="btn btn-outline-light" @click="logout">Выйти</button>
+      </div>
+    </div>
+  </nav>
+</template>
+
+<script setup>
+import { onMounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { auth, fetchCurrentUser, clearAuth } from '../auth.js'
+import { apiFetch } from '../api.js'
+
+const router = useRouter()
+const { user, roles } = auth
+
+onMounted(async () => {
+  if (!auth.user) {
+    try {
+      await fetchCurrentUser()
+    } catch (e) {
+      logout()
+    }
+  }
+})
+
+function logout() {
+  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
+    localStorage.removeItem('access_token')
+    clearAuth()
+    router.push('/login')
+  })
+}
+</script>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,49 +1,10 @@
 <script setup>
-import { ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { apiFetch } from '../api.js'
-
-const router = useRouter()
-const user = ref(null)
-
-async function fetchUser() {
-  try {
-    const data = await apiFetch('/auth/me')
-    user.value = data.user
-  } catch (_err) {
-    router.push('/login')
-  }
-}
-
-function logout() {
-  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
-    localStorage.removeItem('access_token')
-    router.push('/login')
-  })
-}
-
-onMounted(fetchUser)
+import { auth } from '../auth.js'
 </script>
 
 <template>
-  <div class="container mt-5" v-if="user">
-    <nav class="mb-3">
-      <ul class="nav nav-pills gap-2 flex-wrap">
-        <li class="nav-item">
-          <a class="nav-link" href="#">Мои назначения</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Отчеты</a>
-        </li>
-        <li class="nav-item">
-          <a class="nav-link" href="#">Взносы</a>
-        </li>
-        <li class="nav-item">
-          <RouterLink class="nav-link" to="/profile">Личная информация</RouterLink>
-        </li>
-      </ul>
-    </nav>
-    <h1 class="mb-4">Добро пожаловать {{ user.phone }}</h1>
-    <button class="btn btn-secondary" @click="logout">Выйти</button>
+  <div class="container mt-4">
+    <h1 class="mb-4">Добро пожаловать {{ auth.user?.phone }}</h1>
+    <p>Вы успешно вошли в систему.</p>
   </div>
 </template>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -5,6 +5,6 @@ import { auth } from '../auth.js'
 <template>
   <div class="container mt-4">
     <h1 class="mb-4">Добро пожаловать {{ auth.user?.phone }}</h1>
-    <p>Вы успешно вошли в систему.</p>
+    <p>Вы успешно вошли в систему Федерации хоккея Москвы.</p>
   </div>
 </template>

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -19,12 +19,16 @@ export default {
     try {
       const user = await authService.verifyCredentials(phone, password);
       const { accessToken, refreshToken } = authService.issueTokens(user);
+      const roles = (await user.getRoles({ attributes: ['alias'] })).map(
+        (r) => r.alias
+      );
 
       setRefreshCookie(res, refreshToken);
 
       return res.json({
         access_token: accessToken,
         user: userMapper.toPublic(user),
+        roles,
       });
     } catch (_err) {
       void _err;
@@ -40,7 +44,10 @@ export default {
 
   /* GET /auth/me */
   async me(req, res) {
-    return res.json({ user: userMapper.toPublic(req.user) });
+    const roles = (await req.user.getRoles({ attributes: ['alias'] })).map(
+      (r) => r.alias
+    );
+    return res.json({ user: userMapper.toPublic(req.user), roles });
   },
 
   /* POST /auth/refresh */
@@ -56,12 +63,16 @@ export default {
     try {
       const { user, accessToken, refreshToken } =
         await authService.rotateTokens(token);
+      const roles = (await user.getRoles({ attributes: ['alias'] })).map(
+        (r) => r.alias
+      );
 
       setRefreshCookie(res, refreshToken);
 
       return res.json({
         access_token: accessToken,
         user: userMapper.toPublic(user),
+        roles,
       });
     } catch (_err) {
       void _err;


### PR DESCRIPTION
## Summary
- add global navbar and footer
- manage auth state on the client
- show welcome info on Home page
- expose user roles from auth controller
- adjust unit tests for new response shape

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851404cd68c832d81379a50527a7301