### PR TITLE
Improve user admin management

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -18,3 +18,40 @@ export async function apiFetch(path, options = {}) {
   }
   return data;
 }
+
+export function createUser(data) {
+  return apiFetch('/users', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  });
+}
+
+export function updateUser(id, data) {
+  return apiFetch(`/users/${id}`, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+  });
+}
+
+export function blockUser(id) {
+  return apiFetch(`/users/${id}/block`, { method: 'POST' });
+}
+
+export function unblockUser(id) {
+  return apiFetch(`/users/${id}/unblock`, { method: 'POST' });
+}
+
+export function resetPassword(id, password) {
+  return apiFetch(`/users/${id}/reset-password`, {
+    method: 'POST',
+    body: JSON.stringify({ password }),
+  });
+}
+
+export function assignRole(id, roleAlias) {
+  return apiFetch(`/users/${id}/roles/${roleAlias}`, { method: 'POST' });
+}
+
+export function removeRole(id, roleAlias) {
+  return apiFetch(`/users/${id}/roles/${roleAlias}`, { method: 'DELETE' });
+}

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -2,10 +2,12 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Login from './views/Login.vue'
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
+import Admin from './views/Admin.vue'
 
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
+  { path: '/admin', component: Admin, meta: { requiresAuth: true } },
   { path: '/login', component: Login }
 ]
 

--- a/client/src/views/Admin.vue
+++ b/client/src/views/Admin.vue
@@ -1,0 +1,225 @@
+<script setup>
+import { ref } from 'vue'
+import {
+  createUser,
+  updateUser,
+  blockUser,
+  unblockUser,
+  resetPassword,
+  assignRole,
+  removeRole,
+} from '../api.js'
+
+const message = ref('')
+const newUser = ref({
+  first_name: '',
+  last_name: '',
+  patronymic: '',
+  birth_date: '',
+  phone: '',
+  email: '',
+  password: '',
+})
+const updateData = ref({
+  id: '',
+  first_name: '',
+  last_name: '',
+  patronymic: '',
+  birth_date: '',
+  phone: '',
+  email: '',
+})
+const blockId = ref('')
+const unblockId = ref('')
+const resetId = ref('')
+const newPassword = ref('')
+const roleId = ref('')
+const roleAlias = ref('')
+const removeRoleId = ref('')
+const removeRoleAlias = ref('')
+
+function show(msg) {
+  message.value = msg
+}
+
+async function onCreate() {
+  try {
+    const { user } = await createUser(newUser.value)
+    show(`Создан пользователь ${user.id}`)
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onUpdate() {
+  try {
+    await updateUser(updateData.value.id, updateData.value)
+    show('Данные обновлены')
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onBlock() {
+  try {
+    await blockUser(blockId.value)
+    show('Пользователь заблокирован')
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onUnblock() {
+  try {
+    await unblockUser(unblockId.value)
+    show('Пользователь разблокирован')
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onResetPassword() {
+  try {
+    await resetPassword(resetId.value, newPassword.value)
+    show('Пароль обновлен')
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onAssignRole() {
+  try {
+    await assignRole(roleId.value, roleAlias.value)
+    show('Роль назначена')
+  } catch (e) {
+    show(e.message)
+  }
+}
+
+async function onRemoveRole() {
+  try {
+    await removeRole(removeRoleId.value, removeRoleAlias.value)
+    show('Роль удалена')
+  } catch (e) {
+    show(e.message)
+  }
+}
+</script>
+
+<template>
+  <div class="container mt-5">
+    <h1 class="mb-4">Администрирование пользователей</h1>
+    <div v-if="message" class="alert alert-info">{{ message }}</div>
+
+    <h2 class="mt-4">Создать пользователя</h2>
+    <form @submit.prevent="onCreate" class="row g-2">
+      <div class="col-md-4">
+        <input v-model="newUser.last_name" class="form-control" placeholder="Фамилия" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="newUser.first_name" class="form-control" placeholder="Имя" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="newUser.patronymic" class="form-control" placeholder="Отчество" />
+      </div>
+      <div class="col-md-3">
+        <input v-model="newUser.birth_date" type="date" class="form-control" required />
+      </div>
+      <div class="col-md-3">
+        <input v-model="newUser.phone" class="form-control" placeholder="Телефон" required />
+      </div>
+      <div class="col-md-3">
+        <input v-model="newUser.email" type="email" class="form-control" placeholder="Email" required />
+      </div>
+      <div class="col-md-3">
+        <input v-model="newUser.password" type="password" class="form-control" placeholder="Пароль" required />
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary">Создать</button>
+      </div>
+    </form>
+
+    <h2 class="mt-5">Обновить пользователя</h2>
+    <form @submit.prevent="onUpdate" class="row g-2">
+      <div class="col-md-4">
+        <input v-model="updateData.id" class="form-control" placeholder="ID пользователя" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.last_name" class="form-control" placeholder="Фамилия" />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.first_name" class="form-control" placeholder="Имя" />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.patronymic" class="form-control" placeholder="Отчество" />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.birth_date" type="date" class="form-control" />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.phone" class="form-control" placeholder="Телефон" />
+      </div>
+      <div class="col-md-4">
+        <input v-model="updateData.email" type="email" class="form-control" placeholder="Email" />
+      </div>
+      <div class="col-12">
+        <button class="btn btn-primary">Обновить</button>
+      </div>
+    </form>
+
+    <h2 class="mt-5">Блокировка/разблокировка</h2>
+    <form @submit.prevent="onBlock" class="row g-2">
+      <div class="col-md-6">
+        <input v-model="blockId" class="form-control" placeholder="ID" required />
+      </div>
+      <div class="col-md-6">
+        <button class="btn btn-danger">Заблокировать</button>
+      </div>
+    </form>
+    <form @submit.prevent="onUnblock" class="row g-2 mt-2">
+      <div class="col-md-6">
+        <input v-model="unblockId" class="form-control" placeholder="ID" required />
+      </div>
+      <div class="col-md-6">
+        <button class="btn btn-success">Разблокировать</button>
+      </div>
+    </form>
+
+    <h2 class="mt-5">Сброс пароля</h2>
+    <form @submit.prevent="onResetPassword" class="row g-2">
+      <div class="col-md-4">
+        <input v-model="resetId" class="form-control" placeholder="ID" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="newPassword" type="password" class="form-control" placeholder="Новый пароль" required />
+      </div>
+      <div class="col-md-4">
+        <button class="btn btn-warning">Сбросить</button>
+      </div>
+    </form>
+
+    <h2 class="mt-5">Управление ролями</h2>
+    <form @submit.prevent="onAssignRole" class="row g-2">
+      <div class="col-md-4">
+        <input v-model="roleId" class="form-control" placeholder="ID" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="roleAlias" class="form-control" placeholder="Роль" required />
+      </div>
+      <div class="col-md-4">
+        <button class="btn btn-primary">Назначить</button>
+      </div>
+    </form>
+    <form @submit.prevent="onRemoveRole" class="row g-2 mt-2">
+      <div class="col-md-4">
+        <input v-model="removeRoleId" class="form-control" placeholder="ID" required />
+      </div>
+      <div class="col-md-4">
+        <input v-model="removeRoleAlias" class="form-control" placeholder="Роль" required />
+      </div>
+      <div class="col-md-4">
+        <button class="btn btn-secondary">Удалить</button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -41,6 +41,9 @@ onMounted(fetchUser)
         <li class="nav-item">
           <RouterLink class="nav-link" to="/profile">Личная информация</RouterLink>
         </li>
+        <li class="nav-item">
+          <RouterLink class="nav-link" to="/admin">Администрирование</RouterLink>
+        </li>
       </ul>
     </nav>
     <h1 class="mb-4">Добро пожаловать {{ user.phone }}</h1>

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -36,6 +36,10 @@ User.init(
       type: DataTypes.STRING(255), // хранит bcrypt-hash!
       allowNull: false,
     },
+    status_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
   },
   {
     sequelize,

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -61,7 +61,42 @@ router.post('/', auth, authorize('ADMIN'), createUserRules, admin.create);
  */
 router.put('/:id', auth, authorize('ADMIN'), updateUserRules, admin.update);
 
+/**
+ * @swagger
+ * /users/{id}/block:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Block user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user status
+ */
 router.post('/:id/block', auth, authorize('ADMIN'), admin.block);
+
+/**
+ * @swagger
+ * /users/{id}/unblock:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Unblock user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user status
+ */
 router.post('/:id/unblock', auth, authorize('ADMIN'), admin.unblock);
 router.post(
   '/:id/reset-password',
@@ -70,17 +105,78 @@ router.post(
   resetPasswordRules,
   admin.resetPassword
 );
+/**
+ * @swagger
+ * /users/{id}/reset-password:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Reset user password
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user password
+ */
 router.post(
   '/:id/roles/:roleAlias',
   auth,
   authorize('ADMIN'),
   admin.assignRole
 );
+/**
+ * @swagger
+ * /users/{id}/roles/{roleAlias}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Assign role to user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: roleAlias
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user roles
+ */
 router.delete(
   '/:id/roles/:roleAlias',
   auth,
   authorize('ADMIN'),
   admin.removeRole
 );
+/**
+ * @swagger
+ * /users/{id}/roles/{roleAlias}:
+ *   delete:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Remove role from user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *       - in: path
+ *         name: roleAlias
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated user roles
+ */
 
 export default router;

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -39,7 +39,10 @@ async function assignRole(userId, alias) {
   ]);
   if (!user) throw new Error('user_not_found');
   if (!role) throw new Error('role_not_found');
-  await user.addRole(role);
+  const existing = await user.getRoles({ where: { id: role.id } });
+  if (existing.length === 0) {
+    await user.addRole(role);
+  }
   return user;
 }
 
@@ -50,7 +53,10 @@ async function removeRole(userId, alias) {
   ]);
   if (!user) throw new Error('user_not_found');
   if (!role) throw new Error('role_not_found');
-  await user.removeRole(role);
+  const existing = await user.getRoles({ where: { id: role.id } });
+  if (existing.length > 0) {
+    await user.removeRole(role);
+  }
   return user;
 }
 

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -2,8 +2,9 @@ import { expect, jest, test } from '@jest/globals';
 
 const addRoleMock = jest.fn();
 const removeRoleMock = jest.fn();
+const getRolesMock = jest.fn();
 
-const user = { addRole: addRoleMock, removeRole: removeRoleMock };
+const user = { addRole: addRoleMock, removeRole: removeRoleMock, getRoles: getRolesMock };
 
 const findByPkMock = jest.fn();
 const findRoleMock = jest.fn();
@@ -20,6 +21,7 @@ const { default: service } = await import('../src/services/userService.js');
 test('assignRole adds role to user', async () => {
   findByPkMock.mockResolvedValue(user);
   findRoleMock.mockResolvedValue({});
+  getRolesMock.mockResolvedValue([]);
   await service.assignRole('1', 'ADMIN');
   expect(addRoleMock).toHaveBeenCalled();
 });
@@ -27,6 +29,7 @@ test('assignRole adds role to user', async () => {
 test('removeRole removes role from user', async () => {
   findByPkMock.mockResolvedValue(user);
   findRoleMock.mockResolvedValue({});
+  getRolesMock.mockResolvedValue([{}]);
   await service.removeRole('1', 'ADMIN');
   expect(removeRoleMock).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add `status_id` field to User model
- handle role assignment idempotently
- document user blocking and role endpoints in Swagger
- update unit test mocks for role management
- fix user model formatting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851430845e0832d82fc018417c1c9a0