### PR TITLE
Add admin user management

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - Docker and docker-compose setup for local development
 - ESLint and Prettier for code quality
 - Jest unit tests
+- Admin panel for managing users and roles
 
 ## Branching strategy
 
@@ -78,6 +79,18 @@ npm run format      # format with Prettier
 ```bash
 npm test
 ```
+
+### User management API
+
+Administrators can manage users via the following endpoints:
+
+- `GET /users` – list all users
+- `GET /users/{id}` – fetch single user
+- `POST /users` – create user
+- `PUT /users/{id}` – update user
+- `POST /users/{id}/block` and `/unblock` – change status
+- `POST /users/{id}/roles/{roleAlias}` – assign role
+- `DELETE /users/{id}/roles/{roleAlias}` – remove role
 
 ## License
 

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -10,9 +10,11 @@ export async function fetchCurrentUser() {
   const data = await apiFetch('/auth/me')
   auth.user = data.user
   auth.roles = data.roles || []
+  localStorage.setItem('roles', JSON.stringify(auth.roles))
 }
 
 export function clearAuth() {
   auth.user = null
   auth.roles = []
+  localStorage.removeItem('roles')
 }

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -18,12 +18,12 @@
           <li class="nav-item" v-if="roles.includes('REFEREE') || roles.includes('ADMIN')">
             <RouterLink class="nav-link" to="/">Назначения</RouterLink>
           </li>
-          <li class="nav-item" v-if="roles.includes('ADMIN')">
-            <a class="nav-link" href="#">Отчеты</a>
-          </li>
-          <li class="nav-item" v-if="roles.includes('ADMIN')">
-            <a class="nav-link" href="#">Взносы</a>
-          </li>
+        <li class="nav-item" v-if="roles.includes('ADMIN')">
+          <RouterLink class="nav-link" to="/users">Пользователи</RouterLink>
+        </li>
+        <li class="nav-item" v-if="roles.includes('ADMIN')">
+          <a class="nav-link" href="#">Взносы</a>
+        </li>
           <li class="nav-item">
             <RouterLink class="nav-link" to="/profile">Профиль</RouterLink>
           </li>

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -2,10 +2,12 @@ import { createRouter, createWebHistory } from 'vue-router'
 import Login from './views/Login.vue'
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
+import AdminUsers from './views/AdminUsers.vue'
 
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
+  { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/login', component: Login }
 ]
 
@@ -16,8 +18,11 @@ const router = createRouter({
 
 router.beforeEach((to, _from, next) => {
   const isAuthenticated = !!localStorage.getItem('access_token')
+  const roles = JSON.parse(localStorage.getItem('roles') || '[]')
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/login')
+  } else if (to.meta.requiresAdmin && !roles.includes('ADMIN')) {
+    next('/')
   } else {
     next()
   }

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { apiFetch } from '../api.js'
+
+const users = ref([])
+const error = ref('')
+
+async function loadUsers() {
+  try {
+    const data = await apiFetch('/users')
+    users.value = data.users
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function blockUser(id) {
+  await apiFetch(`/users/${id}/block`, { method: 'POST' })
+  await loadUsers()
+}
+
+async function unblockUser(id) {
+  await apiFetch(`/users/${id}/unblock`, { method: 'POST' })
+  await loadUsers()
+}
+
+onMounted(loadUsers)
+</script>
+
+<template>
+  <div>
+    <h1 class="mb-4">Пользователи</h1>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <table class="table table-striped" v-if="users.length">
+      <thead>
+        <tr>
+          <th>Фамилия</th>
+          <th>Имя</th>
+          <th>Телефон</th>
+          <th>Статус</th>
+          <th>Роли</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="u in users" :key="u.id">
+          <td>{{ u.last_name }}</td>
+          <td>{{ u.first_name }}</td>
+          <td>{{ u.phone }}</td>
+          <td>{{ u.status }}</td>
+          <td>{{ u.roles?.join(', ') }}</td>
+          <td>
+            <button
+              v-if="u.status === 'ACTIVE'"
+              @click="blockUser(u.id)"
+              class="btn btn-sm btn-danger me-2"
+            >
+              Block
+            </button>
+            <button
+              v-if="u.status === 'INACTIVE'"
+              @click="unblockUser(u.id)"
+              class="btn btn-sm btn-success"
+            >
+              Unblock
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p v-else>Нет пользователей.</p>
+  </div>
+</template>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -2,6 +2,7 @@
 import { ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiFetch } from '../api.js'
+import { auth } from '../auth.js'
 
 const router = useRouter()
 const phone = ref('')
@@ -39,6 +40,9 @@ async function login() {
       body: JSON.stringify({ phone: phone.value, password: password.value })
     })
     localStorage.setItem('access_token', data.access_token)
+    localStorage.setItem('roles', JSON.stringify(data.roles || []))
+    auth.user = data.user
+    auth.roles = data.roles || []
     router.push('/')
   } catch (err) {
     error.value = err.message

--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -4,6 +4,19 @@ import userService from '../services/userService.js';
 import userMapper from '../mappers/userMapper.js';
 
 export default {
+  async list(_req, res) {
+    const users = await userService.listUsers();
+    return res.json({ users: userMapper.toPublicArray(users) });
+  },
+
+  async get(req, res) {
+    try {
+      const user = await userService.getUser(req.params.id);
+      return res.json({ user: userMapper.toPublic(user) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
   async create(req, res) {
     const errors = validationResult(req);
     if (!errors.isEmpty()) {

--- a/src/mappers/userMapper.js
+++ b/src/mappers/userMapper.js
@@ -47,7 +47,10 @@ function toPublic(user) {
   if (!user) return null;
   const plain =
     typeof user.get === 'function' ? user.get({ plain: true }) : user;
-  return sanitize(plain);
+  const sanitized = sanitize(plain);
+  if (plain.Roles) sanitized.roles = plain.Roles.map((r) => r.alias);
+  if (plain.UserStatus) sanitized.status = plain.UserStatus.alias;
+  return sanitized;
 }
 
 function toPublicArray(users = []) {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -32,6 +32,38 @@ router.get('/me', auth, (req, res) => {
 /**
  * @swagger
  * /users:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: List users
+ *     responses:
+ *       200:
+ *         description: Array of users
+ */
+router.get('/', auth, authorize('ADMIN'), admin.list);
+
+/**
+ * @swagger
+ * /users/{id}:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Get user by ID
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: User data
+ */
+router.get('/:id', auth, authorize('ADMIN'), admin.get);
+
+/**
+ * @swagger
+ * /users:
  *   post:
  *     security:
  *       - bearerAuth: []

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -6,6 +6,16 @@ async function createUser(data) {
   return user;
 }
 
+async function listUsers() {
+  return User.findAll({ include: [Role, UserStatus] });
+}
+
+async function getUser(id) {
+  const user = await User.findByPk(id, { include: [Role, UserStatus] });
+  if (!user) throw new Error('user_not_found');
+  return user;
+}
+
 async function updateUser(id, data) {
   const user = await User.findByPk(id);
   if (!user) throw new Error('user_not_found');
@@ -55,6 +65,8 @@ async function removeRole(userId, alias) {
 }
 
 export default {
+  listUsers,
+  getUser,
   createUser,
   updateUser,
   setStatus,

--- a/tests/userMapper.test.js
+++ b/tests/userMapper.test.js
@@ -32,4 +32,19 @@ describe('userMapper', () => {
     ];
     expect(mapper.toPublicArray(users)).toEqual([{ id: '1' }, { id: '2' }]);
   });
+
+  test('toPublic includes roles and status', () => {
+    const user = {
+      get: () => ({
+        id: '1',
+        Roles: [{ alias: 'ADMIN' }],
+        UserStatus: { alias: 'ACTIVE' },
+      }),
+    };
+    expect(mapper.toPublic(user)).toMatchObject({
+      id: '1',
+      roles: ['ADMIN'],
+      status: 'ACTIVE',
+    });
+  });
 });

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -5,12 +5,13 @@ const removeRoleMock = jest.fn();
 
 const user = { addRole: addRoleMock, removeRole: removeRoleMock };
 
+const findAllMock = jest.fn();
 const findByPkMock = jest.fn();
 const findRoleMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
-  User: { findByPk: findByPkMock },
+  User: { findByPk: findByPkMock, findAll: findAllMock },
   Role: { findOne: findRoleMock },
   UserStatus: { findOne: jest.fn() },
 }));
@@ -29,4 +30,23 @@ test('removeRole removes role from user', async () => {
   findRoleMock.mockResolvedValue({});
   await service.removeRole('1', 'ADMIN');
   expect(removeRoleMock).toHaveBeenCalled();
+});
+
+test('listUsers calls model findAll', async () => {
+  findAllMock.mockResolvedValue([]);
+  const result = await service.listUsers();
+  expect(result).toEqual([]);
+  expect(findAllMock).toHaveBeenCalled();
+});
+
+test('getUser throws on missing user', async () => {
+  findByPkMock.mockResolvedValue(null);
+  await expect(service.getUser('1')).rejects.toThrow('user_not_found');
+});
+
+test('getUser returns user', async () => {
+  findByPkMock.mockResolvedValue(user);
+  const res = await service.getUser('1');
+  expect(res).toBe(user);
+  expect(findByPkMock).toHaveBeenCalledWith('1', expect.any(Object));
 });


### PR DESCRIPTION
## Summary
- expose admin endpoints to list and view users
- extend user service and mapper with role and status info
- update frontend with admin users page and role-aware routing
- persist role list in localStorage
- document user management API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68514cf60f54832dbdcf6ba69755fd27