### PR TITLE
UI cleanup

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -5,10 +5,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
-    />
     <title>Кадровая система Пульс</title>
   </head>
   <body>

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -3,7 +3,7 @@ import { apiFetch } from './api.js'
 
 export const auth = reactive({
   user: null,
-  roles: []
+  roles: JSON.parse(localStorage.getItem('roles') || '[]')
 })
 
 export async function fetchCurrentUser() {

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -14,21 +14,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarNav">
-        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-          <li class="nav-item" v-if="roles.includes('REFEREE') || roles.includes('ADMIN')">
-            <RouterLink class="nav-link" to="/">Назначения</RouterLink>
-          </li>
-        <li class="nav-item" v-if="roles.includes('ADMIN')">
-          <RouterLink class="nav-link" to="/users">Пользователи</RouterLink>
-        </li>
-        <li class="nav-item" v-if="roles.includes('ADMIN')">
-          <a class="nav-link" href="#">Взносы</a>
-        </li>
-          <li class="nav-item">
-            <RouterLink class="nav-link" to="/profile">Профиль</RouterLink>
-          </li>
-        </ul>
-        <span class="navbar-text me-3" v-if="user">{{ user.phone }}</span>
+        <span class="navbar-text me-auto" v-if="user">{{ user.phone }}</span>
         <button class="btn btn-outline-light" @click="logout">Выйти</button>
       </div>
     </div>
@@ -42,7 +28,7 @@ import { auth, fetchCurrentUser, clearAuth } from '../auth.js'
 import { apiFetch } from '../api.js'
 
 const router = useRouter()
-const { user, roles } = auth
+const { user } = auth
 
 onMounted(async () => {
   if (!auth.user) {

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -3,10 +3,12 @@ import Login from './views/Login.vue'
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
 import AdminUsers from './views/AdminUsers.vue'
+import AdminHome from './views/AdminHome.vue'
 
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
+  { path: '/admin', component: AdminHome, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/login', component: Login }
 ]

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -1,0 +1,33 @@
+<script setup>
+import { RouterLink } from 'vue-router'
+
+const tiles = [
+  { title: 'Управление пользователями', icon: 'bi-people', to: '/users' }
+]
+</script>
+
+<template>
+  <div class="container mt-4">
+    <h1 class="mb-4 text-center">Администрирование</h1>
+    <div class="row g-4">
+      <div class="col-6 col-md-4" v-for="tile in tiles" :key="tile.to">
+        <RouterLink :to="tile.to" class="card h-100 text-center tile text-decoration-none text-body">
+          <div class="card-body d-flex flex-column justify-content-center align-items-center">
+            <i :class="tile.icon + ' fs-1 mb-3'"></i>
+            <h5 class="card-title">{{ tile.title }}</h5>
+          </div>
+        </RouterLink>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.tile {
+  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+}
+.tile:hover {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+</style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { auth } from '../auth.js'
+import { computed } from 'vue'
 
 const sections = [
   { title: 'Мои назначения', icon: 'bi-calendar-check' },
@@ -12,6 +13,8 @@ const sections = [
   { title: 'Документы', icon: 'bi-folder2-open' },
   { title: 'Персональные данные', icon: 'bi-person-circle' }
 ]
+
+const isAdmin = computed(() => auth.roles.includes('ADMIN'))
 </script>
 
 <template>
@@ -26,6 +29,14 @@ const sections = [
             <p class="text-muted small mb-0">Раздел в разработке</p>
           </div>
         </div>
+      </div>
+      <div v-if="isAdmin" class="col-6 col-md-4">
+        <RouterLink to="/admin" class="card h-100 text-center tile fade-in text-decoration-none text-body">
+          <div class="card-body d-flex flex-column justify-content-center align-items-center">
+            <i class="bi bi-shield-lock fs-1 mb-3"></i>
+            <h5 class="card-title">Администрирование</h5>
+          </div>
+        </RouterLink>
       </div>
     </div>
   </div>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { auth } from '../auth.js'
 import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
 
 const sections = [
   { title: 'Мои назначения', icon: 'bi-calendar-check' },
@@ -11,7 +12,7 @@ const sections = [
   { title: 'Медосмотр', icon: 'bi-heart-pulse' },
   { title: 'Результаты тестов', icon: 'bi-graph-up' },
   { title: 'Документы', icon: 'bi-folder2-open' },
-  { title: 'Персональные данные', icon: 'bi-person-circle' }
+  { title: 'Персональные данные', icon: 'bi-person-circle', to: '/profile' }
 ]
 
 const isAdmin = computed(() => auth.roles.includes('ADMIN'))
@@ -22,13 +23,17 @@ const isAdmin = computed(() => auth.roles.includes('ADMIN'))
     <h1 class="mb-4 text-center">Добро пожаловать {{ auth.user?.phone }}</h1>
     <div class="row g-4">
       <div class="col-6 col-md-4" v-for="section in sections" :key="section.title">
-        <div class="card h-100 text-center tile fade-in">
+        <component
+          :is="section.to ? RouterLink : 'div'"
+          :to="section.to"
+          class="card h-100 text-center tile fade-in text-decoration-none text-body"
+        >
           <div class="card-body d-flex flex-column justify-content-center align-items-center">
             <i :class="section.icon + ' fs-1 mb-3'"></i>
             <h5 class="card-title">{{ section.title }}</h5>
-            <p class="text-muted small mb-0">Раздел в разработке</p>
+            <p v-if="!section.to" class="text-muted small mb-0">Раздел в разработке</p>
           </div>
-        </div>
+        </component>
       </div>
       <div v-if="isAdmin" class="col-6 col-md-4">
         <RouterLink to="/admin" class="card h-100 text-center tile fade-in text-decoration-none text-body">


### PR DESCRIPTION
## Summary
- remove duplicate stylesheet from `index.html`
- simplify navigation bar and drop unused roles variable
- add admin dashboard link and create admin homepage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516e1acfe8832d991003a3ffd4b598