### PR TITLE
Improve admin user management page

### DIFF
--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { ref, onMounted, computed, watch } from 'vue'
+import { ref, onMounted, watch, computed } from 'vue'
 import { apiFetch } from '../api.js'
 import UserForm from '../components/UserForm.vue'
 import { Modal } from 'bootstrap'
 
 const users = ref([])
+const total = ref(0)
 const error = ref('')
 const editUser = ref(null)
 const modalRef = ref(null)
@@ -17,31 +18,20 @@ let passwordModal
 const search = ref('')
 const currentPage = ref(1)
 const pageSize = 8
-
-const filteredUsers = computed(() => {
-  if (!search.value) return users.value
-  return users.value.filter((u) => {
-    const term = search.value.toLowerCase()
-    return (
-      u.last_name.toLowerCase().includes(term) ||
-      u.first_name.toLowerCase().includes(term) ||
-      u.phone.includes(term) ||
-      u.email.toLowerCase().includes(term)
-    )
-  })
-})
+const sortField = ref('last_name')
+const sortOrder = ref('asc')
 
 const totalPages = computed(() =>
-  Math.max(1, Math.ceil(filteredUsers.value.length / pageSize))
+  Math.max(1, Math.ceil(total.value / pageSize))
 )
 
-const paginatedUsers = computed(() => {
-  const start = (currentPage.value - 1) * pageSize
-  return filteredUsers.value.slice(start, start + pageSize)
+watch([search, sortField, sortOrder], () => {
+  currentPage.value = 1
+  loadUsers()
 })
 
-watch(search, () => {
-  currentPage.value = 1
+watch(currentPage, () => {
+  loadUsers()
 })
 
 function generatePassword(len = 8) {
@@ -55,8 +45,16 @@ function generatePassword(len = 8) {
 
 async function loadUsers() {
   try {
-    const data = await apiFetch('/users')
+    const params = new URLSearchParams({
+      search: search.value,
+      page: currentPage.value,
+      limit: pageSize,
+      sort: sortField.value,
+      order: sortOrder.value,
+    })
+    const data = await apiFetch(`/users?${params}`)
     users.value = data.users
+    total.value = data.total
   } catch (e) {
     error.value = e.message
   }
@@ -118,6 +116,30 @@ async function unblockUser(id) {
   await apiFetch(`/users/${id}/unblock`, { method: 'POST' })
   await loadUsers()
 }
+
+function toggleSort(field) {
+  if (sortField.value === field) {
+    sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
+  } else {
+    sortField.value = field
+    sortOrder.value = 'asc'
+  }
+}
+
+function formatPhone(digits) {
+  if (!digits) return ''
+  let out = '+7'
+  if (digits.length > 1) out += ' (' + digits.slice(1, 4)
+  if (digits.length >= 4) out += ') '
+  if (digits.length >= 4) out += digits.slice(4, 7)
+  if (digits.length >= 7) out += '-' + digits.slice(7, 9)
+  if (digits.length >= 9) out += '-' + digits.slice(9, 11)
+  return out
+}
+
+function copy(text) {
+  navigator.clipboard.writeText(text)
+}
 </script>
 
 <template>
@@ -133,17 +155,55 @@ async function unblockUser(id) {
       />
     </div>
     <div v-if="error" class="alert alert-danger">{{ error }}</div>
-    <div v-if="paginatedUsers.length" class="row row-cols-1 row-cols-sm-2 row-cols-md-3 row-cols-lg-4 g-3">
-      <div class="col" v-for="u in paginatedUsers" :key="u.id">
-        <div class="card h-100 shadow-sm">
-          <div class="card-body d-flex flex-column">
-            <h5 class="card-title mb-1">{{ u.last_name }} {{ u.first_name }}</h5>
-            <p class="text-muted mb-1">{{ u.phone }}</p>
-            <p class="mb-1"><span class="badge bg-secondary">{{ u.status }}</span></p>
-            <p class="mb-3" v-if="u.roles && u.roles.length">
-              <span class="badge bg-info me-1" v-for="r in u.roles" :key="r">{{ r }}</span>
-            </p>
-            <div class="mt-auto text-end">
+    <div class="table-responsive" v-if="users.length">
+      <table class="table table-hover align-middle">
+        <thead>
+          <tr>
+            <th @click="toggleSort('last_name')" class="sortable">
+              ФИО
+            </th>
+            <th
+              class="d-none d-md-table-cell"
+              @click="toggleSort('phone')"
+              class="sortable"
+            >
+              Телефон
+            </th>
+            <th
+              class="d-none d-lg-table-cell"
+              @click="toggleSort('email')"
+              class="sortable"
+            >
+              Email
+            </th>
+            <th class="d-none d-lg-table-cell">Роли</th>
+            <th @click="toggleSort('status')" class="sortable">Статус</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="u in users" :key="u.id">
+            <td>{{ u.last_name }} {{ u.first_name }}</td>
+            <td class="d-none d-md-table-cell">
+              <span>{{ formatPhone(u.phone) }}</span>
+              <button
+                class="btn btn-sm btn-outline-secondary ms-1"
+                @click="copy(u.phone)"
+              >
+                📋
+              </button>
+            </td>
+            <td class="d-none d-lg-table-cell">{{ u.email }}</td>
+            <td class="d-none d-lg-table-cell">
+              <span
+                class="badge bg-info me-1"
+                v-for="r in u.roles"
+                :key="r"
+                >{{ r }}</span
+              >
+            </td>
+            <td><span class="badge bg-secondary">{{ u.status }}</span></td>
+            <td class="text-end">
               <button class="btn btn-sm btn-secondary me-2" @click="openEdit(u)">
                 Редактировать
               </button>
@@ -161,10 +221,10 @@ async function unblockUser(id) {
               >
                 Разблокировать
               </button>
-            </div>
-          </div>
-        </div>
-      </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
     <p v-else>Нет пользователей.</p>
     <nav class="mt-3" v-if="totalPages > 1">
@@ -232,9 +292,7 @@ async function unblockUser(id) {
 </template>
 
 <style scoped>
-.card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+.sortable {
+  cursor: pointer;
 }
 </style>

--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -4,9 +4,25 @@ import userService from '../services/userService.js';
 import userMapper from '../mappers/userMapper.js';
 
 export default {
-  async list(_req, res) {
-    const users = await userService.listUsers();
-    return res.json({ users: userMapper.toPublicArray(users) });
+  async list(req, res) {
+    const {
+      search = '',
+      page = '1',
+      limit = '20',
+      sort = 'last_name',
+      order = 'asc',
+    } = req.query;
+    const { rows, count } = await userService.listUsers({
+      search,
+      page: parseInt(page),
+      limit: parseInt(limit),
+      sort,
+      order,
+    });
+    return res.json({
+      users: userMapper.toPublicArray(rows),
+      total: count,
+    });
   },
 
   async get(req, res) {

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 import { User, Role, UserStatus } from '../models/index.js';
 
 async function createUser(data) {
@@ -6,8 +8,40 @@ async function createUser(data) {
   return user;
 }
 
-async function listUsers() {
-  return User.findAll({ include: [Role, UserStatus] });
+async function listUsers(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1));
+  const limit = Math.max(1, parseInt(options.limit || 20));
+  const offset = (page - 1) * limit;
+
+  const sortField = [
+    'last_name',
+    'first_name',
+    'email',
+    'phone',
+    'createdAt',
+  ].includes(options.sort)
+    ? options.sort
+    : 'last_name';
+  const sortOrder = options.order === 'desc' ? 'DESC' : 'ASC';
+
+  const where = {};
+  if (options.search) {
+    const term = `%${options.search}%`;
+    where[Op.or] = [
+      { last_name: { [Op.iLike]: term } },
+      { first_name: { [Op.iLike]: term } },
+      { phone: { [Op.iLike]: term } },
+      { email: { [Op.iLike]: term } },
+    ];
+  }
+
+  return User.findAndCountAll({
+    include: [Role, UserStatus],
+    where,
+    order: [[sortField, sortOrder]],
+    limit,
+    offset,
+  });
 }
 
 async function getUser(id) {

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -4,7 +4,7 @@ const addRoleMock = jest.fn();
 const removeRoleMock = jest.fn();
 
 const createMock = jest.fn();
-const findAllMock = jest.fn();
+const findAndCountAllMock = jest.fn();
 const findByPkMock = jest.fn();
 const updateMock = jest.fn();
 const user = { addRole: addRoleMock, removeRole: removeRoleMock, update: updateMock };
@@ -16,7 +16,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   User: {
     create: createMock,
     findByPk: findByPkMock,
-    findAll: findAllMock,
+    findAndCountAll: findAndCountAllMock,
   },
   Role: { findOne: findRoleMock },
   UserStatus: { findOne: statusFindMock },
@@ -38,11 +38,11 @@ test('removeRole removes role from user', async () => {
   expect(removeRoleMock).toHaveBeenCalled();
 });
 
-test('listUsers calls model findAll', async () => {
-  findAllMock.mockResolvedValue([]);
-  const result = await service.listUsers();
-  expect(result).toEqual([]);
-  expect(findAllMock).toHaveBeenCalled();
+test('listUsers calls model findAndCountAll', async () => {
+  findAndCountAllMock.mockResolvedValue({ rows: [], count: 0 });
+  const result = await service.listUsers({});
+  expect(result).toEqual({ rows: [], count: 0 });
+  expect(findAndCountAllMock).toHaveBeenCalled();
 });
 
 test('getUser throws on missing user', async () => {


### PR DESCRIPTION
## Summary
- support pagination, search and sorting in user service
- expose query params in admin controller
- redesign AdminUsers view with table layout and mobile tweaks
- update user service tests

## Testing
- `npm test`
- `npm run lint`
- `npm run format`


------
https://chatgpt.com/codex/tasks/task_e_6851779091cc832db53c2a0f5c3c6128