### PR TITLE
Refine nav bar and footer

### DIFF
--- a/client/src/assets/fhm-logo.svg
+++ b/client/src/assets/fhm-logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#113867"/>
+  <text x="50" y="55" font-family="Arial, Helvetica, sans-serif" font-size="50" fill="white" text-anchor="middle">ФХМ</text>
+</svg>

--- a/client/src/components/FooterBar.vue
+++ b/client/src/components/FooterBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <footer class="footer mt-auto py-2 bg-light fixed-bottom">
+  <footer class="footer mt-auto py-2 bg-light">
     <div class="container text-center small">
       <span class="text-muted">&copy; 2024 Федерация хоккея Москвы</span>
     </div>

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,7 +1,10 @@
 <template>
-  <nav class="navbar navbar-expand-md navbar-dark bg-primary">
+  <nav class="navbar navbar-expand-md navbar-dark" :style="{ backgroundColor: '#113867' }">
     <div class="container-fluid">
-      <RouterLink class="navbar-brand" to="/">Федерация хоккея Москвы</RouterLink>
+      <RouterLink class="navbar-brand d-flex align-items-center gap-2" to="/">
+        <img :src="logo" alt="FHM" height="30" />
+        Федерация хоккея Москвы
+      </RouterLink>
       <button
         class="navbar-toggler"
         type="button"
@@ -13,8 +16,10 @@
       >
         <span class="navbar-toggler-icon"></span>
       </button>
-      <div class="collapse navbar-collapse" id="navbarNav">
-        <span class="navbar-text me-auto" v-if="user">{{ user.phone }}</span>
+      <div class="collapse navbar-collapse justify-content-end" id="navbarNav">
+        <span class="navbar-text me-3" v-if="user">
+          {{ user.last_name }} {{ user.patronymic }}
+        </span>
         <button class="btn btn-outline-light" @click="logout">Выйти</button>
       </div>
     </div>
@@ -26,6 +31,7 @@ import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, fetchCurrentUser, clearAuth } from '../auth.js'
 import { apiFetch } from '../api.js'
+import logo from '../assets/fhm-logo.svg'
 
 const router = useRouter()
 const { user } = auth


### PR DESCRIPTION
## Summary
- add simple FHM logo asset
- update nav bar colour and layout
- show surname and patronymic near logout button
- make footer sticky instead of fixed

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685292ed4510832dbdbc37f0a22273a1