### PR TITLE
Add rate limiting middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ import swaggerUi from 'swagger-ui-express';
 
 import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
+import rateLimiter from './src/middlewares/rateLimiter.js';
 import swaggerSpec from './src/docs/swagger.js';
 
 const app = express();
@@ -13,6 +14,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(cors({ origin: true, credentials: true }));
+app.use(rateLimiter);
 app.use(requestLogger);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "debug": "~2.6.9",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
         "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
@@ -3592,6 +3593,21 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-validator": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "debug": "~2.6.9",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
+    "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
     "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",

--- a/src/middlewares/rateLimiter.js
+++ b/src/middlewares/rateLimiter.js
@@ -1,0 +1,12 @@
+import rateLimit from 'express-rate-limit';
+
+/**
+ * Global rate limiter middleware to mitigate denial-of-service attacks.
+ * Limits each IP to 100 requests per 15 minute window.
+ */
+export default rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+});


### PR DESCRIPTION
## Summary
- install express-rate-limit dependency
- create `rateLimiter` middleware that limits requests
- apply rate limiter globally in the Express app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6852cbad6d3c832db56c99adf2673444