### PR TITLE
Potential fix for code scanning alert no. 10: Missing CSRF middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import helmet from 'helmet';
+import { csrf } from 'lusca';
 
 import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
@@ -14,6 +15,7 @@ const app = express();
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
+app.use(csrf());
 app.use(cors({ origin: true, credentials: true }));
 app.use(helmet());
 app.use(rateLimiter);

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",


### PR DESCRIPTION
Potential fix for [https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/10](https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/10)

To fix the issue, we need to add CSRF protection middleware to the application. The `lusca` package provides a straightforward way to implement CSRF protection in Express applications. 

Steps to fix:
1. Install the `lusca` package.
2. Import the `csrf` middleware from `lusca`.
3. Add the `csrf` middleware to the application, ensuring it is applied after `cookieParser()` and before any routes that handle state-changing requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
