### PR TITLE
Enhance authorized user homepage

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -16,29 +16,48 @@ const sections = [
 ]
 
 const isAdmin = computed(() => auth.roles.includes('ADMIN'))
+
+const fullName = computed(() => {
+  if (!auth.user) return ''
+  return [auth.user.last_name, auth.user.first_name, auth.user.patronymic]
+    .filter(Boolean)
+    .join(' ')
+})
 </script>
 
 <template>
   <div class="container mt-4">
-    <h1 class="mb-4 text-center">Добро пожаловать {{ auth.user?.phone }}</h1>
+    <h1 class="mb-4 text-center">
+      Добро пожаловать
+      {{ fullName || auth.user?.phone }}
+    </h1>
     <div class="row g-4">
-      <div class="col-6 col-md-4" v-for="section in sections" :key="section.title">
+      <div class="col-6 col-md-4 col-lg-3" v-for="section in sections" :key="section.title">
         <component
           :is="section.to ? RouterLink : 'div'"
           :to="section.to"
           class="card h-100 text-center tile fade-in text-decoration-none text-body"
+          :class="{ 'placeholder-card': !section.to }"
         >
           <div class="card-body d-flex flex-column justify-content-center align-items-center">
-            <i :class="section.icon + ' fs-1 mb-3'"></i>
+            <i
+              :class="section.icon + ' fs-1 mb-3 icon-brand'"
+              role="img"
+              :aria-label="section.title"
+            ></i>
             <h5 class="card-title">{{ section.title }}</h5>
             <p v-if="!section.to" class="text-muted small mb-0">Раздел в разработке</p>
           </div>
         </component>
       </div>
-      <div v-if="isAdmin" class="col-6 col-md-4">
+      <div v-if="isAdmin" class="col-6 col-md-4 col-lg-3">
         <RouterLink to="/admin" class="card h-100 text-center tile fade-in text-decoration-none text-body">
           <div class="card-body d-flex flex-column justify-content-center align-items-center">
-            <i class="bi bi-shield-lock fs-1 mb-3"></i>
+            <i
+              class="bi bi-shield-lock fs-1 mb-3 icon-brand"
+              role="img"
+              aria-label="Администрирование"
+            ></i>
             <h5 class="card-title">Администрирование</h5>
           </div>
         </RouterLink>
@@ -54,6 +73,18 @@ const isAdmin = computed(() => auth.roles.includes('ADMIN'))
 .tile:hover {
   transform: translateY(-2px) scale(1.02);
   box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+}
+.placeholder-card {
+  background-color: #f8f9fa;
+  opacity: 0.6;
+  cursor: default;
+}
+.placeholder-card:hover {
+  transform: none;
+  box-shadow: none;
+}
+.icon-brand {
+  color: #113867;
 }
 .fade-in {
   animation: fadeIn 0.4s ease-out;


### PR DESCRIPTION
## Summary
- show the logged in user's full name on the homepage
- improve tile grid responsiveness with a `col-lg-3` breakpoint
- indicate sections that are not yet implemented
- add accessible labels and apply brand coloring to icons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685a6be9e5f4832d81b159440f31626b