### PR TITLE
Improve login page UI

### DIFF
--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,5 +1,8 @@
 <template>
-  <nav class="navbar navbar-expand-md navbar-dark" :style="{ backgroundColor: '#113867' }">
+  <nav
+    class="navbar navbar-expand-md navbar-dark"
+    :style="{ backgroundColor: 'var(--brand-color)' }"
+  >
     <div class="container-fluid">
       <RouterLink class="navbar-brand d-flex align-items-center gap-2" to="/">
         <img :src="logo" alt="FHM" height="30" />
@@ -27,30 +30,30 @@
 </template>
 
 <script setup>
-import { onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { auth, fetchCurrentUser, clearAuth } from '../auth.js'
-import { apiFetch } from '../api.js'
-import logo from '../assets/fhm-logo.svg'
+import { onMounted } from 'vue';
+import { useRouter } from 'vue-router';
+import { auth, fetchCurrentUser, clearAuth } from '../auth.js';
+import { apiFetch } from '../api.js';
+import logo from '../assets/fhm-logo.svg';
 
-const router = useRouter()
-const { user } = auth
+const router = useRouter();
+const { user } = auth;
 
 onMounted(async () => {
   if (!auth.user) {
     try {
-      await fetchCurrentUser()
+      await fetchCurrentUser();
     } catch (e) {
-      logout()
+      logout();
     }
   }
-})
+});
 
 function logout() {
   apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
-    localStorage.removeItem('access_token')
-    clearAuth()
-    router.push('/login')
-  })
+    localStorage.removeItem('access_token');
+    clearAuth();
+    router.push('/login');
+  });
 }
 </script>

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -1,7 +1,8 @@
-import { createApp } from 'vue'
-import App from './App.vue'
-import router from './router'
-import 'bootstrap/dist/css/bootstrap.min.css'
-import 'bootstrap'
+import { createApp } from 'vue';
+import App from './App.vue';
+import router from './router';
+import './style.css';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap';
 
-createApp(App).use(router).mount('#app')
+createApp(App).use(router).mount('#app');

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -3,6 +3,8 @@
   line-height: 1.5;
   font-weight: 400;
 
+  --brand-color: #113867;
+
   color-scheme: light dark;
   color: rgba(255, 255, 255, 0.87);
   background-color: #242424;

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,103 +1,182 @@
 <script setup>
-import { ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
-import { apiFetch } from '../api.js'
-import { auth } from '../auth.js'
+import { ref, computed } from 'vue';
+import { useRouter } from 'vue-router';
+import { apiFetch } from '../api.js';
+import { auth } from '../auth.js';
+import logo from '../assets/fhm-logo.svg';
 
-const router = useRouter()
-const phone = ref('')
-const phoneInput = ref('')
-const password = ref('')
-const error = ref('')
-const loading = ref(false)
-
-watch(error, (val) => {
-  if (val) {
-    setTimeout(() => {
-      error.value = ''
-    }, 4000)
-  }
-})
+const router = useRouter();
+const phone = ref('');
+const phoneInput = ref('');
+const password = ref('');
+const showPassword = ref(false);
+const rememberMe = ref(false);
+const error = ref('');
+const loading = ref(false);
+const phoneTouched = ref(false);
+const phoneValid = computed(
+  () => phone.value.length === 11 && phone.value.startsWith('7')
+);
 
 function formatPhone(digits) {
-  let out = '+7'
-  if (digits.length > 1) out += ' (' + digits.slice(1, 4)
-  if (digits.length >= 4) out += ') '
-  if (digits.length >= 4) out += digits.slice(4, 7)
-  if (digits.length >= 7) out += '-' + digits.slice(7, 9)
-  if (digits.length >= 9) out += '-' + digits.slice(9, 11)
-  return out
+  let out = '+7';
+  if (digits.length > 1) out += ' (' + digits.slice(1, 4);
+  if (digits.length >= 4) out += ') ';
+  if (digits.length >= 4) out += digits.slice(4, 7);
+  if (digits.length >= 7) out += '-' + digits.slice(7, 9);
+  if (digits.length >= 9) out += '-' + digits.slice(9, 11);
+  return out;
 }
 
 function onPhoneInput(e) {
-  let digits = e.target.value.replace(/\D/g, '')
-  if (!digits.startsWith('7')) digits = '7' + digits.replace(/^7*/, '')
-  digits = digits.slice(0, 11)
-  phone.value = digits
-  phoneInput.value = formatPhone(digits)
+  let digits = e.target.value.replace(/\D/g, '');
+  if (!digits.startsWith('7')) digits = '7' + digits.replace(/^7*/, '');
+  digits = digits.slice(0, 11);
+  phone.value = digits;
+  phoneInput.value = formatPhone(digits);
+  phoneTouched.value = true;
 }
 
 function onPhoneKeydown(e) {
   if (e.key === 'Backspace' || e.key === 'Delete') {
-    e.preventDefault()
-    phone.value = phone.value.slice(0, -1)
-    phoneInput.value = formatPhone(phone.value)
+    e.preventDefault();
+    phone.value = phone.value.slice(0, -1);
+    phoneInput.value = formatPhone(phone.value);
+    phoneTouched.value = true;
   }
 }
 
 async function login() {
-  error.value = ''
+  error.value = '';
   if (phone.value.length !== 11 || !phone.value.startsWith('7')) {
-    error.value = 'Неверный номер телефона'
-    return
+    error.value = 'Неверный номер телефона';
+    return;
   }
-  loading.value = true
+  loading.value = true;
   try {
     const data = await apiFetch('/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ phone: phone.value, password: password.value })
-    })
-    localStorage.setItem('access_token', data.access_token)
-    localStorage.setItem('roles', JSON.stringify(data.roles || []))
-    auth.user = data.user
-    auth.roles = data.roles || []
-    router.push('/')
+      body: JSON.stringify({ phone: phone.value, password: password.value }),
+    });
+    const storage = rememberMe.value ? localStorage : sessionStorage;
+    storage.setItem('access_token', data.access_token);
+    storage.setItem('roles', JSON.stringify(data.roles || []));
+    (rememberMe.value ? sessionStorage : localStorage).removeItem(
+      'access_token'
+    );
+    (rememberMe.value ? sessionStorage : localStorage).removeItem('roles');
+    auth.user = data.user;
+    auth.roles = data.roles || [];
+    router.push('/');
   } catch (err) {
-    error.value = err.message || 'Ошибка авторизации'
+    error.value = err.message || 'Ошибка авторизации';
   } finally {
-    loading.value = false
+    loading.value = false;
   }
 }
 </script>
 
 <template>
   <div class="d-flex align-items-center justify-content-center vh-100">
-    <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
+    <div class="card p-4 shadow login-card w-100">
+      <img
+        :src="logo"
+        alt="FHM Pulse logo"
+        class="login-logo mb-3 mx-auto d-block"
+      />
       <h1 class="mb-4 text-center">Вход</h1>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>
       <form @submit.prevent="login">
-        <div class="mb-3 input-group">
-          <span class="input-group-text"><i class="bi bi-phone"></i></span>
+        <div
+          class="mb-3 input-group"
+          style="border-radius: 8px; overflow: hidden"
+        >
+          <label for="phoneInput" class="form-label visually-hidden"
+            >Телефон</label
+          >
+          <span
+            class="input-group-text"
+            style="background-color: var(--brand-color); color: #fff"
+            ><i class="bi bi-phone"></i
+          ></span>
           <input
+            id="phoneInput"
             v-model="phoneInput"
             @input="onPhoneInput"
             @keydown="onPhoneKeydown"
             type="tel"
-            class="form-control"
+            :class="[
+              'form-control',
+              { 'is-invalid': phoneTouched && !phoneValid },
+            ]"
             placeholder="+7 (___) ___-__-__"
             required
+            :aria-invalid="phoneTouched && !phoneValid"
           />
+          <div class="invalid-feedback">Введите корректный номер</div>
         </div>
-        <div class="mb-3 input-group">
-          <span class="input-group-text"><i class="bi bi-lock"></i></span>
-          <input v-model="password" type="password" class="form-control" required />
+        <div
+          class="mb-3 input-group"
+          style="border-radius: 8px; overflow: hidden"
+        >
+          <label for="password" class="form-label visually-hidden"
+            >Пароль</label
+          >
+          <span
+            class="input-group-text"
+            style="background-color: var(--brand-color); color: #fff"
+            ><i class="bi bi-lock"></i
+          ></span>
+          <input
+            id="password"
+            v-model="password"
+            :type="showPassword ? 'text' : 'password'"
+            class="form-control"
+            required
+          />
+          <button
+            type="button"
+            class="btn btn-outline-secondary"
+            @click="showPassword = !showPassword"
+            :aria-label="showPassword ? 'Скрыть пароль' : 'Показать пароль'"
+          >
+            <i :class="showPassword ? 'bi bi-eye-slash' : 'bi bi-eye'"></i>
+          </button>
         </div>
-        <button type="submit" class="btn btn-primary w-100" :disabled="loading">
-          <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
+        <div class="form-check mb-3">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="rememberMe"
+            v-model="rememberMe"
+            style="accent-color: var(--brand-color)"
+          />
+          <label class="form-check-label" for="rememberMe"
+            >Запомнить меня</label
+          >
+        </div>
+        <button
+          type="submit"
+          class="btn btn-primary w-100"
+          :disabled="loading"
+          style="
+            background-color: var(--brand-color);
+            border-color: var(--brand-color);
+          "
+        >
+          <span
+            v-if="loading"
+            class="spinner-border spinner-border-sm me-2"
+          ></span>
           Войти
         </button>
+        <div class="text-center mt-2">
+          <router-link to="/forgot-password" style="color: var(--brand-color)"
+            >Забыли пароль?</router-link
+          >
+        </div>
       </form>
     </div>
   </div>
@@ -106,6 +185,14 @@ async function login() {
 <style scoped>
 .login-card {
   animation: fade-in 0.4s ease-out;
+  max-width: 400px;
+  border-radius: 8px;
+  border: 1px solid var(--brand-color);
+}
+
+.login-logo {
+  max-width: 120px;
+  height: auto;
 }
 
 .fade-enter-active,


### PR DESCRIPTION
## Summary
- add accessible labels and validation
- implement show password toggle
- remember user preference for token storage
- add a "remember me" option and forgot password link
- add logo and style refinements to login form
- apply brand color scheme across navbar and login page
- format client code with Prettier for consistency

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a6ee924c4832da9ccf6242e84db13