### PR TITLE
Add logo and registration link to login

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -1,5 +1,6 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import Login from './views/Login.vue'
+import Register from './views/Register.vue'
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
 import AdminUsers from './views/AdminUsers.vue'
@@ -14,7 +15,8 @@ const routes = [
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/login', component: Login }
+  { path: '/login', component: Login },
+  { path: '/register', component: Register }
 ]
 
 const router = createRouter({

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,8 +1,9 @@
 <script setup>
 import { ref, watch } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { auth } from '../auth.js'
+import logo from '../assets/fhm-logo.svg'
 
 const router = useRouter()
 const phone = ref('')
@@ -73,31 +74,44 @@ async function login() {
 <template>
   <div class="d-flex align-items-center justify-content-center vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
+      <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
       <h1 class="mb-4 text-center">Вход</h1>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>
       <form @submit.prevent="login">
-        <div class="mb-3 input-group">
-          <span class="input-group-text"><i class="bi bi-phone"></i></span>
-          <input
-            v-model="phoneInput"
-            @input="onPhoneInput"
-            @keydown="onPhoneKeydown"
-            type="tel"
-            class="form-control"
-            placeholder="+7 (___) ___-__-__"
-            required
-          />
+        <div class="mb-3">
+          <label for="phone" class="form-label">Телефон</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-phone"></i></span>
+            <input
+              id="phone"
+              v-model="phoneInput"
+              @input="onPhoneInput"
+              @keydown="onPhoneKeydown"
+              type="tel"
+              class="form-control"
+              placeholder="+7 (___) ___-__-__"
+              autocomplete="tel"
+              autofocus
+              required
+            />
+          </div>
         </div>
-        <div class="mb-3 input-group">
-          <span class="input-group-text"><i class="bi bi-lock"></i></span>
-          <input v-model="password" type="password" class="form-control" required />
+        <div class="mb-3">
+          <label for="password" class="form-label">Пароль</label>
+          <div class="input-group">
+            <span class="input-group-text"><i class="bi bi-lock"></i></span>
+            <input id="password" v-model="password" type="password" class="form-control" autocomplete="current-password" required />
+          </div>
         </div>
         <button type="submit" class="btn btn-primary w-100" :disabled="loading">
           <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
           Войти
         </button>
+        <div class="text-center mt-3">
+          <RouterLink to="/register" class="link-secondary">Регистрация</RouterLink>
+        </div>
       </form>
     </div>
   </div>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -80,30 +80,32 @@ async function login() {
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>
       <form @submit.prevent="login">
-        <div class="mb-3">
-          <label for="phone" class="form-label">Телефон</label>
-          <div class="input-group">
-            <span class="input-group-text"><i class="bi bi-phone"></i></span>
-            <input
-              id="phone"
-              v-model="phoneInput"
-              @input="onPhoneInput"
-              @keydown="onPhoneKeydown"
-              type="tel"
-              class="form-control"
-              placeholder="+7 (___) ___-__-__"
-              autocomplete="tel"
-              autofocus
-              required
-            />
-          </div>
+        <div class="form-floating mb-3">
+          <input
+            id="phone"
+            v-model="phoneInput"
+            @input="onPhoneInput"
+            @keydown="onPhoneKeydown"
+            type="tel"
+            class="form-control"
+            placeholder="+7 (___) ___-__-__"
+            autocomplete="tel"
+            autofocus
+            required
+          />
+          <label for="phone">Телефон</label>
         </div>
-        <div class="mb-3">
-          <label for="password" class="form-label">Пароль</label>
-          <div class="input-group">
-            <span class="input-group-text"><i class="bi bi-lock"></i></span>
-            <input id="password" v-model="password" type="password" class="form-control" autocomplete="current-password" required />
-          </div>
+        <div class="form-floating mb-3">
+          <input
+            id="password"
+            v-model="password"
+            type="password"
+            class="form-control"
+            placeholder="Пароль"
+            autocomplete="current-password"
+            required
+          />
+          <label for="password">Пароль</label>
         </div>
         <button type="submit" class="btn btn-primary w-100" :disabled="loading">
           <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -1,0 +1,13 @@
+<script setup>
+import { RouterLink } from 'vue-router'
+</script>
+
+<template>
+  <div class="d-flex align-items-center justify-content-center vh-100">
+    <div class="card p-4 shadow w-100" style="max-width: 400px;">
+      <h1 class="mb-4 text-center">Регистрация</h1>
+      <p class="text-center">Страница регистрации в разработке.</p>
+      <RouterLink to="/login" class="btn btn-primary w-100 mt-3">Назад ко входу</RouterLink>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- tweak login view styles and fields
- add registration page placeholder
- register new route for registration page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a94a55964832d83f5332410811613