### PR TITLE
Add bank account admin interface

### DIFF
--- a/client/src/components/BankAccountForm.vue
+++ b/client/src/components/BankAccountForm.vue
@@ -1,0 +1,219 @@
+<script setup>
+import { ref, onMounted } from 'vue'
+import { Modal } from 'bootstrap'
+import { apiFetch } from '../api.js'
+import { findBankByBic } from '../dadata.js'
+import { isValidAccountNumber } from '../utils/bank.js'
+
+const props = defineProps({ userId: { type: String, required: true } })
+
+const account = ref(null)
+const error = ref('')
+const modalRef = ref(null)
+let modal
+const form = ref({ number: '', bic: '' })
+const bank = ref(null)
+const checkStatus = ref('')
+
+onMounted(() => {
+  modal = new Modal(modalRef.value)
+  loadAccount()
+})
+
+async function loadAccount() {
+  try {
+    const { account: acc } = await apiFetch(`/users/${props.userId}/bank-account`)
+    account.value = acc
+    error.value = ''
+  } catch (e) {
+    if (e.message === 'bank_account_not_found') {
+      account.value = null
+      error.value = ''
+    } else {
+      error.value = e.message
+    }
+  }
+}
+
+function open() {
+  if (account.value) {
+    form.value.number = account.value.number
+    form.value.bic = account.value.bic
+    bank.value = { ...account.value }
+    checkStatus.value = 'found'
+  } else {
+    form.value.number = ''
+    form.value.bic = ''
+    bank.value = null
+    checkStatus.value = ''
+  }
+  error.value = ''
+  modal.show()
+}
+
+async function checkBank() {
+  checkStatus.value = 'pending'
+  bank.value = null
+  const res = await findBankByBic(form.value.bic)
+  if (res) {
+    bank.value = {
+      bank_name: res.value,
+      correspondent_account: res.data.correspondent_account,
+      swift: res.data.swift,
+      inn: res.data.inn,
+      kpp: res.data.kpp,
+      address: res.data.address?.unrestricted_value,
+    }
+    checkStatus.value = 'found'
+  } else {
+    checkStatus.value = 'not_found'
+  }
+}
+
+async function save() {
+  if (!isValidAccountNumber(form.value.number, form.value.bic)) {
+    error.value = 'Неверный счёт или БИК'
+    return
+  }
+  const payload = { number: form.value.number, bic: form.value.bic }
+  try {
+    let res
+    if (account.value) {
+      res = await apiFetch(`/users/${props.userId}/bank-account`, {
+        method: 'PUT',
+        body: JSON.stringify(payload)
+      })
+    } else {
+      res = await apiFetch(`/users/${props.userId}/bank-account`, {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      })
+    }
+    account.value = res.account
+    modal.hide()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+
+async function removeAccount() {
+  if (!confirm('Удалить счёт?')) return
+  try {
+    await apiFetch(`/users/${props.userId}/bank-account`, { method: 'DELETE' })
+    account.value = null
+    modal.hide()
+  } catch (e) {
+    error.value = e.message
+  }
+}
+</script>
+
+<template>
+  <div class="card mt-4">
+    <div class="card-body">
+      <h5 class="card-title mb-3">Банковский счёт</h5>
+      <div v-if="account">
+        <div class="row row-cols-1 row-cols-sm-2 g-3 mb-3">
+          <div class="col">
+            <label class="form-label">Счёт</label>
+            <input type="text" class="form-control" :value="account.number" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">БИК</label>
+            <input type="text" class="form-control" :value="account.bic" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">Банк</label>
+            <input type="text" class="form-control" :value="account.bank_name" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">Корсчёт</label>
+            <input type="text" class="form-control" :value="account.correspondent_account" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">SWIFT</label>
+            <input type="text" class="form-control" :value="account.swift" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">ИНН</label>
+            <input type="text" class="form-control" :value="account.inn" readonly />
+          </div>
+          <div class="col">
+            <label class="form-label">КПП</label>
+            <input type="text" class="form-control" :value="account.kpp" readonly />
+          </div>
+          <div class="col-12">
+            <label class="form-label">Адрес</label>
+            <textarea class="form-control" rows="2" :value="account.address" readonly />
+          </div>
+        </div>
+      </div>
+      <p v-else class="mb-2 text-muted">Счёт не указан.</p>
+      <button class="btn btn-outline-primary" @click="open">
+        {{ account ? 'Изменить' : 'Добавить' }}
+      </button>
+      <div v-if="error" class="text-danger mt-2">{{ error }}</div>
+    </div>
+  </div>
+
+  <div ref="modalRef" class="modal fade" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form @submit.prevent="save">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ account ? 'Изменить счёт' : 'Добавить счёт' }}</h5>
+            <button type="button" class="btn-close" @click="modal.hide()"></button>
+          </div>
+          <div class="modal-body">
+            <div v-if="error" class="alert alert-danger">{{ error }}</div>
+            <div class="mb-3">
+              <label class="form-label">Расчётный счёт</label>
+              <input v-model="form.number" class="form-control" placeholder="20 цифр" />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">БИК</label>
+              <input v-model="form.bic" class="form-control" placeholder="9 цифр" />
+            </div>
+            <button type="button" class="btn btn-outline-secondary" @click="checkBank">
+              Проверить
+            </button>
+            <div v-if="checkStatus === 'pending'" class="mt-2">Проверка...</div>
+            <div v-if="checkStatus === 'not_found'" class="text-danger mt-2">Банк не найден</div>
+            <div v-if="checkStatus === 'found' && bank" class="mt-3">
+              <div class="mb-2">
+                <label class="form-label">Банк</label>
+                <input type="text" class="form-control" :value="bank.bank_name" readonly />
+              </div>
+              <div class="mb-2">
+                <label class="form-label">Корсчёт</label>
+                <input type="text" class="form-control" :value="bank.correspondent_account" readonly />
+              </div>
+              <div class="mb-2">
+                <label class="form-label">SWIFT</label>
+                <input type="text" class="form-control" :value="bank.swift" readonly />
+              </div>
+              <div class="mb-2">
+                <label class="form-label">ИНН</label>
+                <input type="text" class="form-control" :value="bank.inn" readonly />
+              </div>
+              <div class="mb-2">
+                <label class="form-label">КПП</label>
+                <input type="text" class="form-control" :value="bank.kpp" readonly />
+              </div>
+              <div class="mb-2">
+                <label class="form-label">Адрес</label>
+                <textarea class="form-control" rows="2" :value="bank.address" readonly />
+              </div>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button v-if="account" type="button" class="btn btn-danger me-auto" @click="removeAccount">Удалить</button>
+            <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+            <button type="submit" class="btn btn-primary">Сохранить</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>
+

--- a/client/src/dadata.js
+++ b/client/src/dadata.js
@@ -55,3 +55,16 @@ export async function cleanPassport(passport) {
     return null
   }
 }
+
+export async function findBankByBic(bic) {
+  if (!bic) return null
+  try {
+    const { bank } = await apiFetch('/dadata/find-bank', {
+      method: 'POST',
+      body: JSON.stringify({ bic })
+    })
+    return bank
+  } catch (_err) {
+    return null
+  }
+}

--- a/client/src/utils/bank.js
+++ b/client/src/utils/bank.js
@@ -1,0 +1,7 @@
+export function isValidAccountNumber(number, bic) {
+  if (!/^\d{20}$/.test(number) || !/^\d{9}$/.test(bic)) return false;
+  const coeff = [7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1];
+  const digits = (bic.slice(-3) + number).split('').map(Number);
+  const sum = digits.reduce((acc, d, idx) => acc + ((d * coeff[idx]) % 10), 0);
+  return sum % 10 === 0;
+}

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -5,6 +5,7 @@ import { apiFetch } from '../api.js'
 import UserForm from '../components/UserForm.vue'
 import AddPassportModal from '../components/AddPassportModal.vue'
 import InnSnilsForm from '../components/InnSnilsForm.vue'
+import BankAccountForm from '../components/BankAccountForm.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -17,7 +18,6 @@ const passportModalRef = ref(null)
 const passport = ref(null)
 const passportError = ref('')
 const placeholderSections = [
-  'Банковские реквизиты',
   'Тип налогообложения',
   'Выданный инвентарь'
 ]
@@ -121,6 +121,7 @@ async function save() {
     </form>
     <p v-else-if="isLoading">Загрузка...</p>
     <InnSnilsForm v-if="user" :userId="route.params.id" />
+    <BankAccountForm v-if="user" :userId="route.params.id" />
 
     <div v-if="passport !== undefined" class="mt-4">
       <div v-if="passport" class="card">

--- a/src/controllers/bankAccountAdminController.js
+++ b/src/controllers/bankAccountAdminController.js
@@ -1,0 +1,87 @@
+import { validationResult } from 'express-validator';
+
+import bankAccountService from '../services/bankAccountService.js';
+import dadataService from '../services/dadataService.js';
+import bankAccountMapper from '../mappers/bankAccountMapper.js';
+
+export default {
+  async get(req, res) {
+    try {
+      const acc = await bankAccountService.getByUser(req.params.id);
+      if (!acc) {
+        return res.status(404).json({ error: 'bank_account_not_found' });
+      }
+      return res.json({ account: bankAccountMapper.toPublic(acc) });
+    } catch (err) {
+      return res.status(400).json({ error: err.message });
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const bank = await dadataService.findBankByBic(req.body.bic);
+      if (!bank) return res.status(400).json({ error: 'bank_not_found' });
+      const data = {
+        number: req.body.number,
+        bic: req.body.bic,
+        bank_name: bank.value,
+        correspondent_account: bank.data.correspondent_account,
+        swift: bank.data.swift,
+        inn: bank.data.inn,
+        kpp: bank.data.kpp,
+        address: bank.data.address?.unrestricted_value,
+      };
+      const acc = await bankAccountService.createForUser(
+        req.params.id,
+        data,
+        req.user.id
+      );
+      return res.status(201).json({ account: bankAccountMapper.toPublic(acc) });
+    } catch (err) {
+      const status = err.message === 'user_not_found' ? 404 : 400;
+      return res.status(status).json({ error: err.message });
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const bank = await dadataService.findBankByBic(req.body.bic);
+      if (!bank) return res.status(400).json({ error: 'bank_not_found' });
+      const data = {
+        number: req.body.number,
+        bic: req.body.bic,
+        bank_name: bank.value,
+        correspondent_account: bank.data.correspondent_account,
+        swift: bank.data.swift,
+        inn: bank.data.inn,
+        kpp: bank.data.kpp,
+        address: bank.data.address?.unrestricted_value,
+      };
+      const acc = await bankAccountService.updateForUser(
+        req.params.id,
+        data,
+        req.user.id
+      );
+      return res.json({ account: bankAccountMapper.toPublic(acc) });
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await bankAccountService.removeForUser(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return res.status(404).json({ error: err.message });
+    }
+  },
+};

--- a/src/controllers/dadataController.js
+++ b/src/controllers/dadataController.js
@@ -23,4 +23,9 @@ export default {
     const result = await dadata.cleanPassport(req.body.passport);
     return res.json({ result });
   },
+
+  async findBank(req, res) {
+    const bank = await dadata.findBankByBic(req.body.bic);
+    return res.json({ bank });
+  },
 };

--- a/src/mappers/bankAccountMapper.js
+++ b/src/mappers/bankAccountMapper.js
@@ -1,0 +1,32 @@
+function sanitize(obj) {
+  const {
+    id,
+    number,
+    bic,
+    bank_name,
+    correspondent_account,
+    swift,
+    inn,
+    kpp,
+    address,
+  } = obj;
+  return {
+    id,
+    number,
+    bic,
+    bank_name,
+    correspondent_account,
+    swift,
+    inn,
+    kpp,
+    address,
+  };
+}
+
+function toPublic(acc) {
+  if (!acc) return null;
+  const plain = typeof acc.get === 'function' ? acc.get({ plain: true }) : acc;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/migrations/20250624161000-create-bank-accounts.js
+++ b/src/migrations/20250624161000-create-bank-accounts.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable('bank_accounts', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      number: { type: Sequelize.STRING(20), allowNull: false },
+      bic: { type: Sequelize.STRING(9), allowNull: false },
+      bank_name: { type: Sequelize.STRING(255) },
+      correspondent_account: { type: Sequelize.STRING(20) },
+      swift: { type: Sequelize.STRING(20) },
+      inn: { type: Sequelize.STRING(12) },
+      kpp: { type: Sequelize.STRING(9) },
+      address: { type: Sequelize.STRING(255) },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+    await queryInterface.addIndex('bank_accounts', ['user_id'], {
+      name: 'uq_bank_accounts_user_id_not_deleted',
+      unique: true,
+      where: { deleted_at: null },
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.dropTable('bank_accounts');
+  },
+};

--- a/src/models/bankAccount.js
+++ b/src/models/bankAccount.js
@@ -1,0 +1,33 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class BankAccount extends Model {}
+
+BankAccount.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    user_id: { type: DataTypes.UUID, allowNull: false },
+    number: { type: DataTypes.STRING(20), allowNull: false },
+    bic: { type: DataTypes.STRING(9), allowNull: false },
+    bank_name: { type: DataTypes.STRING(255) },
+    correspondent_account: { type: DataTypes.STRING(20) },
+    swift: { type: DataTypes.STRING(20) },
+    inn: { type: DataTypes.STRING(12) },
+    kpp: { type: DataTypes.STRING(9) },
+    address: { type: DataTypes.STRING(255) },
+  },
+  {
+    sequelize,
+    modelName: 'BankAccount',
+    tableName: 'bank_accounts',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default BankAccount;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -9,6 +9,7 @@ import Country from './country.js';
 import Passport from './passport.js';
 import Inn from './inn.js';
 import Snils from './snils.js';
+import BankAccount from './bankAccount.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -29,6 +30,8 @@ User.hasOne(Inn, { foreignKey: 'user_id' });
 Inn.belongsTo(User, { foreignKey: 'user_id' });
 User.hasOne(Snils, { foreignKey: 'user_id' });
 Snils.belongsTo(User, { foreignKey: 'user_id' });
+User.hasOne(BankAccount, { foreignKey: 'user_id' });
+BankAccount.belongsTo(User, { foreignKey: 'user_id' });
 
 /* справочники */
 DocumentType.hasMany(Passport, { foreignKey: 'document_type_id' });
@@ -53,4 +56,5 @@ export {
   Passport,
   Inn,
   Snils,
+  BankAccount,
 };

--- a/src/routes/dadata.js
+++ b/src/routes/dadata.js
@@ -33,5 +33,6 @@ router.post('/clean-fio', auth, controller.cleanFio);
 
 router.post('/suggest-fms-unit', auth, controller.suggestFmsUnit);
 router.post('/clean-passport', auth, controller.cleanPassport);
+router.post('/find-bank', auth, controller.findBank);
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -6,12 +6,14 @@ import userMapper from '../mappers/userMapper.js';
 import admin from '../controllers/userAdminController.js';
 import innAdmin from '../controllers/innAdminController.js';
 import snilsAdmin from '../controllers/snilsAdminController.js';
+import bankAccountAdmin from '../controllers/bankAccountAdminController.js';
 import {
   createUserRules,
   updateUserRules,
   resetPasswordRules,
 } from '../validators/userValidators.js';
 import { innRules, snilsRules } from '../validators/personalValidators.js';
+import { bankAccountRules } from '../validators/bankAccountValidators.js';
 import { createPassportRules } from '../validators/passportValidators.js';
 
 const router = express.Router();
@@ -140,6 +142,28 @@ router.put(
 );
 router.delete('/:id/snils', auth, authorize('ADMIN'), snilsAdmin.remove);
 router.get('/:id/snils', auth, authorize('ADMIN'), snilsAdmin.get);
+
+router.post(
+  '/:id/bank-account',
+  auth,
+  authorize('ADMIN'),
+  bankAccountRules,
+  bankAccountAdmin.create
+);
+router.put(
+  '/:id/bank-account',
+  auth,
+  authorize('ADMIN'),
+  bankAccountRules,
+  bankAccountAdmin.update
+);
+router.delete(
+  '/:id/bank-account',
+  auth,
+  authorize('ADMIN'),
+  bankAccountAdmin.remove
+);
+router.get('/:id/bank-account', auth, authorize('ADMIN'), bankAccountAdmin.get);
 
 router.post(
   '/:id/passport',

--- a/src/services/bankAccountService.js
+++ b/src/services/bankAccountService.js
@@ -1,0 +1,35 @@
+import { BankAccount, User } from '../models/index.js';
+
+async function getByUser(userId) {
+  return BankAccount.findOne({ where: { user_id: userId } });
+}
+
+async function createForUser(userId, data, actorId) {
+  const [user, existing] = await Promise.all([
+    User.findByPk(userId),
+    BankAccount.findOne({ where: { user_id: userId } }),
+  ]);
+  if (!user) throw new Error('user_not_found');
+  if (existing) throw new Error('bank_account_exists');
+  return BankAccount.create({
+    user_id: userId,
+    ...data,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+}
+
+async function updateForUser(userId, data, actorId) {
+  const acc = await BankAccount.findOne({ where: { user_id: userId } });
+  if (!acc) throw new Error('bank_account_not_found');
+  await acc.update({ ...data, updated_by: actorId });
+  return acc;
+}
+
+async function removeForUser(userId) {
+  const acc = await BankAccount.findOne({ where: { user_id: userId } });
+  if (!acc) throw new Error('bank_account_not_found');
+  await acc.destroy();
+}
+
+export default { getByUser, createForUser, updateForUser, removeForUser };

--- a/src/services/dadataService.js
+++ b/src/services/dadataService.js
@@ -76,9 +76,17 @@ export async function cleanPassport(passport) {
   return Array.isArray(data) ? data[0] : null;
 }
 
+export async function findBankByBic(bic) {
+  if (!bic) return null;
+  const data = await request('/findById/bank', { query: bic });
+  if (!data?.suggestions?.length) return null;
+  return data.suggestions[0];
+}
+
 export default {
   suggestFio,
   cleanFio,
   suggestFmsUnit,
   cleanPassport,
+  findBankByBic,
 };

--- a/src/utils/bank.js
+++ b/src/utils/bank.js
@@ -1,0 +1,7 @@
+export function isValidAccountNumber(number, bic) {
+  if (!/^\d{20}$/.test(number) || !/^\d{9}$/.test(bic)) return false;
+  const coeff = [7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1,3,7,1];
+  const digits = (bic.slice(-3) + number).split('').map(Number);
+  const sum = digits.reduce((acc, d, idx) => acc + ((d * coeff[idx]) % 10), 0);
+  return sum % 10 === 0;
+}

--- a/src/validators/bankAccountValidators.js
+++ b/src/validators/bankAccountValidators.js
@@ -1,0 +1,13 @@
+import { body } from 'express-validator';
+
+import { isValidAccountNumber } from '../utils/bank.js';
+
+export const bankAccountRules = [
+  body('number')
+    .matches(/^\d{20}$/)
+    .withMessage('invalid_format')
+    .bail()
+    .custom((val, { req }) => isValidAccountNumber(val, req.body.bic))
+    .withMessage('invalid_number'),
+  body('bic').matches(/^\d{9}$/).withMessage('invalid_bic'),
+];

--- a/tests/bank.test.js
+++ b/tests/bank.test.js
@@ -1,0 +1,9 @@
+import { describe, expect, test } from '@jest/globals';
+import { isValidAccountNumber } from '../src/utils/bank.js';
+
+describe('bank utils', () => {
+  test('isValidAccountNumber validates checksum', () => {
+    expect(isValidAccountNumber('40702810900000005555', '044525225')).toBe(true);
+    expect(isValidAccountNumber('40702810900000005554', '044525225')).toBe(false);
+  });
+});

--- a/tests/dadataService.test.js
+++ b/tests/dadataService.test.js
@@ -18,6 +18,7 @@ const {
   cleanFio,
   suggestFmsUnit,
   cleanPassport,
+  findBankByBic,
 } = await import('../src/services/dadataService.js');
 
 test('suggestFio returns array from API', async () => {
@@ -71,4 +72,19 @@ test('cleanPassport returns first element', async () => {
     })
   );
   expect(res).toEqual({ number: '123' });
+});
+
+test('findBankByBic returns first suggestion', async () => {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ suggestions: [{ value: 'bank' }] }),
+  });
+  const res = await findBankByBic('044525225');
+  expect(fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/findById/bank'),
+    expect.objectContaining({
+      body: JSON.stringify({ query: '044525225' }),
+    })
+  );
+  expect(res).toEqual({ value: 'bank' });
 });


### PR DESCRIPTION
## Summary
- expose DaData bank search endpoint
- validate account numbers on the client
- add Vue component for managing user bank accounts
- integrate bank account card in admin user edit page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685aa0331ee8832d89052b1df09fd442