### PR TITLE
Add duplicate checks for personal IDs

### DIFF
--- a/tests/innService.test.js
+++ b/tests/innService.test.js
@@ -1,0 +1,32 @@
+import { expect, jest, test } from '@jest/globals';
+
+const findOneMock = jest.fn();
+const createMock = jest.fn();
+const updateMock = jest.fn();
+
+const innInstance = { update: updateMock };
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  Inn: {
+    findOne: findOneMock,
+    create: createMock,
+  },
+}));
+jest.unstable_mockModule('../src/services/taxationService.js', () => ({
+  __esModule: true,
+  default: { removeByUser: jest.fn() },
+}));
+
+const { default: service } = await import('../src/services/innService.js');
+
+test('create throws when duplicate exists', async () => {
+  findOneMock.mockResolvedValueOnce({ id: 'd' });
+  await expect(service.create('u1', '123', 'a')).rejects.toThrow('inn_exists');
+});
+
+test('update throws when duplicate exists', async () => {
+  findOneMock.mockResolvedValueOnce(innInstance); // first call for user record
+  findOneMock.mockResolvedValueOnce({ id: 'other' }); // second call duplicate
+  await expect(service.update('u1', '123', 'a')).rejects.toThrow('inn_exists');
+});

--- a/tests/snilsService.test.js
+++ b/tests/snilsService.test.js
@@ -1,0 +1,28 @@
+import { expect, jest, test } from '@jest/globals';
+
+const findOneMock = jest.fn();
+const createMock = jest.fn();
+const updateMock = jest.fn();
+
+const snilsInstance = { update: updateMock };
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  Snils: {
+    findOne: findOneMock,
+    create: createMock,
+  },
+}));
+
+const { default: service } = await import('../src/services/snilsService.js');
+
+test('create throws when duplicate exists', async () => {
+  findOneMock.mockResolvedValueOnce({ id: 'd' });
+  await expect(service.create('u1', '123', 'a')).rejects.toThrow('snils_exists');
+});
+
+test('update throws when duplicate exists', async () => {
+  findOneMock.mockResolvedValueOnce(snilsInstance); // user record
+  findOneMock.mockResolvedValueOnce({ id: 'other' }); // duplicate
+  await expect(service.update('u1', '123', 'a')).rejects.toThrow('snils_exists');
+});


### PR DESCRIPTION
## Summary
- check for active duplicate INN and SNILS numbers when creating or updating
- add unit tests for new uniqueness checks

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ae8e5cbf8832d933ee6fed89c578b