### PR TITLE
Improve registration data validation

### DIFF
--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -1,47 +1,78 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { auth } from '../auth.js'
+import UserForm from '../components/UserForm.vue'
+import { isValidInn, isValidSnils, formatSnils } from '../utils/personal.js'
 
 const router = useRouter()
 const step = ref(
   auth.user?.status === 'REGISTRATION_STEP_2' ? 2 : 1
 )
 const total = 2
-const snils = ref('')
+const user = ref({})
 const inn = ref('')
+const snilsDigits = ref('')
+const snilsInput = ref('')
 const error = ref('')
 const loading = ref(false)
+const formRef = ref(null)
+
+onMounted(async () => {
+  try {
+    const data = await apiFetch('/users/me')
+    user.value = data.user
+  } catch (_) {}
+})
+
+function onInnInput(e) {
+  inn.value = e.target.value.replace(/\D/g, '').slice(0, 12)
+}
+
+function onSnilsInput(e) {
+  let digits = e.target.value.replace(/\D/g, '').slice(0, 11)
+  snilsDigits.value = digits
+  snilsInput.value = formatSnils(digits)
+}
 
 async function saveStep() {
   loading.value = true
   error.value = ''
   try {
     if (step.value === 1) {
-      await apiFetch('/snils', {
-        method: 'POST',
-        body: JSON.stringify({ number: snils.value })
-      })
+      if (!formRef.value.validate()) {
+        loading.value = false
+        return
+      }
       await apiFetch('/profile/progress', {
         method: 'POST',
         body: JSON.stringify({ status: 'REGISTRATION_STEP_2' })
       })
       auth.user.status = 'REGISTRATION_STEP_2'
-    } else if (step.value === 2) {
-      await apiFetch('/inns', {
-        method: 'POST',
-        body: JSON.stringify({ number: inn.value })
-      })
-    }
-    if (step.value < total) {
-      step.value++
+      step.value = 2
       loading.value = false
       return
     }
+    if (!isValidSnils(snilsInput.value)) {
+      error.value = 'Неверный СНИЛС'
+      return
+    }
+    if (!isValidInn(inn.value)) {
+      error.value = 'Неверный ИНН'
+      return
+    }
+    await apiFetch('/snils', {
+      method: 'POST',
+      body: JSON.stringify({ number: snilsInput.value })
+    })
+    await apiFetch('/inns', {
+      method: 'POST',
+      body: JSON.stringify({ number: inn.value })
+    })
     await apiFetch('/profile/complete', { method: 'POST' })
     auth.user.status = 'AWAITING_CONFIRMATION'
-    router.push('/login')
+    router.push('/')
   } catch (e) {
     error.value = e.message
   } finally {
@@ -51,24 +82,41 @@ async function saveStep() {
 </script>
 
 <template>
-  <div class="container py-5" style="max-width: 500px">
+  <div class="container py-5" style="max-width: 600px">
     <h1 class="mb-4 text-center">Заполнение профиля</h1>
     <div class="progress mb-4">
       <div class="progress-bar" role="progressbar" :style="{ width: (step / total) * 100 + '%' }"></div>
     </div>
     <div v-if="error" class="alert alert-danger">{{ error }}</div>
     <form @submit.prevent="saveStep">
-      <div v-if="step === 1" class="mb-3">
-        <label for="snils" class="form-label">СНИЛС</label>
-        <input id="snils" v-model="snils" class="form-control" required />
+      <div v-if="step === 1" class="mb-4">
+        <UserForm ref="formRef" v-model="user" />
       </div>
-      <div v-else-if="step === 2" class="mb-3">
-        <label for="inn" class="form-label">ИНН</label>
-        <input id="inn" v-model="inn" class="form-control" required />
+      <div v-else-if="step === 2" class="mb-4">
+        <div class="form-floating mb-3">
+          <input
+            id="snils"
+            v-model="snilsInput"
+            @input="onSnilsInput"
+            class="form-control"
+            placeholder="СНИЛС"
+          />
+          <label for="snils">СНИЛС</label>
+        </div>
+        <div class="form-floating">
+          <input
+            id="inn"
+            v-model="inn"
+            @input="onInnInput"
+            class="form-control"
+            placeholder="ИНН"
+          />
+          <label for="inn">ИНН</label>
+        </div>
       </div>
       <button type="submit" class="btn btn-primary w-100" :disabled="loading">
         <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
-        {{ step < total ? 'Далее' : 'Отправить на проверку' }}
+        {{ step < total ? 'Все верно, продолжить' : 'Завершить' }}
       </button>
     </form>
   </div>

--- a/src/controllers/innController.js
+++ b/src/controllers/innController.js
@@ -1,3 +1,5 @@
+import { validationResult } from 'express-validator';
+
 import innService from '../services/innService.js';
 import innMapper from '../mappers/innMapper.js';
 
@@ -11,6 +13,10 @@ export default {
   },
 
   async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
     try {
       const inn = await innService.create(
         req.user.id,

--- a/src/controllers/snilsController.js
+++ b/src/controllers/snilsController.js
@@ -1,3 +1,5 @@
+import { validationResult } from 'express-validator';
+
 import snilsService from '../services/snilsService.js';
 import snilsMapper from '../mappers/snilsMapper.js';
 
@@ -11,6 +13,10 @@ export default {
   },
 
   async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
     try {
       const snils = await snilsService.create(
         req.user.id,

--- a/src/routes/inns.js
+++ b/src/routes/inns.js
@@ -1,5 +1,6 @@
 import express from 'express';
-import { body } from 'express-validator';
+
+import { innRules } from '../validators/personalValidators.js';
 
 import auth from '../middlewares/auth.js';
 import innController from '../controllers/innController.js';
@@ -7,11 +8,6 @@ import innController from '../controllers/innController.js';
 const router = express.Router();
 
 router.get('/me', auth, innController.me);
-router.post(
-  '/',
-  auth,
-  body('number').isString().notEmpty(),
-  innController.create
-);
+router.post('/', auth, innRules, innController.create);
 
 export default router;

--- a/src/routes/snils.js
+++ b/src/routes/snils.js
@@ -1,5 +1,6 @@
 import express from 'express';
-import { body } from 'express-validator';
+
+import { snilsRules } from '../validators/personalValidators.js';
 
 import auth from '../middlewares/auth.js';
 import snilsController from '../controllers/snilsController.js';
@@ -7,11 +8,6 @@ import snilsController from '../controllers/snilsController.js';
 const router = express.Router();
 
 router.get('/me', auth, snilsController.me);
-router.post(
-  '/',
-  auth,
-  body('number').isString().notEmpty(),
-  snilsController.create
-);
+router.post('/', auth, snilsRules, snilsController.create);
 
 export default router;


### PR DESCRIPTION
## Summary
- validate user-provided INN and SNILS during profile completion
- use same validation rules as admin panel
- return validation errors from personal controllers
- collect personal details in wizard step 1 with UserForm
- add UI to input SNILS and INN on step 2

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b0a379c44832da6d35cf54314bbd9