### PR TITLE
Enhance profile wizard validation

### DIFF
--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -3,7 +3,8 @@ import { reactive, watch, ref } from 'vue'
 import { suggestFmsUnit, cleanPassport } from '../dadata.js'
 
 const props = defineProps({
-  modelValue: Object
+  modelValue: Object,
+  locked: Boolean
 })
 const emit = defineEmits(['update:modelValue'])
 
@@ -36,6 +37,7 @@ watch(form, (val) => {
 })
 
 function updateSuggestions() {
+  if (props.locked) return
   clearTimeout(timeout.value)
   const q = form.issuing_authority_code || form.issuing_authority
   if (!q || q.length < 3) {
@@ -53,6 +55,7 @@ watch(
 )
 
 async function onPassportBlur() {
+  if (props.locked) return
   const query = `${form.series} ${form.number}`.trim()
   if (!query) return
   const cleaned = await cleanPassport(query)
@@ -88,6 +91,7 @@ defineExpose({ validate })
   <div class="card">
     <div class="card-body">
       <h5 class="card-title mb-3">Паспорт</h5>
+      <fieldset :disabled="props.locked">
       <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
         <div class="col">
           <label class="form-label">Тип документа</label>
@@ -158,6 +162,7 @@ defineExpose({ validate })
           <input v-model="form.place_of_birth" class="form-control" />
         </div>
       </div>
+      </fieldset>
     </div>
   </div>
 </template>

--- a/client/src/components/UserForm.vue
+++ b/client/src/components/UserForm.vue
@@ -46,6 +46,7 @@ watch(form, (val) => {
 
 
 function updateSuggestions(field, part) {
+  if (!editing.value) return
   clearTimeout(timeouts[field])
   const value = form[field]
   if (!value || value.length < 2) {
@@ -132,7 +133,7 @@ const editing = ref(!props.locked)
 watch(editing, (val) => emit('editing-changed', val))
 
 function unlock() {
-  editing.value = true
+  if (!props.locked) editing.value = true
 }
 
 function lock() {
@@ -149,7 +150,7 @@ defineExpose({ validate, unlock, lock, editing })
         <div class="d-flex justify-content-between mb-3">
           <h5 class="card-title mb-0">Основные данные и контакты</h5>
           <button
-            v-if="!editing"
+            v-if="!editing && !props.locked"
             type="button"
             class="btn btn-link p-0"
             @click="unlock"


### PR DESCRIPTION
## Summary
- hide DaData hints for initial personal data check and disable edits
- sanitize INN and SNILS values loaded from the legacy database
- lock passport fields unless DaData marks them invalid
- require valid passport information when editing

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb05026e0832d9d13da3e3b940ab5