### PR TITLE
Add server-side passport validity calc

### DIFF
--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -122,17 +122,15 @@ defineExpose({ validate })
       <div class="row row-cols-1 row-cols-sm-2 row-cols-lg-4 g-3">
         <div class="col">
           <label class="form-label">Тип документа</label>
-          <select v-model="form.document_type" class="form-select">
-            <option value="CIVIL">Паспорт гражданина</option>
-            <option value="FOREIGN">Заграничный паспорт</option>
-            <option value="RESIDENCE_PERMIT">Вид на жительство</option>
-          </select>
+          <input
+            class="form-control"
+            value="Паспорт гражданина"
+            readonly
+          />
         </div>
         <div class="col">
           <label class="form-label">Страна</label>
-          <select v-model="form.country" class="form-select">
-            <option value="RU">Российская Федерация</option>
-          </select>
+          <input class="form-control" value="Российская Федерация" readonly />
         </div>
         <div class="col">
           <label class="form-label">Серия</label>

--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -85,7 +85,6 @@ function applySuggestion(s) {
 }
 
 function calcValid() {
-  if (isLocked('issue_date')) return
   if (form.country !== 'RU' || form.document_type !== 'CIVIL') return
   if (!props.birthDate || !form.issue_date) return
   const birth = new Date(props.birthDate)

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -53,9 +53,9 @@ onMounted(async () => {
       passportLocked.value = cleaned && cleaned.qc === 0 && !isExpired(passport.value)
       if (passportLocked.value) {
         passportLockFields.value = {
-          series: true,
-          number: true,
-          issue_date: true,
+          series: !!passport.value.series,
+          number: !!passport.value.number,
+          issue_date: !!passport.value.issue_date,
           issuing_authority_code: !!passport.value.issuing_authority_code,
         }
       }
@@ -177,9 +177,9 @@ async function saveStep() {
       passportLocked.value = !isExpired(passport.value)
       if (passportLocked.value) {
         passportLockFields.value = {
-          series: true,
-          number: true,
-          issue_date: true,
+          series: !!passport.value.series,
+          number: !!passport.value.number,
+          issue_date: !!passport.value.issue_date,
           issuing_authority_code: !!passport.value.issuing_authority_code,
         }
       }

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -37,16 +37,16 @@ onMounted(async () => {
     user.value = data.user
   } catch (_) {}
   try {
-    const data = await apiFetch('/inns/me?prefill=1')
+    const data = await apiFetch('/inns/me')
     inn.value = data.inn.number.replace(/\D/g, '')
   } catch (_) {}
   try {
-    const data = await apiFetch('/snils/me?prefill=1')
+    const data = await apiFetch('/snils/me')
     snilsInput.value = formatSnils(data.snils.number.replace(/\D/g, ''))
     snilsDigits.value = data.snils.number.replace(/\D/g, '')
   } catch (_) {}
   try {
-    const data = await apiFetch('/passports/me?prefill=1')
+    const data = await apiFetch('/passports/me')
     passport.value = data.passport
     if (passport.value.series && passport.value.number) {
       const cleaned = await cleanPassport(`${passport.value.series} ${passport.value.number}`)
@@ -62,7 +62,7 @@ onMounted(async () => {
     }
   } catch (_) {}
   try {
-    const data = await apiFetch('/bank-accounts/me?prefill=1')
+    const data = await apiFetch('/bank-accounts/me')
     bank.value.number = data.account.number
     bank.value.bic = data.account.bic
     const info = await findBankByBic(bank.value.bic)

--- a/src/controllers/bankAccountController.js
+++ b/src/controllers/bankAccountController.js
@@ -1,12 +1,27 @@
 import bankAccountService from '../services/bankAccountService.js';
 import bankAccountMapper from '../mappers/bankAccountMapper.js';
+import legacyService from '../services/legacyUserService.js';
+import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
     const acc = await bankAccountService.getByUser(req.user.id);
-    if (!acc) {
+    if (acc) {
+      return res.json({ account: bankAccountMapper.toPublic(acc) });
+    }
+    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    if (!ext) {
       return res.status(404).json({ error: 'bank_account_not_found' });
     }
-    return res.json({ account: bankAccountMapper.toPublic(acc) });
+    const legacy = await legacyService.findById(ext.external_id);
+    if (legacy?.bank_rs && legacy?.bik_bank) {
+      return res.json({
+        account: {
+          number: String(legacy.bank_rs),
+          bic: String(legacy.bik_bank).padStart(9, '0'),
+        },
+      });
+    }
+    return res.status(404).json({ error: 'bank_account_not_found' });
   },
 };

--- a/src/controllers/bankAccountController.js
+++ b/src/controllers/bankAccountController.js
@@ -9,7 +9,9 @@ export default {
     if (acc) {
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     }
-    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    const ext = await UserExternalId.findOne({
+      where: { user_id: req.user.id },
+    });
     if (!ext) {
       return res.status(404).json({ error: 'bank_account_not_found' });
     }

--- a/src/controllers/bankAccountController.js
+++ b/src/controllers/bankAccountController.js
@@ -9,9 +9,6 @@ export default {
     if (acc) {
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     }
-    if (req.query.prefill !== '1') {
-      return res.status(404).json({ error: 'bank_account_not_found' });
-    }
     const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
     if (!ext) {
       return res.status(404).json({ error: 'bank_account_not_found' });

--- a/src/controllers/bankAccountController.js
+++ b/src/controllers/bankAccountController.js
@@ -9,6 +9,9 @@ export default {
     if (acc) {
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     }
+    if (req.query.prefill !== '1') {
+      return res.status(404).json({ error: 'bank_account_not_found' });
+    }
     const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
     if (!ext) {
       return res.status(404).json({ error: 'bank_account_not_found' });

--- a/src/controllers/innController.js
+++ b/src/controllers/innController.js
@@ -7,6 +7,9 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
+    if (req.query.prefill !== '1') {
+      return res.status(404).json({ error: 'inn_not_found' });
+    }
     const inn = await innService.getByUser(req.user.id);
     if (inn) {
       return res.json({ inn: innMapper.toPublic(inn) });

--- a/src/controllers/innController.js
+++ b/src/controllers/innController.js
@@ -7,11 +7,13 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
-    let inn = await innService.getByUser(req.user.id);
+    const inn = await innService.getByUser(req.user.id);
     if (inn) {
       return res.json({ inn: innMapper.toPublic(inn) });
     }
-    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    const ext = await UserExternalId.findOne({
+      where: { user_id: req.user.id },
+    });
     if (!ext) {
       return res.status(404).json({ error: 'inn_not_found' });
     }

--- a/src/controllers/innController.js
+++ b/src/controllers/innController.js
@@ -7,9 +7,6 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
-    if (req.query.prefill !== '1') {
-      return res.status(404).json({ error: 'inn_not_found' });
-    }
     const inn = await innService.getByUser(req.user.id);
     if (inn) {
       return res.json({ inn: innMapper.toPublic(inn) });

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -9,7 +9,9 @@ export default {
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
-    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    const ext = await UserExternalId.findOne({
+      where: { user_id: req.user.id },
+    });
     if (!ext) {
       return res.status(404).json({ error: 'passport_not_found' });
     }

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -9,6 +9,9 @@ export default {
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
+    if (req.query.prefill !== '1') {
+      return res.status(404).json({ error: 'passport_not_found' });
+    }
     const ext = await UserExternalId.findOne({
       where: { user_id: req.user.id },
     });

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -1,12 +1,32 @@
 import passportService from '../services/passportService.js';
 import passportMapper from '../mappers/passportMapper.js';
+import legacyService from '../services/legacyUserService.js';
+import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
     const passport = await passportService.getByUser(req.user.id);
-    if (!passport) {
+    if (passport) {
+      return res.json({ passport: passportMapper.toPublic(passport) });
+    }
+    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    if (!ext) {
       return res.status(404).json({ error: 'passport_not_found' });
     }
-    return res.json({ passport: passportMapper.toPublic(passport) });
+    const legacy = await legacyService.findById(ext.external_id);
+    if (legacy?.ps_ser && legacy?.ps_num) {
+      return res.json({
+        passport: {
+          series: String(legacy.ps_ser),
+          number: String(legacy.ps_num).padStart(6, '0'),
+          issue_date: legacy.ps_date,
+          issuing_authority: legacy.ps_org,
+          issuing_authority_code: legacy.ps_pdrz,
+          document_type: 'CIVIL',
+          country: 'RU',
+        },
+      });
+    }
+    return res.status(404).json({ error: 'passport_not_found' });
   },
 };

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -9,9 +9,6 @@ export default {
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
-    if (req.query.prefill !== '1') {
-      return res.status(404).json({ error: 'passport_not_found' });
-    }
     const ext = await UserExternalId.findOne({
       where: { user_id: req.user.id },
     });

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -24,10 +24,7 @@ export default {
           series: String(legacy.ps_ser),
           number: String(legacy.ps_num).padStart(6, '0'),
           issue_date: legacy.ps_date,
-          valid_until: calculateValidUntil(
-            req.user.birth_date,
-            legacy.ps_date,
-          ),
+          valid_until: calculateValidUntil(req.user.birth_date, legacy.ps_date),
           issuing_authority: legacy.ps_org,
           issuing_authority_code: legacy.ps_pdrz,
           document_type: 'CIVIL',

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -2,6 +2,7 @@ import passportService from '../services/passportService.js';
 import passportMapper from '../mappers/passportMapper.js';
 import legacyService from '../services/legacyUserService.js';
 import { UserExternalId } from '../models/index.js';
+import { calculateValidUntil } from '../utils/passportUtils.js';
 
 export default {
   async me(req, res) {
@@ -9,6 +10,7 @@ export default {
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
+          valid_until: calculateValidUntil(req.user.birth_date, legacy.ps_date),
     const ext = await UserExternalId.findOne({
       where: { user_id: req.user.id },
     });

--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -10,7 +10,7 @@ export default {
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
-          valid_until: calculateValidUntil(req.user.birth_date, legacy.ps_date),
+
     const ext = await UserExternalId.findOne({
       where: { user_id: req.user.id },
     });
@@ -24,6 +24,10 @@ export default {
           series: String(legacy.ps_ser),
           number: String(legacy.ps_num).padStart(6, '0'),
           issue_date: legacy.ps_date,
+          valid_until: calculateValidUntil(
+            req.user.birth_date,
+            legacy.ps_date,
+          ),
           issuing_authority: legacy.ps_org,
           issuing_authority_code: legacy.ps_pdrz,
           document_type: 'CIVIL',

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -40,8 +40,6 @@ export default {
       return res.status(400).json({ error: err.message });
     }
 
-
-
     const system = await ExternalSystem.findOne({
       where: { alias: 'HOCKEYMOS' },
     });

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -5,11 +5,6 @@ import { User } from '../models/index.js';
 import emailVerificationService from '../services/emailVerificationService.js';
 import legacyService from '../services/legacyUserService.js';
 import userService from '../services/userService.js';
-import innService from '../services/innService.js';
-import snilsService from '../services/snilsService.js';
-import passportService from '../services/passportService.js';
-import bankAccountService from '../services/bankAccountService.js';
-import dadataService from '../services/dadataService.js';
 import authService from '../services/authService.js';
 import { ExternalSystem, UserExternalId } from '../models/index.js';
 import userMapper from '../mappers/userMapper.js';
@@ -45,45 +40,7 @@ export default {
       return res.status(400).json({ error: err.message });
     }
 
-    try {
-      if (legacy.sv_ops) {
-        await snilsService.create(user.id, legacy.sv_ops, user.id);
-      }
-      if (legacy.sv_inn) {
-        await innService.create(user.id, legacy.sv_inn, user.id);
-      }
-      if (legacy.ps_ser && legacy.ps_num) {
-        await passportService.createForUser(
-          user.id,
-          {
-            document_type: 'CIVIL',
-            country: 'RU',
-            series: String(legacy.ps_ser),
-            number: String(legacy.ps_num).padStart(6, '0'),
-            issue_date: legacy.ps_date,
-            issuing_authority: legacy.ps_org,
-            issuing_authority_code: legacy.ps_pdrz,
-          },
-          user.id
-        );
-      }
-      if (legacy.bank_rs && legacy.bik_bank) {
-        const bank = await dadataService.findBankByBic(String(legacy.bik_bank));
-        const accData = {
-          number: String(legacy.bank_rs),
-          bic: String(legacy.bik_bank).padStart(9, '0'),
-          bank_name: bank?.value,
-          correspondent_account: bank?.data.correspondent_account,
-          swift: bank?.data.swift,
-          inn: bank?.data.inn,
-          kpp: bank?.data.kpp,
-          address: bank?.data.address?.unrestricted_value,
-        };
-        await bankAccountService.createForUser(user.id, accData, user.id);
-      }
-    } catch {
-      // ignore import errors
-    }
+
 
     const system = await ExternalSystem.findOne({
       where: { alias: 'HOCKEYMOS' },

--- a/src/controllers/snilsController.js
+++ b/src/controllers/snilsController.js
@@ -7,9 +7,6 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
-    if (req.query.prefill !== '1') {
-      return res.status(404).json({ error: 'snils_not_found' });
-    }
     const snils = await snilsService.getByUser(req.user.id);
     if (snils) {
       return res.json({ snils: snilsMapper.toPublic(snils) });

--- a/src/controllers/snilsController.js
+++ b/src/controllers/snilsController.js
@@ -7,11 +7,13 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
-    let snils = await snilsService.getByUser(req.user.id);
+    const snils = await snilsService.getByUser(req.user.id);
     if (snils) {
       return res.json({ snils: snilsMapper.toPublic(snils) });
     }
-    const ext = await UserExternalId.findOne({ where: { user_id: req.user.id } });
+    const ext = await UserExternalId.findOne({
+      where: { user_id: req.user.id },
+    });
     if (!ext) {
       return res.status(404).json({ error: 'snils_not_found' });
     }

--- a/src/controllers/snilsController.js
+++ b/src/controllers/snilsController.js
@@ -7,6 +7,9 @@ import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
+    if (req.query.prefill !== '1') {
+      return res.status(404).json({ error: 'snils_not_found' });
+    }
     const snils = await snilsService.getByUser(req.user.id);
     if (snils) {
       return res.json({ snils: snilsMapper.toPublic(snils) });

--- a/src/services/legacyUserService.js
+++ b/src/services/legacyUserService.js
@@ -8,4 +8,12 @@ export async function findByEmail(email) {
   return rows[0] || null;
 }
 
-export default { findByEmail };
+export async function findById(id) {
+  const [rows] = await legacyDb.query(
+    'SELECT * FROM a_player WHERE id = ? LIMIT 1',
+    [id]
+  );
+  return rows[0] || null;
+}
+
+export default { findByEmail, findById };

--- a/src/services/passportService.js
+++ b/src/services/passportService.js
@@ -1,4 +1,5 @@
 import { Passport, DocumentType, Country, User } from '../models/index.js';
+import { calculateValidUntil } from '../utils/passportUtils.js';
 
 async function getByUser(userId) {
   return Passport.findOne({
@@ -22,6 +23,11 @@ async function createForUser(userId, data, adminId) {
   if (!type) throw new Error('document_type_not_found');
   if (!country) throw new Error('country_not_found');
 
+  let validUntil = data.valid_until;
+  if (data.document_type === 'CIVIL' && data.country === 'RU') {
+    validUntil = calculateValidUntil(user.birth_date, data.issue_date);
+  }
+
   await Passport.create({
     user_id: userId,
     document_type_id: type.id,
@@ -29,7 +35,7 @@ async function createForUser(userId, data, adminId) {
     series: data.series,
     number: data.number,
     issue_date: data.issue_date,
-    valid_until: data.valid_until,
+    valid_until: validUntil,
     issuing_authority: data.issuing_authority,
     issuing_authority_code: data.issuing_authority_code,
     place_of_birth: data.place_of_birth,

--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -2,7 +2,8 @@ export function calculateValidUntil(birthDate, issueDate) {
   if (!birthDate || !issueDate) return null;
   const birth = new Date(birthDate);
   const issue = new Date(issueDate);
-  if (Number.isNaN(birth.getTime()) || Number.isNaN(issue.getTime())) return null;
+  if (Number.isNaN(birth.getTime()) || Number.isNaN(issue.getTime()))
+    return null;
   const age = (issue - birth) / (365.25 * 24 * 3600 * 1000);
   let until;
   if (age < 20) {

--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -1,0 +1,18 @@
+export function calculateValidUntil(birthDate, issueDate) {
+  if (!birthDate || !issueDate) return null;
+  const birth = new Date(birthDate);
+  const issue = new Date(issueDate);
+  if (Number.isNaN(birth.getTime()) || Number.isNaN(issue.getTime())) return null;
+  const age = (issue - birth) / (365.25 * 24 * 3600 * 1000);
+  let until;
+  if (age < 20) {
+    until = new Date(birth);
+    until.setFullYear(until.getFullYear() + 20);
+  } else if (age < 45) {
+    until = new Date(birth);
+    until.setFullYear(until.getFullYear() + 45);
+  } else {
+    return null;
+  }
+  return until.toISOString().slice(0, 10);
+}

--- a/tests/bankAccountController.test.js
+++ b/tests/bankAccountController.test.js
@@ -34,11 +34,11 @@ test('me returns stored account', async () => {
   expect(res.json).toHaveBeenCalled();
 });
 
-test('me returns legacy account when not stored', async () => {
+test('me returns legacy account when prefill requested', async () => {
   service.default.getByUser.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '8' });
   legacyFindMock.mockResolvedValue({ bank_rs: '40702810', bik_bank: '044525225' });
-  const req = { user: { id: 'u1' } };
+  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalledWith({

--- a/tests/bankAccountController.test.js
+++ b/tests/bankAccountController.test.js
@@ -34,11 +34,11 @@ test('me returns stored account', async () => {
   expect(res.json).toHaveBeenCalled();
 });
 
-test('me returns legacy account when prefill requested', async () => {
+test('me returns legacy account when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '8' });
   legacyFindMock.mockResolvedValue({ bank_rs: '40702810', bik_bank: '044525225' });
-  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
+  const req = { user: { id: 'u1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalledWith({

--- a/tests/bankAccountController.test.js
+++ b/tests/bankAccountController.test.js
@@ -1,0 +1,48 @@
+import { expect, jest, test } from '@jest/globals';
+
+jest.unstable_mockModule('../src/services/bankAccountService.js', () => ({
+  __esModule: true,
+  default: { getByUser: jest.fn() },
+}));
+
+jest.unstable_mockModule('../src/mappers/bankAccountMapper.js', () => ({
+  __esModule: true,
+  default: { toPublic: jest.fn((a) => a) },
+}));
+
+const findOneExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  UserExternalId: { findOne: findOneExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
+}));
+
+const { default: controller } = await import('../src/controllers/bankAccountController.js');
+const service = await import('../src/services/bankAccountService.js');
+
+test('me returns stored account', async () => {
+  service.default.getByUser.mockResolvedValue({ id: 'b1' });
+  const req = { user: { id: 'u1' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalled();
+});
+
+test('me returns legacy account when not stored', async () => {
+  service.default.getByUser.mockResolvedValue(null);
+  findOneExtMock.mockResolvedValue({ external_id: '8' });
+  legacyFindMock.mockResolvedValue({ bank_rs: '40702810', bik_bank: '044525225' });
+  const req = { user: { id: 'u1' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalledWith({
+    account: { number: '40702810', bic: '044525225' },
+  });
+});
+

--- a/tests/innController.test.js
+++ b/tests/innController.test.js
@@ -58,8 +58,8 @@ test('create stores new inn', async () => {
   expect(res.json).toHaveBeenCalledWith({ inn: { id: 'n1' } });
 });
 
-test('me returns legacy inn when not stored', async () => {
-  const req = { user: { id: 'u1' } };
+test('me returns legacy inn when prefill requested', async () => {
+  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const service = await import('../src/services/innService.js');
   service.default.getByUser.mockResolvedValue(null);

--- a/tests/innController.test.js
+++ b/tests/innController.test.js
@@ -58,8 +58,8 @@ test('create stores new inn', async () => {
   expect(res.json).toHaveBeenCalledWith({ inn: { id: 'n1' } });
 });
 
-test('me returns legacy inn when prefill requested', async () => {
-  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
+test('me returns legacy inn when none stored', async () => {
+  const req = { user: { id: 'u1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const service = await import('../src/services/innService.js');
   service.default.getByUser.mockResolvedValue(null);

--- a/tests/innController.test.js
+++ b/tests/innController.test.js
@@ -17,6 +17,19 @@ jest.unstable_mockModule('../src/services/innService.js', () => ({
   default: { create: createMock, getByUser: jest.fn() },
 }));
 
+const findOneExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  UserExternalId: { findOne: findOneExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
+}));
+
 jest.unstable_mockModule('../src/mappers/innMapper.js', () => ({
   __esModule: true,
   default: { toPublic: toPublicMock },
@@ -43,4 +56,15 @@ test('create stores new inn', async () => {
   expect(toPublicMock).toHaveBeenCalled();
   expect(res.status).toHaveBeenCalledWith(201);
   expect(res.json).toHaveBeenCalledWith({ inn: { id: 'n1' } });
+});
+
+test('me returns legacy inn when not stored', async () => {
+  const req = { user: { id: 'u1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const service = await import('../src/services/innService.js');
+  service.default.getByUser.mockResolvedValue(null);
+  findOneExtMock.mockResolvedValue({ external_id: '20' });
+  legacyFindMock.mockResolvedValue({ sv_inn: '123456789012' });
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalledWith({ inn: { number: '123456789012' } });
 });

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -34,11 +34,11 @@ test('me returns stored passport', async () => {
   expect(res.json).toHaveBeenCalled();
 });
 
-test('me returns legacy passport when prefill requested', async () => {
+test('me returns legacy passport when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '5' });
   legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
-  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
+  const req = { user: { id: 'u1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalledWith({

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -34,11 +34,11 @@ test('me returns stored passport', async () => {
   expect(res.json).toHaveBeenCalled();
 });
 
-test('me returns legacy passport when not stored', async () => {
+test('me returns legacy passport when prefill requested', async () => {
   service.default.getByUser.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '5' });
   legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
-  const req = { user: { id: 'u1' } };
+  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalledWith({

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -38,7 +38,7 @@ test('me returns legacy passport when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '5' });
   legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
-  const req = { user: { id: 'u1' } };
+  const req = { user: { id: 'u1', birth_date: '1990-01-01' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalledWith({
@@ -46,6 +46,7 @@ test('me returns legacy passport when none stored', async () => {
       series: '11',
       number: '000022',
       issue_date: '2000-01-01',
+      valid_until: '2010-01-01',
       issuing_authority: 'OVD',
       issuing_authority_code: '770-000',
       document_type: 'CIVIL',

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -1,0 +1,55 @@
+import { expect, jest, test } from '@jest/globals';
+
+jest.unstable_mockModule('../src/services/passportService.js', () => ({
+  __esModule: true,
+  default: { getByUser: jest.fn() },
+}));
+
+jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
+  __esModule: true,
+  default: { toPublic: jest.fn((p) => p) },
+}));
+
+const findOneExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  UserExternalId: { findOne: findOneExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
+}));
+
+const { default: controller } = await import('../src/controllers/passportController.js');
+const service = await import('../src/services/passportService.js');
+
+test('me returns stored passport', async () => {
+  service.default.getByUser.mockResolvedValue({ id: 'p1' });
+  const req = { user: { id: 'u1' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalled();
+});
+
+test('me returns legacy passport when not stored', async () => {
+  service.default.getByUser.mockResolvedValue(null);
+  findOneExtMock.mockResolvedValue({ external_id: '5' });
+  legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
+  const req = { user: { id: 'u1' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalledWith({
+    passport: {
+      series: '11',
+      number: '000022',
+      issue_date: '2000-01-01',
+      issuing_authority: 'OVD',
+      issuing_authority_code: '770-000',
+      document_type: 'CIVIL',
+      country: 'RU',
+    },
+  });
+});

--- a/tests/passportService.test.js
+++ b/tests/passportService.test.js
@@ -49,6 +49,21 @@ test('createForUser validates and creates passport', async () => {
   expect(res).toBe(passportInstance);
 });
 
+test('createForUser calculates valid_until for RU CIVIL passport', async () => {
+  findByPkMock.mockResolvedValue({ id: 'u1', birth_date: '1990-01-01' });
+  findOneMock.mockResolvedValueOnce(null);
+  findTypeMock.mockResolvedValue({ id: 't1' });
+  findCountryMock.mockResolvedValue({ id: 'c1' });
+  createMock.mockResolvedValue(passportInstance);
+  findOneMock.mockResolvedValueOnce(passportInstance);
+
+  const data = { document_type: 'CIVIL', country: 'RU', issue_date: '2010-02-03' };
+  await service.createForUser('u1', data, 'admin');
+  expect(createMock).toHaveBeenCalledWith(
+    expect.objectContaining({ valid_until: '2035-01-01' })
+  );
+});
+
 test('removeByUser destroys passport', async () => {
   findOneMock.mockResolvedValue(passportInstance);
   await service.removeByUser('u1');

--- a/tests/passportUtils.test.js
+++ b/tests/passportUtils.test.js
@@ -1,0 +1,16 @@
+import { describe, test, expect } from '@jest/globals';
+import { calculateValidUntil } from '../src/utils/passportUtils.js';
+
+describe('passport utils', () => {
+  test('calculateValidUntil for age below 20', () => {
+    expect(calculateValidUntil('1990-01-01', '2005-02-03')).toBe('2010-01-01');
+  });
+
+  test('calculateValidUntil for age below 45', () => {
+    expect(calculateValidUntil('1990-01-01', '2010-02-03')).toBe('2035-01-01');
+  });
+
+  test('calculateValidUntil returns null for age 45+', () => {
+    expect(calculateValidUntil('1950-01-01', '2020-01-01')).toBe(null);
+  });
+});

--- a/tests/snilsController.test.js
+++ b/tests/snilsController.test.js
@@ -58,8 +58,8 @@ test('create stores new snils', async () => {
   expect(res.json).toHaveBeenCalledWith({ snils: { id: 's1' } });
 });
 
-test('me returns legacy snils when prefill requested', async () => {
-  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
+test('me returns legacy snils when none stored', async () => {
+  const req = { user: { id: 'u1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const service = await import('../src/services/snilsService.js');
   service.default.getByUser.mockResolvedValue(null);

--- a/tests/snilsController.test.js
+++ b/tests/snilsController.test.js
@@ -17,6 +17,19 @@ jest.unstable_mockModule('../src/services/snilsService.js', () => ({
   default: { create: createMock, getByUser: jest.fn() },
 }));
 
+const findOneExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  UserExternalId: { findOne: findOneExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
+}));
+
 jest.unstable_mockModule('../src/mappers/snilsMapper.js', () => ({
   __esModule: true,
   default: { toPublic: toPublicMock },
@@ -43,4 +56,15 @@ test('create stores new snils', async () => {
   expect(toPublicMock).toHaveBeenCalled();
   expect(res.status).toHaveBeenCalledWith(201);
   expect(res.json).toHaveBeenCalledWith({ snils: { id: 's1' } });
+});
+
+test('me returns legacy snils when not stored', async () => {
+  const req = { user: { id: 'u1' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const service = await import('../src/services/snilsService.js');
+  service.default.getByUser.mockResolvedValue(null);
+  findOneExtMock.mockResolvedValue({ external_id: '10' });
+  legacyFindMock.mockResolvedValue({ sv_ops: '111-222-333 44' });
+  await controller.me(req, res);
+  expect(res.json).toHaveBeenCalledWith({ snils: { number: '111-222-333 44' } });
 });

--- a/tests/snilsController.test.js
+++ b/tests/snilsController.test.js
@@ -58,8 +58,8 @@ test('create stores new snils', async () => {
   expect(res.json).toHaveBeenCalledWith({ snils: { id: 's1' } });
 });
 
-test('me returns legacy snils when not stored', async () => {
-  const req = { user: { id: 'u1' } };
+test('me returns legacy snils when prefill requested', async () => {
+  const req = { user: { id: 'u1' }, query: { prefill: '1' } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
   const service = await import('../src/services/snilsService.js');
   service.default.getByUser.mockResolvedValue(null);


### PR DESCRIPTION
## Summary
- compute validity date for Russian CIVIL passports on the server
- expose helper `calculateValidUntil`
- cover new logic with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bb89479f4832dbf2d5281bf2abe83