### PR TITLE
Import passport from legacy

### DIFF
--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -6,7 +6,12 @@ import { calculateValidUntil } from '../utils/passportUtils.js';
 
 export default {
   async me(req, res) {
-    const passport = await passportService.getByUser(req.user.id);
+    let passport = await passportService.getByUser(req.user.id);
+    if (passport) {
+      return res.json({ passport: passportMapper.toPublic(passport) });
+    }
+
+    passport = await passportService.importFromLegacy(req.user.id);
     if (passport) {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -6,6 +6,7 @@ import emailVerificationService from '../services/emailVerificationService.js';
 import legacyService from '../services/legacyUserService.js';
 import userService from '../services/userService.js';
 import authService from '../services/authService.js';
+import passportService from '../services/passportService.js';
 import { ExternalSystem, UserExternalId } from '../models/index.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie } from '../utils/cookie.js';
@@ -73,6 +74,7 @@ export default {
         'REGISTRATION_STEP_1'
       );
       await userService.resetPassword(user.id, password);
+      await passportService.importFromLegacy(user.id);
       const updated = await user.reload();
       const roles = (await updated.getRoles({ attributes: ['alias'] })).map(
         (r) => r.alias

--- a/src/services/passportService.js
+++ b/src/services/passportService.js
@@ -6,6 +6,7 @@ import {
   UserExternalId,
 } from '../models/index.js';
 import { calculateValidUntil } from '../utils/passportUtils.js';
+
 import legacyUserService from './legacyUserService.js';
 
 async function getByUser(userId) {
@@ -68,15 +69,20 @@ async function importFromLegacy(userId) {
   if (!legacy?.ps_ser || !legacy?.ps_num) return null;
 
   try {
-    return await createForUser(userId, {
-      document_type: 'CIVIL',
-      country: 'RU',
-      series: String(legacy.ps_ser),
-      number: String(legacy.ps_num).padStart(6, '0'),
-      issue_date: legacy.ps_date,
-      issuing_authority: legacy.ps_org,
-      issuing_authority_code: legacy.ps_pdrz,
-    }, userId);
+    return await createForUser(
+      userId,
+      {
+        document_type: 'CIVIL',
+        country: 'RU',
+        series: String(legacy.ps_ser),
+        number: String(legacy.ps_num).padStart(6, '0'),
+        issue_date: legacy.ps_date,
+        issuing_authority: legacy.ps_org,
+        issuing_authority_code: legacy.ps_pdrz,
+      },
+      userId
+    );
+    // eslint-disable-next-line no-unused-vars
   } catch (err) {
     return null;
   }

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -2,7 +2,7 @@ import { expect, jest, test } from '@jest/globals';
 
 jest.unstable_mockModule('../src/services/passportService.js', () => ({
   __esModule: true,
-  default: { getByUser: jest.fn() },
+  default: { getByUser: jest.fn(), importFromLegacy: jest.fn() },
 }));
 
 jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
@@ -28,19 +28,23 @@ const service = await import('../src/services/passportService.js');
 
 test('me returns stored passport', async () => {
   service.default.getByUser.mockResolvedValue({ id: 'p1' });
+  service.default.importFromLegacy.mockResolvedValue(null);
   const req = { user: { id: 'u1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalled();
+  expect(service.default.importFromLegacy).not.toHaveBeenCalled();
 });
 
 test('me returns legacy passport when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
+  service.default.importFromLegacy.mockResolvedValue(null);
   findOneExtMock.mockResolvedValue({ external_id: '5' });
   legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
   const req = { user: { id: 'u1', birth_date: '1990-01-01' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
+  expect(service.default.importFromLegacy).toHaveBeenCalledWith('u1');
   expect(res.json).toHaveBeenCalledWith({
     passport: {
       series: '11',
@@ -53,4 +57,16 @@ test('me returns legacy passport when none stored', async () => {
       country: 'RU',
     },
   });
+});
+
+test('me returns persisted passport from legacy', async () => {
+  service.default.getByUser.mockResolvedValue(null);
+  service.default.importFromLegacy.mockResolvedValue({ id: 'p2' });
+  findOneExtMock.mockClear();
+  const req = { user: { id: 'u2' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.me(req, res);
+  expect(service.default.importFromLegacy).toHaveBeenCalledWith('u2');
+  expect(res.json).toHaveBeenCalledWith({ passport: { id: 'p2' } });
+  expect(findOneExtMock).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- add `importFromLegacy` in passportService to create passport if legacy data is available
- store legacy passport after registration
- persist passport automatically in passport controller when available
- update tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bd02b3acc832d8640875f3dfde204