### PR TITLE
Validate passport using DaData

### DIFF
--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -14,8 +14,10 @@ const step = ref(auth.user?.status === 'REGISTRATION_STEP_2' ? 2 : 1)
 const total = 4
 const user = ref({})
 const inn = ref('')
+const innLocked = ref(false)
 const snilsDigits = ref('')
 const snilsInput = ref('')
+const snilsLocked = ref(false)
 const passport = ref({})
 const passportLocked = ref(false)
 const passportLockFields = ref({})
@@ -40,11 +42,13 @@ onMounted(async () => {
   try {
     const data = await apiFetch('/inns/me')
     inn.value = data.inn.number.replace(/\D/g, '')
+    innLocked.value = isValidInn(inn.value)
   } catch (_) {}
   try {
     const data = await apiFetch('/snils/me')
     snilsInput.value = formatSnils(data.snils.number.replace(/\D/g, ''))
     snilsDigits.value = data.snils.number.replace(/\D/g, '')
+    snilsLocked.value = isValidSnils(snilsInput.value)
   } catch (_) {}
   try {
     const data = await apiFetch('/passports/me')
@@ -177,6 +181,8 @@ async function saveStep() {
         method: 'POST',
         body: JSON.stringify({ number: inn.value })
       })
+      snilsLocked.value = true
+      innLocked.value = true
       step.value = 3
       loading.value = false
       return
@@ -265,6 +271,7 @@ async function saveStep() {
             @input="onSnilsInput"
             class="form-control"
             placeholder="СНИЛС"
+            :disabled="snilsLocked"
           />
           <label for="snils">СНИЛС</label>
         </div>
@@ -275,6 +282,7 @@ async function saveStep() {
             @input="onInnInput"
             class="form-control"
             placeholder="ИНН"
+            :disabled="innLocked"
           />
           <label for="inn">ИНН</label>
         </div>

--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -17,3 +17,31 @@ export function calculateValidUntil(birthDate, issueDate) {
   }
   return until.toISOString().slice(0, 10);
 }
+
+export function sanitizePassportData(data = {}) {
+  const out = { ...data };
+  if (out.series !== undefined) {
+    out.series = String(out.series).replace(/\s+/g, '').trim();
+  }
+  if (out.number !== undefined) {
+    out.number = String(out.number).replace(/\s+/g, '').trim();
+  }
+  if (out.issue_date !== undefined && out.issue_date !== null) {
+    out.issue_date = String(out.issue_date).trim();
+  }
+  if (out.valid_until !== undefined && out.valid_until !== null) {
+    out.valid_until = String(out.valid_until).trim();
+  }
+  if (out.issuing_authority !== undefined) {
+    out.issuing_authority = String(out.issuing_authority).trim();
+  }
+  if (out.issuing_authority_code !== undefined) {
+    out.issuing_authority_code = String(out.issuing_authority_code)
+      .replace(/\s+/g, '')
+      .trim();
+  }
+  if (out.place_of_birth !== undefined) {
+    out.place_of_birth = String(out.place_of_birth).trim();
+  }
+  return out;
+}

--- a/src/validators/passportValidators.js
+++ b/src/validators/passportValidators.js
@@ -9,14 +9,16 @@ export const createPassportRules = [
         req.body.document_type === 'CIVIL' && req.body.country === 'RU'
     )
     .notEmpty()
-    .isString(),
+    .matches(/^\d{4}$/)
+    .withMessage('invalid_format'),
   body('number')
     .if(
       (value, { req }) =>
         req.body.document_type === 'CIVIL' && req.body.country === 'RU'
     )
     .notEmpty()
-    .isString(),
+    .matches(/^\d{6}$/)
+    .withMessage('invalid_format'),
   body('issue_date')
     .if(
       (value, { req }) =>
@@ -38,7 +40,8 @@ export const createPassportRules = [
         req.body.document_type === 'CIVIL' && req.body.country === 'RU'
     )
     .notEmpty()
-    .isString(),
+    .matches(/^\d{3}-\d{3}$/)
+    .withMessage('invalid_format'),
   body('place_of_birth')
     .if(
       (value, { req }) =>


### PR DESCRIPTION
## Summary
- enforce stricter rules in `createPassportRules`
- validate passport with DaData before saving
- update passport service tests
- trim passport fields before persistence

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4dbadabc832d820f2ebc0f17afa8