### PR TITLE
Lock imported passport fields in profile wizard

### DIFF
--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -49,19 +49,21 @@ onMounted(async () => {
   try {
     const data = await apiFetch('/passports/me')
     passport.value = data.passport
+    passportLockFields.value = {
+      series: !!passport.value.series,
+      number: !!passport.value.number,
+      issue_date: !!passport.value.issue_date,
+      issuing_authority: !!passport.value.issuing_authority,
+      issuing_authority_code: !!passport.value.issuing_authority_code,
+      place_of_birth: !!passport.value.place_of_birth,
+    }
     if (passport.value.series && passport.value.number) {
       const cleaned = await cleanPassport(`${passport.value.series} ${passport.value.number}`)
-      passportLocked.value = cleaned && cleaned.qc === 0 && !isExpired(passport.value)
-      if (passportLocked.value) {
-        passportLockFields.value = {
-          series: !!passport.value.series,
-          number: !!passport.value.number,
-          issue_date: !!passport.value.issue_date,
-          issuing_authority: !!passport.value.issuing_authority,
-          issuing_authority_code: !!passport.value.issuing_authority_code,
-          place_of_birth: !!passport.value.place_of_birth,
-        }
-      }
+      passportLocked.value =
+        cleaned &&
+        cleaned.qc === 0 &&
+        !isExpired(passport.value) &&
+        Object.values(passportLockFields.value).every(Boolean)
     }
   } catch (_) {}
   try {
@@ -182,7 +184,10 @@ async function saveStep() {
       return
     }
     if (step.value === 3) {
-      if (passportLocked.value) {
+      if (
+        passportLocked.value &&
+        Object.values(passportLockFields.value).every(Boolean)
+      ) {
         step.value = 4
         loading.value = false
         return
@@ -204,15 +209,13 @@ async function saveStep() {
         body: JSON.stringify(passport.value)
       })
       passportLocked.value = !isExpired(passport.value)
-      if (passportLocked.value) {
-        passportLockFields.value = {
-          series: !!passport.value.series,
-          number: !!passport.value.number,
-          issue_date: !!passport.value.issue_date,
-          issuing_authority: !!passport.value.issuing_authority,
-          issuing_authority_code: !!passport.value.issuing_authority_code,
-          place_of_birth: !!passport.value.place_of_birth,
-        }
+      passportLockFields.value = {
+        series: !!passport.value.series,
+        number: !!passport.value.number,
+        issue_date: !!passport.value.issue_date,
+        issuing_authority: !!passport.value.issuing_authority,
+        issuing_authority_code: !!passport.value.issuing_authority_code,
+        place_of_birth: !!passport.value.place_of_birth,
       }
       step.value = 4
       loading.value = false


### PR DESCRIPTION
## Summary
- disable imported passport fields after passport import
- require completion of remaining passport data before proceeding

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e597263dc832d8c75f398f095f6d5