### PR TITLE
Implement bank account validation on registration

### DIFF
--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -7,6 +7,7 @@ import legacyService from '../services/legacyUserService.js';
 import userService from '../services/userService.js';
 import authService from '../services/authService.js';
 import passportService from '../services/passportService.js';
+import bankAccountService from '../services/bankAccountService.js';
 import { ExternalSystem, UserExternalId } from '../models/index.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie } from '../utils/cookie.js';
@@ -74,6 +75,8 @@ export default {
         'REGISTRATION_STEP_1'
       );
       await userService.resetPassword(user.id, password);
+      const account = await bankAccountService.importFromLegacy(user.id);
+      if (!account) throw new Error('bank_account_invalid');
       await passportService.importFromLegacy(user.id);
       const updated = await user.reload();
       const roles = (await updated.getRoles({ attributes: ['alias'] })).map(

--- a/src/services/bankAccountService.js
+++ b/src/services/bankAccountService.js
@@ -1,4 +1,7 @@
-import { BankAccount, User } from '../models/index.js';
+import { BankAccount, User, UserExternalId } from '../models/index.js';
+import legacyUserService from './legacyUserService.js';
+import dadataService from './dadataService.js';
+import { isValidAccountNumber } from '../utils/bank.js';
 
 async function getByUser(userId) {
   return BankAccount.findOne({ where: { user_id: userId } });
@@ -38,4 +41,47 @@ async function removeForUser(userId) {
   await acc.destroy();
 }
 
-export default { getByUser, createForUser, updateForUser, removeForUser };
+async function importFromLegacy(userId) {
+  const existing = await BankAccount.findOne({ where: { user_id: userId } });
+  if (existing) return existing;
+
+  const ext = await UserExternalId.findOne({ where: { user_id: userId } });
+  if (!ext) return null;
+  const legacy = await legacyUserService.findById(ext.external_id);
+  if (!legacy?.bank_rs || !legacy?.bik_bank) return null;
+
+  const number = String(legacy.bank_rs);
+  const bic = String(legacy.bik_bank).padStart(9, '0');
+  if (!isValidAccountNumber(number, bic)) return null;
+
+  const bank = await dadataService.findBankByBic(bic);
+  if (!bank) return null;
+
+  try {
+    return await createForUser(
+      userId,
+      {
+        number,
+        bic,
+        bank_name: bank.value,
+        correspondent_account: bank.data.correspondent_account,
+        swift: bank.data.swift,
+        inn: bank.data.inn,
+        kpp: bank.data.kpp,
+        address: bank.data.address?.unrestricted_value,
+      },
+      userId
+    );
+    // eslint-disable-next-line no-unused-vars
+  } catch (err) {
+    return null;
+  }
+}
+
+export default {
+  getByUser,
+  createForUser,
+  updateForUser,
+  removeForUser,
+  importFromLegacy,
+};

--- a/tests/bankAccountService.test.js
+++ b/tests/bankAccountService.test.js
@@ -4,6 +4,9 @@ const findOneMock = jest.fn();
 const createMock = jest.fn();
 const findByPkMock = jest.fn();
 const updateMock = jest.fn();
+const findExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+const findBankMock = jest.fn();
 
 const accountInstance = { update: updateMock };
 
@@ -14,6 +17,17 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     create: createMock,
   },
   User: { findByPk: findByPkMock },
+  UserExternalId: { findOne: findExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
+}));
+
+jest.unstable_mockModule('../src/services/dadataService.js', () => ({
+  __esModule: true,
+  default: { findBankByBic: findBankMock },
 }));
 
 const { default: service } = await import('../src/services/bankAccountService.js');
@@ -40,6 +54,46 @@ test('updateForUser updates other fields', async () => {
   const res = await service.updateForUser('u', data, 'admin');
   expect(updateMock).toHaveBeenCalledWith({ ...data, updated_by: 'admin' });
   expect(res).toBe(acc);
+});
+
+test('importFromLegacy returns existing account', async () => {
+  findOneMock.mockResolvedValue(accountInstance);
+  const res = await service.importFromLegacy('u1');
+  expect(res).toBe(accountInstance);
+  expect(findExtMock).not.toHaveBeenCalled();
+});
+
+test('importFromLegacy creates account from legacy data', async () => {
+  findOneMock.mockResolvedValueOnce(null); // existing check
+  findExtMock.mockResolvedValue({ external_id: '5' });
+  legacyFindMock.mockResolvedValue({
+    bank_rs: '40702810900000005555',
+    bik_bank: '044525225',
+  });
+  findByPkMock.mockResolvedValue({ id: 'u1' });
+  findOneMock.mockResolvedValueOnce(null); // createForUser existing check
+  const created = { id: 'b1' };
+  createMock.mockResolvedValue(created);
+  findBankMock.mockResolvedValue({
+    value: 'Bank',
+    data: { correspondent_account: '301', swift: 'SW', inn: '1', kpp: '2', address: { unrestricted_value: 'A' } },
+  });
+
+  const res = await service.importFromLegacy('u1');
+  expect(createMock).toHaveBeenCalled();
+  expect(findBankMock).toHaveBeenCalledWith('044525225');
+  expect(res).toBe(created);
+});
+
+test('importFromLegacy returns null on invalid data', async () => {
+  findOneMock.mockResolvedValueOnce(null);
+  findExtMock.mockResolvedValue({ external_id: '9' });
+  legacyFindMock.mockResolvedValue({ bank_rs: '1', bik_bank: '2' });
+  findBankMock.mockClear();
+
+  const res = await service.importFromLegacy('u2');
+  expect(res).toBeNull();
+  expect(findBankMock).not.toHaveBeenCalled();
 });
 
 


### PR DESCRIPTION
## Summary
- validate and enrich bank account info via DaData during registration
- store imported account and prevent registration if invalid
- add `importFromLegacy` function to bank account service
- cover new logic with unit tests

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e59d320fc832d938165ed91685348