### PR TITLE
Translate error codes to Russian

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,3 +1,4 @@
+import { translateError } from './errors.js';
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:3000';
 
 export async function apiFetch(path, options = {}) {
@@ -11,10 +12,17 @@ export async function apiFetch(path, options = {}) {
     opts.headers['Authorization'] = `Bearer ${token}`;
   }
 
-  const res = await fetch(`${API_BASE}${path}`, opts);
+  let res;
+  try {
+    res = await fetch(`${API_BASE}${path}`, opts);
+  } catch (_err) {
+    throw new Error('Сетевая ошибка');
+  }
+
   const data = await res.json().catch(() => ({}));
   if (!res.ok) {
-    throw new Error(data.error || `Ошибка запроса, код ${res.status}`);
+    const message = translateError(data.error) || `Ошибка запроса, код ${res.status}`;
+    throw new Error(message);
   }
   return data;
 }

--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -1,0 +1,35 @@
+export const ERROR_MESSAGES = {
+  account_locked: 'Аккаунт заблокирован',
+  already_confirmed: 'Электронная почта уже подтверждена',
+  bank_account_exists: 'Банковский счёт уже указан',
+  bank_account_invalid: 'Неверные реквизиты счёта',
+  bank_account_locked: 'Банковский счёт заблокирован',
+  bank_account_not_found: 'Банковский счёт не найден',
+  bank_not_found: 'Банк не найден',
+  country_not_found: 'Страна не найдена',
+  document_type_not_found: 'Тип документа не найден',
+  email_exists: 'Email уже зарегистрирован',
+  inn_exists: 'ИНН уже зарегистрирован',
+  inn_not_found: 'ИНН не найден',
+  invalid_code: 'Неверный код',
+  invalid_credentials: 'Неверные учётные данные',
+  invalid_passport: 'Неверные данные паспорта',
+  invalid_token_type: 'Некорректный тип токена',
+  passport_exists: 'Паспорт уже добавлен',
+  passport_not_found: 'Паспорт не найден',
+  phone_exists: 'Телефон уже зарегистрирован',
+  role_not_found: 'Роль не найдена',
+  snils_exists: 'СНИЛС уже зарегистрирован',
+  snils_not_found: 'СНИЛС не найден',
+  status_not_found: 'Статус не найден',
+  status_required: 'Не указан статус',
+  taxation_not_found: 'Налоговый статус не найден',
+  user_exists: 'Пользователь уже существует',
+  user_not_found: 'Пользователь не найден',
+  not_found: 'Не найдено'
+};
+
+export function translateError(code) {
+  if (!code) return '';
+  return ERROR_MESSAGES[code] || code;
+}


### PR DESCRIPTION
## Summary
- add dictionary for translating backend error codes
- improve client API helper to map codes and handle network failures

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5c467b80832d97b2636f56cedde1