### PR TITLE
Extend passport validity with 90‑day grace period

### DIFF
--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -15,6 +15,7 @@ export function calculateValidUntil(birthDate, issueDate) {
   } else {
     return null;
   }
+  until.setDate(until.getDate() + 90);
   return until.toISOString().slice(0, 10);
 }
 

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -50,7 +50,7 @@ test('me returns legacy passport when none stored', async () => {
       series: '11',
       number: '000022',
       issue_date: '2000-01-01',
-      valid_until: '2010-01-01',
+      valid_until: '2010-04-01',
       issuing_authority: 'OVD',
       issuing_authority_code: '770-000',
       document_type: 'CIVIL',

--- a/tests/passportService.test.js
+++ b/tests/passportService.test.js
@@ -119,7 +119,7 @@ test('createForUser calculates valid_until for RU CIVIL passport', async () => {
   await service.createForUser('u1', data, 'admin');
   expect(cleanPassportMock).toHaveBeenCalledWith('4512 123456');
   expect(createMock).toHaveBeenCalledWith(
-    expect.objectContaining({ valid_until: '2035-01-01' })
+    expect.objectContaining({ valid_until: '2035-04-01' })
   );
 });
 

--- a/tests/passportUtils.test.js
+++ b/tests/passportUtils.test.js
@@ -3,11 +3,11 @@ import { calculateValidUntil } from '../src/utils/passportUtils.js';
 
 describe('passport utils', () => {
   test('calculateValidUntil for age below 20', () => {
-    expect(calculateValidUntil('1990-01-01', '2005-02-03')).toBe('2010-01-01');
+    expect(calculateValidUntil('1990-01-01', '2005-02-03')).toBe('2010-04-01');
   });
 
   test('calculateValidUntil for age below 45', () => {
-    expect(calculateValidUntil('1990-01-01', '2010-02-03')).toBe('2035-01-01');
+    expect(calculateValidUntil('1990-01-01', '2010-02-03')).toBe('2035-04-01');
   });
 
   test('calculateValidUntil returns null for age 45+', () => {


### PR DESCRIPTION
## Summary
- adjust `calculateValidUntil` logic for RU civil passport
- update corresponding tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5cb74508832db836a1e8d8a4d0b5