### PR TITLE
Add Swagger docs for registration endpoints

### DIFF
--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -8,7 +8,54 @@ import {
 
 const router = express.Router();
 
+/**
+ * @swagger
+ * /register/start:
+ *   post:
+ *     summary: Begin user registration
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *             properties:
+ *               email:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Verification code sent
+ */
 router.post('/start', startRegistrationRules, controller.start);
+
+/**
+ * @swagger
+ * /register/finish:
+ *   post:
+ *     summary: Complete user registration
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *               - code
+ *               - password
+ *             properties:
+ *               email:
+ *                 type: string
+ *               code:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Registration completed
+ */
 router.post('/finish', finishRegistrationRules, controller.finish);
 
 export default router;


### PR DESCRIPTION
## Summary
- document `/register/start` and `/register/finish` routes

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5d1159a4832db72a3059f9a9567d