### PR TITLE
Add cookie notice on login page

### DIFF
--- a/client/src/components/CookieNotice.vue
+++ b/client/src/components/CookieNotice.vue
@@ -1,0 +1,35 @@
+<template>
+  <div
+    class="cookie-notice alert alert-info d-flex align-items-center position-fixed bottom-0 start-50 translate-middle-x mb-3 fade"
+    :class="{ show: visible }"
+    role="alert"
+  >
+    <span class="me-3">
+      Продолжая работу с сайтом, вы соглашаетесь с использованием файлов cookie и обработкой персональных данных в соответствии с законодательством.
+    </span>
+    <button type="button" class="btn btn-primary btn-sm" @click="accept">Принять</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+
+const visible = ref(false)
+
+function accept() {
+  localStorage.setItem('cookieConsent', 'true')
+  visible.value = false
+}
+
+onMounted(() => {
+  if (!localStorage.getItem('cookieConsent')) {
+    visible.value = true
+  }
+})
+</script>
+
+<style scoped>
+.cookie-notice {
+  z-index: 1080;
+}
+</style>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { ref, watch } from 'vue'
+import CookieNotice from '../components/CookieNotice.vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { auth } from '../auth.js'
@@ -120,6 +121,7 @@ async function login() {
         </div>
       </form>
     </div>
+    <CookieNotice />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- show a cookie usage notice on the login page
- store consent in localStorage so it appears only once

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5cf1c408832d9607772a4edcdd1d