### PR TITLE
Add registration rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ DADATA_SECRET=your_dadata_secret
 # SMTP_USER=user@example.com
 # SMTP_PASS=secret
 # EMAIL_FROM=no-reply@example.com
+# REGISTRATION_RATE_WINDOW_MS=3600000
+# REGISTRATION_RATE_MAX=5
 ```
 
 ## Running with Docker

--- a/src/middlewares/registrationRateLimiter.js
+++ b/src/middlewares/registrationRateLimiter.js
@@ -1,0 +1,15 @@
+import rateLimit from 'express-rate-limit';
+
+/**
+ * Rate limiter for registration endpoints.
+ * Defaults to 5 requests per hour unless overridden by env vars.
+ */
+const windowMs = parseInt(process.env.REGISTRATION_RATE_WINDOW_MS || '3600000');
+const max = parseInt(process.env.REGISTRATION_RATE_MAX || '5');
+
+export default rateLimit({
+  windowMs,
+  max,
+  standardHeaders: true,
+  legacyHeaders: false,
+});

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -5,10 +5,21 @@ import {
   startRegistrationRules,
   finishRegistrationRules,
 } from '../validators/registrationValidators.js';
+import registrationRateLimiter from '../middlewares/registrationRateLimiter.js';
 
 const router = express.Router();
 
-router.post('/start', startRegistrationRules, controller.start);
-router.post('/finish', finishRegistrationRules, controller.finish);
+router.post(
+  '/start',
+  registrationRateLimiter,
+  startRegistrationRules,
+  controller.start
+);
+router.post(
+  '/finish',
+  registrationRateLimiter,
+  finishRegistrationRules,
+  controller.finish
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- add registration rate limiter middleware with env config
- protect registration routes with the limiter
- document new environment variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685e5d138e24832d853e77ceebda71c4