### PR TITLE
Add configurable password policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,18 @@ DADATA_SECRET=your_dadata_secret
 # JWT_ACCESS_TTL=15m
 # JWT_REFRESH_TTL=30d
 # JWT_ALG=HS256
+# PASSWORD_MIN_LENGTH=8
+# PASSWORD_PATTERN="(?=.*[A-Za-z])(?=.*\\d)"
 # SMTP_HOST=smtp.example.com
 # SMTP_PORT=587
 # SMTP_USER=user@example.com
 # SMTP_PASS=secret
 # EMAIL_FROM=no-reply@example.com
 ```
+
+`PASSWORD_MIN_LENGTH` and `PASSWORD_PATTERN` allow customizing the
+password policy for user registration. By default passwords must be at
+least eight characters long and contain both letters and numbers.
 
 ## Running with Docker
 

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -3,6 +3,12 @@ export const REFRESH_TTL = process.env.JWT_REFRESH_TTL || '30d';
 export const JWT_ALG = process.env.JWT_ALG || 'HS256';
 export const JWT_SECRET = process.env.JWT_SECRET;
 
+export const PASSWORD_MIN_LENGTH =
+  parseInt(process.env.PASSWORD_MIN_LENGTH, 10) || 8;
+export const PASSWORD_PATTERN = new RegExp(
+  process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)'
+);
+
 export const COOKIE_NAME = 'refresh_token';
 export const COOKIE_HTTP_ONLY = true;
 export const COOKIE_SAME_SITE = 'strict';

--- a/src/validators/registrationValidators.js
+++ b/src/validators/registrationValidators.js
@@ -1,4 +1,5 @@
 import { body } from 'express-validator';
+import { PASSWORD_MIN_LENGTH, PASSWORD_PATTERN } from '../config/auth.js';
 
 export const startRegistrationRules = [body('email').isEmail()];
 
@@ -7,8 +8,7 @@ export const finishRegistrationRules = [
   body('code').isString().notEmpty(),
   body('password')
     .isString()
-    .isLength({ min: 8 })
-    .matches(/[a-z]/i)
-    .matches(/[0-9]/)
+    .isLength({ min: PASSWORD_MIN_LENGTH })
+    .matches(PASSWORD_PATTERN)
     .custom((val) => !['password', '123456', 'qwerty'].includes(val)),
 ];


### PR DESCRIPTION
## Summary
- expose `PASSWORD_MIN_LENGTH` and `PASSWORD_PATTERN` in auth config
- use them in registration validators
- document new variables in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5d1527f8832d8575d452145cc375