### PR TITLE
Hash verification codes and track attempts

### DIFF
--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -90,6 +90,11 @@ export default {
         roles,
       });
     } catch (err) {
+      if (err.message === 'too_many_attempts') {
+        return res.status(400).json({
+          error: 'Слишком много неверных попыток подтверждения',
+        });
+      }
       return res.status(400).json({ error: err.message });
     }
   },

--- a/src/controllers/userEmailController.js
+++ b/src/controllers/userEmailController.js
@@ -23,6 +23,11 @@ export default {
       const user = await req.user.reload();
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
+      if (err.message === 'too_many_attempts') {
+        return res.status(400).json({
+          error: 'Слишком много неверных попыток подтверждения',
+        });
+      }
       return res.status(400).json({ error: err.message });
     }
   },

--- a/src/models/emailCode.js
+++ b/src/models/emailCode.js
@@ -12,7 +12,8 @@ EmailCode.init(
       primaryKey: true,
     },
     user_id: { type: DataTypes.UUID, allowNull: false },
-    code: { type: DataTypes.STRING(6), allowNull: false },
+    // store bcrypt hash of 6 digit code
+    code: { type: DataTypes.STRING(100), allowNull: false },
     expires_at: { type: DataTypes.DATE, allowNull: false },
   },
   {

--- a/src/services/emailCodeAttempts.js
+++ b/src/services/emailCodeAttempts.js
@@ -1,0 +1,32 @@
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const attempts = new Map();
+
+export function markFailed(id, now = Date.now()) {
+  const entry = attempts.get(id);
+  if (!entry || now - entry.first > WINDOW_MS) {
+    attempts.set(id, { count: 1, first: now });
+    return 1;
+  }
+  entry.count += 1;
+  return entry.count;
+}
+
+export function clear(id) {
+  attempts.delete(id);
+}
+
+export function get(id, now = Date.now()) {
+  const entry = attempts.get(id);
+  if (!entry) return 0;
+  if (now - entry.first > WINDOW_MS) {
+    attempts.delete(id);
+    return 0;
+  }
+  return entry.count;
+}
+
+export function _reset() {
+  attempts.clear();
+}
+
+export { WINDOW_MS };

--- a/src/services/emailVerificationService.js
+++ b/src/services/emailVerificationService.js
@@ -1,9 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Op } from 'sequelize';
+import bcrypt from 'bcryptjs';
 
 import { EmailCode, UserStatus } from '../models/index.js';
 
 import emailService from './emailService.js';
+import * as attempts from './emailCodeAttempts.js';
 
 function generateCode() {
   return String(Math.floor(100000 + Math.random() * 900000));
@@ -13,12 +15,14 @@ export async function sendCode(user) {
   const code = generateCode();
   const expires = new Date(Date.now() + 15 * 60 * 1000);
   await EmailCode.destroy({ where: { user_id: user.id } });
+  const hash = await bcrypt.hash(code, 10);
   await EmailCode.create({
     id: uuidv4(),
     user_id: user.id,
-    code,
+    code: hash,
     expires_at: expires,
   });
+  attempts.clear(user.id);
   await emailService.sendVerificationEmail(user, code);
 }
 
@@ -26,11 +30,19 @@ export async function verifyCode(user, code, statusAlias = 'ACTIVE') {
   const rec = await EmailCode.findOne({
     where: {
       user_id: user.id,
-      code,
       expires_at: { [Op.gt]: new Date() },
     },
   });
   if (!rec) throw new Error('invalid_code');
+  const ok = await bcrypt.compare(code, rec.code);
+  if (!ok) {
+    const count = attempts.markFailed(user.id);
+    if (count >= 5) {
+      throw new Error('too_many_attempts');
+    }
+    throw new Error('invalid_code');
+  }
+  attempts.clear(user.id);
   const status = await UserStatus.findOne({ where: { alias: statusAlias } });
   if (!status) throw new Error('status_not_found');
   await Promise.all([

--- a/tests/emailVerificationService.test.js
+++ b/tests/emailVerificationService.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const createMock = jest.fn();
+const destroyMock = jest.fn();
+const findOneMock = jest.fn();
+const statusFindMock = jest.fn();
+const sendEmailMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  EmailCode: { create: createMock, destroy: destroyMock, findOne: findOneMock },
+  UserStatus: { findOne: statusFindMock },
+}));
+
+jest.unstable_mockModule('../src/services/emailService.js', () => ({
+  __esModule: true,
+  default: { sendVerificationEmail: sendEmailMock },
+}));
+
+const hashMock = jest.fn(async (c) => `hash-${c}`);
+const compareMock = jest.fn();
+
+jest.unstable_mockModule('bcryptjs', () => ({
+  __esModule: true,
+  default: { hash: hashMock, compare: compareMock },
+  hash: hashMock,
+  compare: compareMock,
+}));
+
+import * as attemptStore from '../src/services/emailCodeAttempts.js';
+
+const { sendCode, verifyCode } = await import('../src/services/emailVerificationService.js');
+
+beforeEach(() => {
+  createMock.mockClear();
+  destroyMock.mockClear();
+  findOneMock.mockClear();
+  statusFindMock.mockClear();
+  sendEmailMock.mockClear();
+  hashMock.mockClear();
+  compareMock.mockClear();
+  attemptStore._reset();
+});
+
+test('sendCode stores hashed code and sends email', async () => {
+  const user = { id: '1' };
+  await sendCode(user);
+  expect(createMock).toHaveBeenCalled();
+  const data = createMock.mock.calls[0][0];
+  expect(data.user_id).toBe('1');
+  expect(data.code).toMatch(/^hash-/);
+  expect(sendEmailMock).toHaveBeenCalledWith(user, expect.any(String));
+});
+
+test('verifyCode succeeds with correct code', async () => {
+  const user = { id: '1', update: jest.fn() };
+  findOneMock.mockResolvedValue({ code: 'hash-123456' });
+  compareMock.mockResolvedValue(true);
+  statusFindMock.mockResolvedValue({ id: 's1' });
+  destroyMock.mockResolvedValue();
+  await verifyCode(user, '123456');
+  expect(compareMock).toHaveBeenCalledWith('123456', 'hash-123456');
+  expect(user.update).toHaveBeenCalled();
+  expect(attemptStore.get('1')).toBe(0);
+});
+
+test('verifyCode counts failed attempts and locks after five', async () => {
+  const user = { id: '1', update: jest.fn() };
+  findOneMock.mockResolvedValue({ code: 'hash-000000' });
+  compareMock.mockResolvedValue(false);
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('too_many_attempts');
+  expect(attemptStore.get('1')).toBe(5);
+});


### PR DESCRIPTION
## Summary
- hash email verification codes before storing
- compare hashes when verifying and keep failed attempt counts
- handle verification lockout errors in controllers
- implement in-memory tracking for email code attempts
- add tests for verification logic

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5d128e24832d83efc795ca8f50b7