### PR TITLE
Ensure registration is transactional

### DIFF
--- a/src/services/emailVerificationService.js
+++ b/src/services/emailVerificationService.js
@@ -9,16 +9,19 @@ function generateCode() {
   return String(Math.floor(100000 + Math.random() * 900000));
 }
 
-export async function sendCode(user) {
+export async function sendCode(user, transaction) {
   const code = generateCode();
   const expires = new Date(Date.now() + 15 * 60 * 1000);
-  await EmailCode.destroy({ where: { user_id: user.id } });
-  await EmailCode.create({
-    id: uuidv4(),
-    user_id: user.id,
-    code,
-    expires_at: expires,
-  });
+  await EmailCode.destroy({ where: { user_id: user.id }, transaction });
+  await EmailCode.create(
+    {
+      id: uuidv4(),
+      user_id: user.id,
+      code,
+      expires_at: expires,
+    },
+    { transaction },
+  );
   await emailService.sendVerificationEmail(user, code);
 }
 

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -2,7 +2,7 @@ import { Op } from 'sequelize';
 
 import { User, Role, UserStatus } from '../models/index.js';
 
-async function createUser(data) {
+async function createUser(data, options = {}) {
   const [activeStatus, unconfirmedStatus] = await Promise.all([
     UserStatus.findOne({ where: { alias: 'ACTIVE' } }),
     UserStatus.findOne({ where: { alias: 'EMAIL_UNCONFIRMED' } }),
@@ -28,7 +28,10 @@ async function createUser(data) {
   if (personalExisting) throw new Error('user_exists');
 
   const status = unconfirmedStatus || activeStatus;
-  const user = await User.create({ ...data, status_id: status.id });
+  const createOpts = options.transaction ? { transaction: options.transaction } : null;
+  const args = [{ ...data, status_id: status.id }];
+  if (createOpts) args.push(createOpts);
+  const user = await User.create(...args);
   return user;
 }
 

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -1,0 +1,162 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+let validationOk = true;
+
+jest.unstable_mockModule('express-validator', () => ({
+  validationResult: jest.fn(() => ({
+    isEmpty: () => validationOk,
+    array: () => [{ msg: 'bad' }],
+  })),
+}));
+
+const findOneUserMock = jest.fn();
+const findLegacyMock = jest.fn();
+const createUserMock = jest.fn();
+const findSystemMock = jest.fn();
+const createExtMock = jest.fn();
+const sendCodeMock = jest.fn();
+
+const transaction = { commit: jest.fn(), rollback: jest.fn() };
+const transactionFn = jest.fn(() => transaction);
+
+jest.unstable_mockModule('../src/config/database.js', () => ({
+  __esModule: true,
+  default: { transaction: transactionFn },
+}));
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  User: { findOne: findOneUserMock },
+  ExternalSystem: { findOne: findSystemMock },
+  UserExternalId: { create: createExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findByEmail: findLegacyMock },
+}));
+
+jest.unstable_mockModule('../src/services/userService.js', () => ({
+  __esModule: true,
+  default: { createUser: createUserMock },
+}));
+
+jest.unstable_mockModule('../src/services/emailVerificationService.js', () => ({
+  __esModule: true,
+  default: { sendCode: sendCodeMock },
+}));
+
+jest.unstable_mockModule('../src/services/authService.js', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.unstable_mockModule('../src/services/passportService.js', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.unstable_mockModule('../src/services/bankAccountService.js', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.unstable_mockModule('../src/mappers/userMapper.js', () => ({
+  __esModule: true,
+  default: {},
+}));
+
+jest.unstable_mockModule('../src/utils/cookie.js', () => ({
+  __esModule: true,
+  setRefreshCookie: jest.fn(),
+}));
+
+const { default: controller } = await import('../src/controllers/registrationController.js');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  validationOk = true;
+});
+
+test('start commits on success', async () => {
+  findOneUserMock.mockResolvedValueOnce(null); // existing user
+  findLegacyMock.mockResolvedValue({
+    last_name: 'L',
+    first_name: 'F',
+    second_name: 'S',
+    b_date: '2000-01-01',
+    phone_cod: '99',
+    phone_number: '1234567',
+    id: 'ext1',
+  });
+  createUserMock.mockResolvedValue({ id: 'u1' });
+  findSystemMock.mockResolvedValue({ id: 'sys1' });
+  createExtMock.mockResolvedValue({});
+  sendCodeMock.mockResolvedValue();
+
+  const req = { body: { email: 'e@x.ru' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await controller.start(req, res);
+
+  expect(transactionFn).toHaveBeenCalled();
+  expect(createUserMock).toHaveBeenCalledWith(expect.any(Object), { transaction });
+  expect(createExtMock).toHaveBeenCalledWith(expect.any(Object), { transaction });
+  expect(sendCodeMock).toHaveBeenCalledWith({ id: 'u1' }, transaction);
+  expect(transaction.commit).toHaveBeenCalled();
+  expect(res.json).toHaveBeenCalledWith({ message: 'code_sent' });
+});
+
+test('start rolls back on email failure', async () => {
+  findOneUserMock.mockResolvedValueOnce(null);
+  findLegacyMock.mockResolvedValue({
+    last_name: 'L',
+    first_name: 'F',
+    second_name: 'S',
+    b_date: '2000-01-01',
+    phone_cod: '99',
+    phone_number: '1234567',
+    id: 'ext1',
+  });
+  createUserMock.mockResolvedValue({ id: 'u1' });
+  findSystemMock.mockResolvedValue({ id: 'sys1' });
+  createExtMock.mockResolvedValue({});
+  sendCodeMock.mockRejectedValue(new Error('fail'));
+
+  const req = { body: { email: 'e@x.ru' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await controller.start(req, res);
+
+  expect(transaction.rollback).toHaveBeenCalled();
+  expect(transaction.commit).not.toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith({ error: 'fail' });
+});
+
+test('start rolls back on external id failure', async () => {
+  findOneUserMock.mockResolvedValueOnce(null);
+  findLegacyMock.mockResolvedValue({
+    last_name: 'L',
+    first_name: 'F',
+    second_name: 'S',
+    b_date: '2000-01-01',
+    phone_cod: '99',
+    phone_number: '1234567',
+    id: 'ext1',
+  });
+  createUserMock.mockResolvedValue({ id: 'u1' });
+  findSystemMock.mockResolvedValue({ id: 'sys1' });
+  createExtMock.mockRejectedValue(new Error('bad'));
+
+  const req = { body: { email: 'e@x.ru' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+
+  await controller.start(req, res);
+
+  expect(transaction.rollback).toHaveBeenCalled();
+  expect(transaction.commit).not.toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(res.json).toHaveBeenCalledWith({ error: 'bad' });
+});
+


### PR DESCRIPTION
## Summary
- wrap registration user creation and verification code generation in a DB transaction
- extend emailVerificationService and userService to support transactions
- add regression tests for registration transactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5d148500832dae64e5e376cc8451