### PR TITLE
Fix null checks for form validation

### DIFF
--- a/client/src/views/AdminUserCreate.vue
+++ b/client/src/views/AdminUserCreate.vue
@@ -34,7 +34,7 @@ onMounted(() => {
 })
 
 async function save() {
-  if (!formRef.value.validate()) return
+  if (!formRef.value?.validate || !formRef.value.validate()) return
   const payload = { ...user.value }
   const pass = generatePassword()
   payload.password = pass

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -105,7 +105,7 @@ function cancelEdit() {
 }
 
 async function save() {
-  if (!formRef.value.validate()) return
+  if (!formRef.value?.validate || !formRef.value.validate()) return
   const payload = { ...user.value }
   delete payload.roles
   delete payload.status

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -165,7 +165,7 @@ async function saveStep() {
   error.value = ''
   try {
     if (step.value === 1) {
-      if (!formRef.value.validate()) {
+      if (!formRef.value?.validate || !formRef.value.validate()) {
         loading.value = false
         return
       }
@@ -222,7 +222,7 @@ async function saveStep() {
         loading.value = false
         return
       }
-      if (passportRef.value && !passportRef.value.validate()) {
+      if (passportRef.value && (!passportRef.value.validate || !passportRef.value.validate())) {
         loading.value = false
         return
       }


### PR DESCRIPTION
## Summary
- check ref existence before running form validation in Profile Wizard
- handle undefined refs in admin user create/edit views

## Testing
- `npm test --silent`
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_685e604a4b3c832d8fc1e656e1007cbe