### PR TITLE
Fix email code storage

### DIFF
--- a/src/models/emailCode.js
+++ b/src/models/emailCode.js
@@ -12,8 +12,8 @@ EmailCode.init(
       primaryKey: true,
     },
     user_id: { type: DataTypes.UUID, allowNull: false },
-    // store bcrypt hash of 6 digit code
-    code: { type: DataTypes.STRING(100), allowNull: false },
+    // store 6 digit verification code
+    code: { type: DataTypes.STRING(6), allowNull: false },
     expires_at: { type: DataTypes.DATE, allowNull: false },
   },
   {

--- a/tests/emailVerificationService.test.js
+++ b/tests/emailVerificationService.test.js
@@ -17,15 +17,6 @@ jest.unstable_mockModule('../src/services/emailService.js', () => ({
   default: { sendVerificationEmail: sendEmailMock },
 }));
 
-const hashMock = jest.fn(async (c) => `hash-${c}`);
-const compareMock = jest.fn();
-
-jest.unstable_mockModule('bcryptjs', () => ({
-  __esModule: true,
-  default: { hash: hashMock, compare: compareMock },
-  hash: hashMock,
-  compare: compareMock,
-}));
 
 import * as attemptStore from '../src/services/emailCodeAttempts.js';
 
@@ -37,37 +28,32 @@ beforeEach(() => {
   findOneMock.mockClear();
   statusFindMock.mockClear();
   sendEmailMock.mockClear();
-  hashMock.mockClear();
-  compareMock.mockClear();
   attemptStore._reset();
 });
 
-test('sendCode stores hashed code and sends email', async () => {
+test('sendCode stores plain code and sends email', async () => {
   const user = { id: '1' };
   await sendCode(user);
   expect(createMock).toHaveBeenCalled();
   const data = createMock.mock.calls[0][0];
   expect(data.user_id).toBe('1');
-  expect(data.code).toMatch(/^hash-/);
+  expect(data.code).toMatch(/^\d{6}$/);
   expect(sendEmailMock).toHaveBeenCalledWith(user, expect.any(String));
 });
 
 test('verifyCode succeeds with correct code', async () => {
   const user = { id: '1', update: jest.fn() };
-  findOneMock.mockResolvedValue({ code: 'hash-123456' });
-  compareMock.mockResolvedValue(true);
+  findOneMock.mockResolvedValue({ code: '123456' });
   statusFindMock.mockResolvedValue({ id: 's1' });
   destroyMock.mockResolvedValue();
   await verifyCode(user, '123456');
-  expect(compareMock).toHaveBeenCalledWith('123456', 'hash-123456');
   expect(user.update).toHaveBeenCalled();
   expect(attemptStore.get('1')).toBe(0);
 });
 
 test('verifyCode counts failed attempts and locks after five', async () => {
   const user = { id: '1', update: jest.fn() };
-  findOneMock.mockResolvedValue({ code: 'hash-000000' });
-  compareMock.mockResolvedValue(false);
+  findOneMock.mockResolvedValue(null);
   await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
   await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
   await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');


### PR DESCRIPTION
## Summary
- store verification codes directly instead of bcrypt hashes
- look up codes by value in the verification service
- update tests for plaintext codes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e623ab800832da5ad9e53b49b8b02