### PR TITLE
Refactor passport import flow

### DIFF
--- a/src/controllers/passportController.js
+++ b/src/controllers/passportController.js
@@ -1,7 +1,5 @@
 import passportService from '../services/passportService.js';
 import passportMapper from '../mappers/passportMapper.js';
-import legacyService from '../services/legacyUserService.js';
-import { UserExternalId } from '../models/index.js';
 import { calculateValidUntil } from '../utils/passportUtils.js';
 
 export default {
@@ -11,29 +9,15 @@ export default {
       return res.json({ passport: passportMapper.toPublic(passport) });
     }
 
-    passport = await passportService.importFromLegacy(req.user.id);
-    if (passport) {
-      return res.json({ passport: passportMapper.toPublic(passport) });
-    }
-
-    const ext = await UserExternalId.findOne({
-      where: { user_id: req.user.id },
-    });
-    if (!ext) {
-      return res.status(404).json({ error: 'passport_not_found' });
-    }
-    const legacy = await legacyService.findById(ext.external_id);
-    if (legacy?.ps_ser && legacy?.ps_num) {
+    const legacy = await passportService.fetchFromLegacy(req.user.id);
+    if (legacy) {
       return res.json({
         passport: {
-          series: String(legacy.ps_ser),
-          number: String(legacy.ps_num).padStart(6, '0'),
-          issue_date: legacy.ps_date,
-          valid_until: calculateValidUntil(req.user.birth_date, legacy.ps_date),
-          issuing_authority: legacy.ps_org,
-          issuing_authority_code: legacy.ps_pdrz,
-          document_type: 'CIVIL',
-          country: 'RU',
+          ...legacy,
+          valid_until: calculateValidUntil(
+            req.user.birth_date,
+            legacy.issue_date
+          ),
         },
       });
     }

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -77,7 +77,7 @@ export default {
       await userService.resetPassword(user.id, password);
       const account = await bankAccountService.importFromLegacy(user.id);
       if (!account) throw new Error('bank_account_invalid');
-      await passportService.importFromLegacy(user.id);
+      await passportService.fetchFromLegacy(user.id);
       const updated = await user.reload();
       const roles = (await updated.getRoles({ attributes: ['alias'] })).map(
         (r) => r.alias

--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -28,10 +28,16 @@ export function sanitizePassportData(data = {}) {
     out.number = String(out.number).replace(/\s+/g, '').trim();
   }
   if (out.issue_date !== undefined && out.issue_date !== null) {
-    out.issue_date = String(out.issue_date).trim();
+    const d = new Date(out.issue_date);
+    out.issue_date = Number.isNaN(d.getTime())
+      ? String(out.issue_date).trim()
+      : d.toISOString().slice(0, 10);
   }
   if (out.valid_until !== undefined && out.valid_until !== null) {
-    out.valid_until = String(out.valid_until).trim();
+    const d = new Date(out.valid_until);
+    out.valid_until = Number.isNaN(d.getTime())
+      ? String(out.valid_until).trim()
+      : d.toISOString().slice(0, 10);
   }
   if (out.issuing_authority !== undefined) {
     out.issuing_authority = String(out.issuing_authority).trim();

--- a/src/validators/passportValidators.js
+++ b/src/validators/passportValidators.js
@@ -25,7 +25,10 @@ export const createPassportRules = [
         req.body.document_type === 'CIVIL' && req.body.country === 'RU'
     )
     .notEmpty()
-    .isISO8601(),
+    .custom((v) => {
+      const d = new Date(v);
+      return !Number.isNaN(d.getTime());
+    }),
   body('valid_until').optional().isISO8601(),
   body('issuing_authority')
     .if(

--- a/tests/passportController.test.js
+++ b/tests/passportController.test.js
@@ -2,7 +2,7 @@ import { expect, jest, test } from '@jest/globals';
 
 jest.unstable_mockModule('../src/services/passportService.js', () => ({
   __esModule: true,
-  default: { getByUser: jest.fn(), importFromLegacy: jest.fn() },
+  default: { getByUser: jest.fn(), fetchFromLegacy: jest.fn() },
 }));
 
 jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
@@ -10,41 +10,35 @@ jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
   default: { toPublic: jest.fn((p) => p) },
 }));
 
-const findOneExtMock = jest.fn();
-const legacyFindMock = jest.fn();
-
-jest.unstable_mockModule('../src/models/index.js', () => ({
-  __esModule: true,
-  UserExternalId: { findOne: findOneExtMock },
-}));
-
-jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
-  __esModule: true,
-  default: { findById: legacyFindMock },
-}));
-
-const { default: controller } = await import('../src/controllers/passportController.js');
+const { default: controller } = await import(
+  '../src/controllers/passportController.js'
+);
 const service = await import('../src/services/passportService.js');
 
 test('me returns stored passport', async () => {
   service.default.getByUser.mockResolvedValue({ id: 'p1' });
-  service.default.importFromLegacy.mockResolvedValue(null);
+  service.default.fetchFromLegacy.mockResolvedValue(null);
   const req = { user: { id: 'u1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalled();
-  expect(service.default.importFromLegacy).not.toHaveBeenCalled();
+  expect(service.default.fetchFromLegacy).not.toHaveBeenCalled();
 });
 
 test('me returns legacy passport when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
-  service.default.importFromLegacy.mockResolvedValue(null);
-  findOneExtMock.mockResolvedValue({ external_id: '5' });
-  legacyFindMock.mockResolvedValue({ ps_ser: '11', ps_num: '22', ps_date: '2000-01-01', ps_org: 'OVD', ps_pdrz: '770-000' });
+  service.default.fetchFromLegacy.mockResolvedValue({
+    series: '11',
+    number: '000022',
+    issue_date: '2000-01-01',
+    issuing_authority: 'OVD',
+    issuing_authority_code: '770-000',
+    document_type: 'CIVIL',
+    country: 'RU',
+  });
   const req = { user: { id: 'u1', birth_date: '1990-01-01' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
-  expect(service.default.importFromLegacy).toHaveBeenCalledWith('u1');
   expect(res.json).toHaveBeenCalledWith({
     passport: {
       series: '11',
@@ -59,14 +53,12 @@ test('me returns legacy passport when none stored', async () => {
   });
 });
 
-test('me returns persisted passport from legacy', async () => {
+test('me returns 404 when no passport data found', async () => {
   service.default.getByUser.mockResolvedValue(null);
-  service.default.importFromLegacy.mockResolvedValue({ id: 'p2' });
-  findOneExtMock.mockClear();
+  service.default.fetchFromLegacy.mockResolvedValue(null);
   const req = { user: { id: 'u2' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
-  expect(service.default.importFromLegacy).toHaveBeenCalledWith('u2');
-  expect(res.json).toHaveBeenCalledWith({ passport: { id: 'p2' } });
-  expect(findOneExtMock).not.toHaveBeenCalled();
+  expect(res.status).toHaveBeenCalledWith(404);
+  expect(res.json).toHaveBeenCalledWith({ error: 'passport_not_found' });
 });

--- a/tests/passportUtils.test.js
+++ b/tests/passportUtils.test.js
@@ -1,5 +1,8 @@
 import { describe, test, expect } from '@jest/globals';
-import { calculateValidUntil } from '../src/utils/passportUtils.js';
+import {
+  calculateValidUntil,
+  sanitizePassportData,
+} from '../src/utils/passportUtils.js';
 
 describe('passport utils', () => {
   test('calculateValidUntil for age below 20', () => {
@@ -12,5 +15,14 @@ describe('passport utils', () => {
 
   test('calculateValidUntil returns null for age 45+', () => {
     expect(calculateValidUntil('1950-01-01', '2020-01-01')).toBe(null);
+  });
+
+  test('sanitizePassportData normalizes dates', () => {
+    const res = sanitizePassportData({
+      issue_date: 'Tue Mar 17 2020 00:00:00 GMT+0000 (Coordinated Universal Time)',
+      valid_until: 'Wed Mar 18 2026 00:00:00 GMT+0000 (Coordinated Universal Time)',
+    });
+    expect(res.issue_date).toBe('2020-03-17');
+    expect(res.valid_until).toBe('2026-03-18');
   });
 });


### PR DESCRIPTION
## Summary
- add `fetchFromLegacy` helper to passport service
- pull passport data from legacy without persisting
- call the helper during registration finish
- update controller and tests accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e6a75750c832db07dc6f87fd95db6