### PR TITLE
Fix bank account saving timing

### DIFF
--- a/src/controllers/bankAccountController.js
+++ b/src/controllers/bankAccountController.js
@@ -1,7 +1,5 @@
 import bankAccountService from '../services/bankAccountService.js';
 import bankAccountMapper from '../mappers/bankAccountMapper.js';
-import legacyService from '../services/legacyUserService.js';
-import { UserExternalId } from '../models/index.js';
 
 export default {
   async me(req, res) {
@@ -9,19 +7,10 @@ export default {
     if (acc) {
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     }
-    const ext = await UserExternalId.findOne({
-      where: { user_id: req.user.id },
-    });
-    if (!ext) {
-      return res.status(404).json({ error: 'bank_account_not_found' });
-    }
-    const legacy = await legacyService.findById(ext.external_id);
-    if (legacy?.bank_rs && legacy?.bik_bank) {
+    const legacy = await bankAccountService.fetchFromLegacy(req.user.id);
+    if (legacy) {
       return res.json({
-        account: {
-          number: String(legacy.bank_rs),
-          bic: String(legacy.bik_bank).padStart(9, '0'),
-        },
+        account: { number: legacy.number, bic: legacy.bic },
       });
     }
     return res.status(404).json({ error: 'bank_account_not_found' });

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -75,8 +75,7 @@ export default {
         'REGISTRATION_STEP_1'
       );
       await userService.resetPassword(user.id, password);
-      const account = await bankAccountService.importFromLegacy(user.id);
-      if (!account) throw new Error('bank_account_invalid');
+      await bankAccountService.fetchFromLegacy(user.id);
       await passportService.fetchFromLegacy(user.id);
       const updated = await user.reload();
       const roles = (await updated.getRoles({ attributes: ['alias'] })).map(

--- a/src/services/bankAccountService.js
+++ b/src/services/bankAccountService.js
@@ -42,6 +42,31 @@ async function removeForUser(userId) {
   await acc.destroy();
 }
 
+async function fetchFromLegacy(userId) {
+  const ext = await UserExternalId.findOne({ where: { user_id: userId } });
+  if (!ext) return null;
+  const legacy = await legacyUserService.findById(ext.external_id);
+  if (!legacy?.bank_rs || !legacy?.bik_bank) return null;
+
+  const number = String(legacy.bank_rs);
+  const bic = String(legacy.bik_bank).padStart(9, '0');
+  if (!isValidAccountNumber(number, bic)) return null;
+
+  const bank = await dadataService.findBankByBic(bic);
+  if (!bank) return null;
+
+  return {
+    number,
+    bic,
+    bank_name: bank.value,
+    correspondent_account: bank.data.correspondent_account,
+    swift: bank.data.swift,
+    inn: bank.data.inn,
+    kpp: bank.data.kpp,
+    address: bank.data.address?.unrestricted_value,
+  };
+}
+
 async function importFromLegacy(userId) {
   const existing = await BankAccount.findOne({ where: { user_id: userId } });
   if (existing) return existing;
@@ -84,5 +109,6 @@ export default {
   createForUser,
   updateForUser,
   removeForUser,
+  fetchFromLegacy,
   importFromLegacy,
 };

--- a/tests/bankAccountController.test.js
+++ b/tests/bankAccountController.test.js
@@ -2,25 +2,12 @@ import { expect, jest, test } from '@jest/globals';
 
 jest.unstable_mockModule('../src/services/bankAccountService.js', () => ({
   __esModule: true,
-  default: { getByUser: jest.fn() },
+  default: { getByUser: jest.fn(), fetchFromLegacy: jest.fn() },
 }));
 
 jest.unstable_mockModule('../src/mappers/bankAccountMapper.js', () => ({
   __esModule: true,
   default: { toPublic: jest.fn((a) => a) },
-}));
-
-const findOneExtMock = jest.fn();
-const legacyFindMock = jest.fn();
-
-jest.unstable_mockModule('../src/models/index.js', () => ({
-  __esModule: true,
-  UserExternalId: { findOne: findOneExtMock },
-}));
-
-jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
-  __esModule: true,
-  default: { findById: legacyFindMock },
 }));
 
 const { default: controller } = await import('../src/controllers/bankAccountController.js');
@@ -32,12 +19,15 @@ test('me returns stored account', async () => {
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);
   expect(res.json).toHaveBeenCalled();
+  expect(service.default.fetchFromLegacy).not.toHaveBeenCalled();
 });
 
 test('me returns legacy account when none stored', async () => {
   service.default.getByUser.mockResolvedValue(null);
-  findOneExtMock.mockResolvedValue({ external_id: '8' });
-  legacyFindMock.mockResolvedValue({ bank_rs: '40702810', bik_bank: '044525225' });
+  service.default.fetchFromLegacy.mockResolvedValue({
+    number: '40702810',
+    bic: '044525225',
+  });
   const req = { user: { id: 'u1' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.me(req, res);

--- a/tests/bankAccountService.test.js
+++ b/tests/bankAccountService.test.js
@@ -96,4 +96,42 @@ test('importFromLegacy returns null on invalid data', async () => {
   expect(findBankMock).not.toHaveBeenCalled();
 });
 
+test('fetchFromLegacy returns null when user not linked', async () => {
+  findExtMock.mockResolvedValue(null);
+  legacyFindMock.mockClear();
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toBeNull();
+  expect(legacyFindMock).not.toHaveBeenCalled();
+});
+
+test('fetchFromLegacy returns sanitized data', async () => {
+  findExtMock.mockResolvedValue({ external_id: '5' });
+  legacyFindMock.mockResolvedValue({
+    bank_rs: '40702810900000005555',
+    bik_bank: '044525225',
+  });
+  findBankMock.mockResolvedValue({
+    value: 'Bank',
+    data: {
+      correspondent_account: '301',
+      swift: 'SW',
+      inn: '1',
+      kpp: '2',
+      address: { unrestricted_value: 'A' },
+    },
+  });
+
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toEqual({
+    number: '40702810900000005555',
+    bic: '044525225',
+    bank_name: 'Bank',
+    correspondent_account: '301',
+    swift: 'SW',
+    inn: '1',
+    kpp: '2',
+    address: 'A',
+  });
+});
+
 

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -34,17 +34,18 @@ jest.unstable_mockModule('../src/services/userService.js', () => ({
 
 const fetchPassportMock = jest.fn();
 
+const fetchBankMock = jest.fn();
+
 jest.unstable_mockModule('../src/services/passportService.js', () => ({
   __esModule: true,
   default: { fetchFromLegacy: fetchPassportMock },
 }));
 
-const importBankMock = jest.fn();
-
 jest.unstable_mockModule('../src/services/bankAccountService.js', () => ({
   __esModule: true,
-  default: { importFromLegacy: importBankMock },
+  default: { fetchFromLegacy: fetchBankMock },
 }));
+
 
 const issueTokensMock = jest.fn(() => ({
   accessToken: 'a',
@@ -130,8 +131,8 @@ test('finish issues tokens after valid code', async () => {
   user.reload.mockResolvedValue(updated);
   findUserMock.mockResolvedValueOnce(user);
   verifyCodeMock.mockResolvedValueOnce();
-  importBankMock.mockResolvedValueOnce({});
   fetchPassportMock.mockResolvedValueOnce({});
+  fetchBankMock.mockResolvedValueOnce({});
   const req = {
     body: { email: 't@example.com', code: '123', password: 'Passw0rd' },
   };
@@ -143,6 +144,7 @@ test('finish issues tokens after valid code', async () => {
     'REGISTRATION_STEP_1'
   );
   expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd');
+  expect(fetchBankMock).toHaveBeenCalledWith('u1');
   expect(fetchPassportMock).toHaveBeenCalledWith('u1');
   expect(issueTokensMock).toHaveBeenCalledWith(updated);
   expect(setRefreshCookieMock).toHaveBeenCalledWith(res, 'r');


### PR DESCRIPTION
## Summary
- avoid persisting bank info during registration until confirmation
- fetch bank details from legacy when needed
- adjust controllers and unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e8e5fae64832d926d29184331f265