### PR TITLE
Fix legacy import for personal identifiers

### DIFF
--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -8,6 +8,8 @@ import userService from '../services/userService.js';
 import authService from '../services/authService.js';
 import passportService from '../services/passportService.js';
 import bankAccountService from '../services/bankAccountService.js';
+import innService from '../services/innService.js';
+import snilsService from '../services/snilsService.js';
 import { ExternalSystem, UserExternalId } from '../models/index.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie } from '../utils/cookie.js';
@@ -75,8 +77,10 @@ export default {
         'REGISTRATION_STEP_1'
       );
       await userService.resetPassword(user.id, password);
-      await bankAccountService.fetchFromLegacy(user.id);
-      await passportService.fetchFromLegacy(user.id);
+      await bankAccountService.importFromLegacy(user.id);
+      await passportService.importFromLegacy(user.id);
+      await innService.importFromLegacy(user.id);
+      await snilsService.importFromLegacy(user.id);
       const updated = await user.reload();
       const roles = (await updated.getRoles({ attributes: ['alias'] })).map(
         (r) => r.alias

--- a/src/services/innService.js
+++ b/src/services/innService.js
@@ -1,8 +1,10 @@
 import { Op } from 'sequelize';
 
-import { Inn } from '../models/index.js';
+import { Inn, UserExternalId } from '../models/index.js';
 
 import taxationService from './taxationService.js';
+import legacyUserService from './legacyUserService.js';
+import { isValidInn } from '../utils/personal.js';
 
 async function getByUser(userId) {
   return Inn.findOne({ where: { user_id: userId } });
@@ -40,4 +42,25 @@ async function remove(userId) {
   await taxationService.removeByUser(userId);
 }
 
-export default { getByUser, create, update, remove };
+async function importFromLegacy(userId) {
+  const existing = await Inn.findOne({ where: { user_id: userId } });
+  if (existing) return existing;
+
+  const ext = await UserExternalId.findOne({ where: { user_id: userId } });
+  if (!ext) return null;
+
+  const legacy = await legacyUserService.findById(ext.external_id);
+  if (!legacy?.sv_inn) return null;
+
+  const number = String(legacy.sv_inn).replace(/\D/g, '');
+  if (!isValidInn(number)) return null;
+
+  try {
+    return await create(userId, number, userId);
+    // eslint-disable-next-line no-unused-vars
+  } catch (err) {
+    return null;
+  }
+}
+
+export default { getByUser, create, update, remove, importFromLegacy };

--- a/tests/innService.test.js
+++ b/tests/innService.test.js
@@ -4,6 +4,9 @@ const findOneMock = jest.fn();
 const createMock = jest.fn();
 const updateMock = jest.fn();
 
+const findExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
 const innInstance = { update: updateMock };
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -12,6 +15,11 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     findOne: findOneMock,
     create: createMock,
   },
+  UserExternalId: { findOne: findExtMock },
+}));
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
 }));
 jest.unstable_mockModule('../src/services/taxationService.js', () => ({
   __esModule: true,
@@ -70,4 +78,40 @@ test('remove destroys record and taxation removed', async () => {
 test('remove throws when record not found', async () => {
   findOneMock.mockResolvedValueOnce(null);
   await expect(service.remove('u1')).rejects.toThrow('inn_not_found');
+});
+
+test('importFromLegacy returns existing record', async () => {
+  findOneMock.mockResolvedValue(innInstance);
+  const res = await service.importFromLegacy('u1');
+  expect(res).toBe(innInstance);
+  expect(findExtMock).not.toHaveBeenCalled();
+});
+
+test('importFromLegacy creates inn from legacy data', async () => {
+  findOneMock.mockReset();
+  createMock.mockClear();
+  findExtMock.mockClear();
+  legacyFindMock.mockClear();
+  findOneMock.mockResolvedValueOnce(null); // check existing
+  findExtMock.mockResolvedValue({ external_id: '5' });
+  legacyFindMock.mockResolvedValue({ sv_inn: '500100732259' });
+  const created = { id: 'n2' };
+  createMock.mockResolvedValue(created);
+
+  const res = await service.importFromLegacy('u1');
+  expect(createMock).toHaveBeenCalledWith({
+    user_id: 'u1',
+    number: '500100732259',
+    created_by: 'u1',
+    updated_by: 'u1',
+  });
+  expect(res).toBe(created);
+});
+
+test('importFromLegacy returns null on invalid data', async () => {
+  findOneMock.mockResolvedValueOnce(null);
+  findExtMock.mockResolvedValue({ external_id: '7' });
+  legacyFindMock.mockResolvedValue({ sv_inn: 'bad' });
+  const res = await service.importFromLegacy('u1');
+  expect(res).toBeNull();
 });

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -32,18 +32,31 @@ jest.unstable_mockModule('../src/services/userService.js', () => ({
   default: { createUser: createUserMock, resetPassword: resetPasswordMock },
 }));
 
-const fetchPassportMock = jest.fn();
+const importPassportMock = jest.fn();
 
-const fetchBankMock = jest.fn();
+const importBankMock = jest.fn();
+
+const importInnMock = jest.fn();
+const importSnilsMock = jest.fn();
 
 jest.unstable_mockModule('../src/services/passportService.js', () => ({
   __esModule: true,
-  default: { fetchFromLegacy: fetchPassportMock },
+  default: { importFromLegacy: importPassportMock },
 }));
 
 jest.unstable_mockModule('../src/services/bankAccountService.js', () => ({
   __esModule: true,
-  default: { fetchFromLegacy: fetchBankMock },
+  default: { importFromLegacy: importBankMock },
+}));
+
+jest.unstable_mockModule('../src/services/innService.js', () => ({
+  __esModule: true,
+  default: { importFromLegacy: importInnMock },
+}));
+
+jest.unstable_mockModule('../src/services/snilsService.js', () => ({
+  __esModule: true,
+  default: { importFromLegacy: importSnilsMock },
 }));
 
 
@@ -131,8 +144,8 @@ test('finish issues tokens after valid code', async () => {
   user.reload.mockResolvedValue(updated);
   findUserMock.mockResolvedValueOnce(user);
   verifyCodeMock.mockResolvedValueOnce();
-  fetchPassportMock.mockResolvedValueOnce({});
-  fetchBankMock.mockResolvedValueOnce({});
+  importPassportMock.mockResolvedValueOnce({});
+  importBankMock.mockResolvedValueOnce({});
   const req = {
     body: { email: 't@example.com', code: '123', password: 'Passw0rd' },
   };
@@ -144,8 +157,10 @@ test('finish issues tokens after valid code', async () => {
     'REGISTRATION_STEP_1'
   );
   expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd');
-  expect(fetchBankMock).toHaveBeenCalledWith('u1');
-  expect(fetchPassportMock).toHaveBeenCalledWith('u1');
+  expect(importBankMock).toHaveBeenCalledWith('u1');
+  expect(importPassportMock).toHaveBeenCalledWith('u1');
+  expect(importInnMock).toHaveBeenCalledWith('u1');
+  expect(importSnilsMock).toHaveBeenCalledWith('u1');
   expect(issueTokensMock).toHaveBeenCalledWith(updated);
   expect(setRefreshCookieMock).toHaveBeenCalledWith(res, 'r');
   expect(res.json).toHaveBeenCalledWith({

--- a/tests/snilsService.test.js
+++ b/tests/snilsService.test.js
@@ -4,6 +4,9 @@ const findOneMock = jest.fn();
 const createMock = jest.fn();
 const updateMock = jest.fn();
 
+const findExtMock = jest.fn();
+const legacyFindMock = jest.fn();
+
 const snilsInstance = { update: updateMock };
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -12,6 +15,11 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     findOne: findOneMock,
     create: createMock,
   },
+  UserExternalId: { findOne: findExtMock },
+}));
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: legacyFindMock },
 }));
 
 const { default: service } = await import('../src/services/snilsService.js');
@@ -64,4 +72,39 @@ test('remove deletes snils', async () => {
 test('remove throws when not found', async () => {
   findOneMock.mockResolvedValueOnce(null);
   await expect(service.remove('u1')).rejects.toThrow('snils_not_found');
+});
+
+test('importFromLegacy returns existing record', async () => {
+  findOneMock.mockResolvedValue(snilsInstance);
+  const res = await service.importFromLegacy('u1');
+  expect(res).toBe(snilsInstance);
+  expect(findExtMock).not.toHaveBeenCalled();
+});
+
+test('importFromLegacy creates snils from legacy data', async () => {
+  findOneMock.mockReset();
+  createMock.mockClear();
+  findExtMock.mockClear();
+  legacyFindMock.mockClear();
+  findOneMock.mockResolvedValueOnce(null);
+  findExtMock.mockResolvedValue({ external_id: '10' });
+  legacyFindMock.mockResolvedValue({ sv_ops: '112-233-445 95' });
+  const created = { id: 's2' };
+  createMock.mockResolvedValue(created);
+  const res = await service.importFromLegacy('u1');
+  expect(createMock).toHaveBeenCalledWith({
+    user_id: 'u1',
+    number: '112-233-445 95',
+    created_by: 'u1',
+    updated_by: 'u1',
+  });
+  expect(res).toBe(created);
+});
+
+test('importFromLegacy returns null on invalid data', async () => {
+  findOneMock.mockResolvedValueOnce(null);
+  findExtMock.mockResolvedValue({ external_id: '7' });
+  legacyFindMock.mockResolvedValue({ sv_ops: 'bad' });
+  const res = await service.importFromLegacy('u1');
+  expect(res).toBeNull();
 });


### PR DESCRIPTION
## Summary
- import INN and SNILS data when completing registration
- implement `importFromLegacy` in INN and SNILS services
- update unit tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e96c3e7a4832d9ae7030e5cb25c5b