### PR TITLE
Add mask for passport division code

### DIFF
--- a/client/src/components/AddPassportModal.vue
+++ b/client/src/components/AddPassportModal.vue
@@ -104,6 +104,14 @@ function updateSuggestions() {
 
 watch(() => form.issuing_authority_code, updateSuggestions)
 
+function onIssuingCodeInput(e) {
+  let digits = e.target.value.replace(/\D/g, '').slice(0, 6)
+  if (digits.length > 3) {
+    digits = digits.slice(0, 3) + '-' + digits.slice(3)
+  }
+  form.issuing_authority_code = digits
+}
+
 function applySuggestion(s) {
   form.issuing_authority = s.data.name
   form.issuing_authority_code = s.data.code
@@ -209,6 +217,8 @@ async function save() {
               <label class="form-label">Код подразделения</label>
               <input
                 v-model="form.issuing_authority_code"
+                @input="onIssuingCodeInput"
+                maxlength="7"
                 class="form-control"
                 :class="{ 'is-invalid': errors.issuing_authority_code }"
               />

--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -240,20 +240,6 @@ defineExpose({ validate })
         <div class="col position-relative">
           <div class="form-floating">
             <input
-              id="issuedBy"
-              v-model="form.issuing_authority"
-              class="form-control"
-              :class="{ 'is-invalid': errors.issuing_authority }"
-              :disabled="isLocked('issuing_authority')"
-              placeholder="Кем выдан"
-            />
-            <label for="issuedBy">Кем выдан</label>
-            <div class="invalid-feedback d-block">{{ errors.issuing_authority }}</div>
-          </div>
-        </div>
-        <div class="col position-relative">
-          <div class="form-floating">
-            <input
               id="issuingCode"
               v-model="form.issuing_authority_code"
               @input="onIssuingCodeInput"
@@ -280,6 +266,20 @@ defineExpose({ validate })
               {{ s.value }}
             </li>
           </ul>
+        </div>
+        <div class="col position-relative">
+          <div class="form-floating">
+            <input
+              id="issuedBy"
+              v-model="form.issuing_authority"
+              class="form-control"
+              :class="{ 'is-invalid': errors.issuing_authority }"
+              :disabled="isLocked('issuing_authority')"
+              placeholder="Кем выдан"
+            />
+            <label for="issuedBy">Кем выдан</label>
+            <div class="invalid-feedback d-block">{{ errors.issuing_authority }}</div>
+          </div>
         </div>
         <div class="col">
           <div class="form-floating">

--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -108,6 +108,14 @@ function onNumberInput(e) {
   form.number = e.target.value.replace(/\D/g, '').slice(0, 6)
 }
 
+function onIssuingCodeInput(e) {
+  let digits = e.target.value.replace(/\D/g, '').slice(0, 6)
+  if (digits.length > 3) {
+    digits = digits.slice(0, 3) + '-' + digits.slice(3)
+  }
+  form.issuing_authority_code = digits
+}
+
 function applySuggestion(s) {
   form.issuing_authority = s.data.name
   form.issuing_authority_code = s.data.code
@@ -248,6 +256,8 @@ defineExpose({ validate })
             <input
               id="issuingCode"
               v-model="form.issuing_authority_code"
+              @input="onIssuingCodeInput"
+              maxlength="7"
               class="form-control"
               :class="{ 'is-invalid': errors.issuing_authority_code }"
               :disabled="isLocked('issuing_authority_code')"

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -82,7 +82,9 @@ onMounted(async () => {
           user.value.birth_date,
           passport.value.issue_date
         ) === passport.value.valid_until,
-      issuing_authority: !!passport.value.issuing_authority,
+      issuing_authority:
+        !!passport.value.issuing_authority &&
+        !!passport.value.issuing_authority_code,
       issuing_authority_code: !!passport.value.issuing_authority_code,
       place_of_birth: !!passport.value.place_of_birth,
     }
@@ -258,7 +260,9 @@ async function saveStep() {
             user.value.birth_date,
             passport.value.issue_date
           ) === passport.value.valid_until,
-        issuing_authority: !!passport.value.issuing_authority,
+        issuing_authority:
+          !!passport.value.issuing_authority &&
+          !!passport.value.issuing_authority_code,
         issuing_authority_code: !!passport.value.issuing_authority_code,
         place_of_birth: !!passport.value.place_of_birth,
       }


### PR DESCRIPTION
## Summary
- add input mask for issuing authority code
- unlock `issuing_authority` editing if code missing

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_685ed1b1afc0832da39fdb3546a09c87