### PR TITLE
Persist profile wizard progress

### DIFF
--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -30,7 +30,11 @@ function calculateValidUntil(birthDate, issueDate) {
 }
 
 const router = useRouter()
-const step = ref(auth.user?.status === 'REGISTRATION_STEP_2' ? 2 : 1)
+const step = ref(
+  auth.user?.status?.startsWith('REGISTRATION_STEP_')
+    ? parseInt(auth.user.status.split('_').pop()) || 1
+    : 1
+)
 const total = 4
 const user = ref({})
 const inn = ref('')
@@ -217,6 +221,11 @@ async function saveStep() {
         method: 'POST',
         body: JSON.stringify({ number: inn.value })
       })
+      await apiFetch('/profile/progress', {
+        method: 'POST',
+        body: JSON.stringify({ status: 'REGISTRATION_STEP_3' })
+      })
+      auth.user.status = 'REGISTRATION_STEP_3'
       snilsLocked.value = true
       innLocked.value = true
       step.value = 3

--- a/src/seeders/20250701000000-add-registration-steps.js
+++ b/src/seeders/20250701000000-add-registration-steps.js
@@ -4,11 +4,6 @@ const { v4: uuidv4 } = require('uuid');
 
 module.exports = {
   async up(queryInterface) {
-    const [existing] = await queryInterface.sequelize.query(
-      // eslint-disable-next-line
-      "SELECT COUNT(*) AS cnt FROM user_statuses WHERE alias IN ('REGISTRATION_STEP_1','REGISTRATION_STEP_2');"
-    );
-    if (Number(existing[0].cnt) > 0) return;
     const now = new Date();
     await queryInterface.bulkInsert(
       'user_statuses',
@@ -27,6 +22,13 @@ module.exports = {
           created_at: now,
           updated_at: now,
         },
+        {
+          id: uuidv4(),
+          name: 'Registration step 3',
+          alias: 'REGISTRATION_STEP_3',
+          created_at: now,
+          updated_at: now,
+        },
       ],
       { ignoreDuplicates: true }
     );
@@ -34,7 +36,7 @@ module.exports = {
 
   async down(queryInterface) {
     await queryInterface.bulkDelete('user_statuses', {
-      alias: ['REGISTRATION_STEP_1', 'REGISTRATION_STEP_2'],
+      alias: ['REGISTRATION_STEP_1', 'REGISTRATION_STEP_2', 'REGISTRATION_STEP_3'],
     });
   },
 };

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -124,7 +124,7 @@ test('login returns next_step when registration not complete', async () => {
     reload: jest.fn().mockResolvedValue({
       id: '1',
       getRoles: jest.fn().mockResolvedValue([{ alias: 'USER' }]),
-      UserStatus: { alias: 'REGISTRATION_STEP_2' },
+      UserStatus: { alias: 'REGISTRATION_STEP_3' },
     }),
   };
   verifyCredentialsMock.mockResolvedValue(user);
@@ -136,9 +136,9 @@ test('login returns next_step when registration not complete', async () => {
 
   expect(res.json).toHaveBeenCalledWith({
     access_token: 'access',
-    user: { id: '1', status: 'REGISTRATION_STEP_2' },
+    user: { id: '1', status: 'REGISTRATION_STEP_3' },
     roles: ['USER'],
-    next_step: 2,
+    next_step: 3,
   });
 });
 


### PR DESCRIPTION
## Summary
- remember user's profile step past step 2
- seed new REGISTRATION_STEP_3 status
- adjust login test for new status

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed201c344832dbdff8fe1e875e884