### PR TITLE
Add birth and passport issue date validation

### DIFF
--- a/src/services/passportService.js
+++ b/src/services/passportService.js
@@ -23,6 +23,13 @@ async function getByUser(userId) {
 async function createForUser(userId, data, adminId) {
   data = sanitizePassportData(data);
 
+  if (data.issue_date) {
+    const issue = new Date(data.issue_date);
+    if (Number.isNaN(issue.getTime()) || issue < new Date('2000-01-01')) {
+      throw new Error('invalid_issue_date');
+    }
+  }
+
   const [user, existing] = await Promise.all([
     User.findByPk(userId),
     Passport.findOne({ where: { user_id: userId } }),

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -3,6 +3,10 @@ import { Op } from 'sequelize';
 import { User, Role, UserStatus } from '../models/index.js';
 
 async function createUser(data) {
+  const birth = new Date(data.birth_date);
+  if (Number.isNaN(birth.getTime()) || birth < new Date('1945-01-01')) {
+    throw new Error('invalid_birth_date');
+  }
   const [activeStatus, unconfirmedStatus] = await Promise.all([
     UserStatus.findOne({ where: { alias: 'ACTIVE' } }),
     UserStatus.findOne({ where: { alias: 'EMAIL_UNCONFIRMED' } }),

--- a/src/validators/passportValidators.js
+++ b/src/validators/passportValidators.js
@@ -27,8 +27,9 @@ export const createPassportRules = [
     .notEmpty()
     .custom((v) => {
       const d = new Date(v);
-      return !Number.isNaN(d.getTime());
-    }),
+      return !Number.isNaN(d.getTime()) && d >= new Date('2000-01-01');
+    })
+    .withMessage('invalid_issue_date'),
   body('valid_until').optional().isISO8601(),
   body('issuing_authority')
     .if(

--- a/src/validators/userValidators.js
+++ b/src/validators/userValidators.js
@@ -3,7 +3,13 @@ import { body } from 'express-validator';
 export const createUserRules = [
   body('first_name').isString().notEmpty(),
   body('last_name').isString().notEmpty(),
-  body('birth_date').isISO8601(),
+  body('birth_date')
+    .isISO8601()
+    .custom((v) => {
+      const d = new Date(v);
+      return !Number.isNaN(d.getTime()) && d >= new Date('1945-01-01');
+    })
+    .withMessage('invalid_birth_date'),
   body('phone').isMobilePhone(),
   body('email').isEmail(),
   body('password').isString().notEmpty(),
@@ -13,7 +19,14 @@ export const updateUserRules = [
   body('first_name').optional().isString().notEmpty(),
   body('last_name').optional().isString().notEmpty(),
   body('patronymic').optional().isString(),
-  body('birth_date').optional().isISO8601(),
+  body('birth_date')
+    .optional()
+    .isISO8601()
+    .custom((v) => {
+      const d = new Date(v);
+      return !Number.isNaN(d.getTime()) && d >= new Date('1945-01-01');
+    })
+    .withMessage('invalid_birth_date'),
   body('phone').optional().isMobilePhone(),
   body('email').optional().isEmail(),
 ];

--- a/tests/passportService.test.js
+++ b/tests/passportService.test.js
@@ -225,3 +225,30 @@ test('createForUser throws error on DaData failure', async () => {
     'invalid_passport'
   );
 });
+
+test('createForUser rejects issue_date before 2000', async () => {
+  findByPkMock.mockResolvedValue({ id: 'u2' });
+  findOneMock.mockResolvedValueOnce(null);
+  findTypeMock.mockResolvedValue({ id: 't1' });
+  findCountryMock.mockResolvedValue({ id: 'c1' });
+  cleanPassportMock.mockResolvedValue({
+    qc: 0,
+    series: '4512',
+    number: '123456',
+    issue_date: '1990-01-01',
+    issue_org: 'OVD',
+    issue_code: '770-000',
+  });
+  const data = {
+    document_type: 'CIVIL',
+    country: 'RU',
+    series: '4512',
+    number: '123456',
+    issue_date: '1990-01-01',
+    issuing_authority: 'OVD',
+    issuing_authority_code: '770-000',
+  };
+  await expect(service.createForUser('u2', data, 'admin')).rejects.toThrow(
+    'invalid_issue_date'
+  );
+});

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -138,3 +138,17 @@ test('updateUser throws when missing', async () => {
   findByPkMock.mockResolvedValue(null);
   await expect(service.updateUser('1', {})).rejects.toThrow('user_not_found');
 });
+
+test('createUser rejects birth date before 1945', async () => {
+  await expect(
+    service.createUser({
+      phone: '123',
+      email: 'e',
+      last_name: 'L',
+      first_name: 'F',
+      patronymic: 'P',
+      birth_date: '1940-01-01',
+      password: 'p',
+    })
+  ).rejects.toThrow('invalid_birth_date');
+});


### PR DESCRIPTION
## Summary
- enforce minimum birth year and passport issue date in validators and services
- test validation of birth date and passport issue date

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed521886c832db355eafb837f1677