### PR TITLE
Enhance awaiting confirmation screen

### DIFF
--- a/client/src/views/AwaitingConfirmation.vue
+++ b/client/src/views/AwaitingConfirmation.vue
@@ -1,9 +1,27 @@
 <script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { apiFetch } from '../api.js'
-import { clearAuth } from '../auth.js'
+import { clearAuth, fetchCurrentUser, auth } from '../auth.js'
+import logo from '../assets/fhm-logo.svg'
 
 const router = useRouter()
+const checking = ref(false)
+let intervalId
+
+async function checkStatus() {
+  checking.value = true
+  try {
+    await fetchCurrentUser()
+    if (auth.user?.status !== 'AWAITING_CONFIRMATION') {
+      router.push('/')
+    }
+  } catch (_) {
+    // ignore errors
+  } finally {
+    checking.value = false
+  }
+}
 
 function logout() {
   apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
@@ -12,13 +30,48 @@ function logout() {
     router.push('/login')
   })
 }
+
+onMounted(() => {
+  checkStatus()
+  intervalId = setInterval(checkStatus, 30000)
+})
+
+onUnmounted(() => {
+  clearInterval(intervalId)
+})
 </script>
 
 <template>
-  <div class="d-flex flex-column align-items-center justify-content-center vh-100 text-center">
-    <h1 class="mb-4">Заявка отправлена</h1>
-    <p class="mb-3">Ваша регистрация завершена и ожидает проверки администратором.</p>
-    <p class="mb-4">После подтверждения вам станет доступен портал.</p>
-    <button class="btn btn-secondary" @click="logout">Выйти</button>
+  <div class="d-flex align-items-center justify-content-center vh-100">
+    <div class="card p-4 shadow login-card w-100 text-center" style="max-width: 420px;">
+      <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
+      <h2 class="mb-3">Заявка отправлена</h2>
+      <p class="mb-3">Ваша регистрация завершена и ожидает проверки администратором.</p>
+      <p class="mb-4">После подтверждения вам станет доступен портал.</p>
+      <div class="d-flex justify-content-center gap-2">
+        <button class="btn btn-outline-primary" @click="checkStatus" :disabled="checking">
+          <span v-if="checking" class="spinner-border spinner-border-sm me-2"></span>
+          Проверить статус
+        </button>
+        <button class="btn btn-secondary" @click="logout">Выйти</button>
+      </div>
+    </div>
   </div>
 </template>
+
+<style scoped>
+.login-card {
+  animation: fade-in 0.4s ease-out;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -61,10 +61,11 @@ export default {
 
   /* GET /auth/me */
   async me(req, res) {
-    const roles = (await req.user.getRoles({ attributes: ['alias'] })).map(
+    const user = await req.user.reload({ include: [UserStatus] });
+    const roles = (await user.getRoles({ attributes: ['alias'] })).map(
       (r) => r.alias
     );
-    return res.json({ user: userMapper.toPublic(req.user), roles });
+    return res.json({ user: userMapper.toPublic(user), roles });
   },
 
   /* POST /auth/refresh */

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -178,16 +178,27 @@ test('logout clears refresh cookie', async () => {
   expect(res.json).toHaveBeenCalledWith({ message: 'Logged out' });
 });
 
-test('me returns sanitized user', async () => {
+test('me returns sanitized user with status', async () => {
+  const loaded = {
+    id: '1',
+    getRoles: jest.fn().mockResolvedValue([{ alias: 'ADMIN' }]),
+    UserStatus: { alias: 'AWAITING_CONFIRMATION' },
+  };
   const req = {
-    user: { id: '1', password: 'hash', getRoles: jest.fn().mockResolvedValue([{ alias: 'ADMIN' }]) },
+    user: {
+      reload: jest.fn().mockResolvedValue(loaded),
+    },
   };
   const res = { json: jest.fn() };
 
   await authController.me(req, res);
 
-  expect(toPublicMock).toHaveBeenCalledWith(req.user);
-  expect(res.json).toHaveBeenCalledWith({ user: { id: '1' }, roles: ['ADMIN'] });
+  expect(req.user.reload).toHaveBeenCalled();
+  expect(toPublicMock).toHaveBeenCalledWith(loaded);
+  expect(res.json).toHaveBeenCalledWith({
+    user: { id: '1', status: 'AWAITING_CONFIRMATION' },
+    roles: ['ADMIN'],
+  });
 });
 
 test('refresh returns new tokens when valid', async () => {


### PR DESCRIPTION
## Summary
- improve the awaiting confirmation page to follow branded card layout
- add polling to check user status and auto redirect
- include FHM logo and button to manually recheck

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed61292d4832d9c2418ae03b879e1