### PR TITLE
Refine admin user management UI

### DIFF
--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -1,0 +1,20 @@
+:root {
+  --brand-color: #113867;
+}
+
+.btn-brand {
+  color: #fff;
+  background-color: var(--brand-color);
+  border-color: var(--brand-color);
+}
+.btn-brand:hover,
+.btn-brand:focus {
+  color: #fff;
+  background-color: #0d2747;
+  border-color: #0d2747;
+}
+
+.icon-brand {
+  color: var(--brand-color);
+}
+

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <nav class="navbar navbar-expand-md navbar-dark" :style="{ backgroundColor: '#113867' }">
+  <nav class="navbar navbar-expand-md navbar-dark" style="background-color: var(--brand-color)">
     <div class="container-fluid">
       <RouterLink class="navbar-brand d-flex align-items-center gap-2" to="/">
         <img :src="logo" alt="FHM" height="30" />

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -3,5 +3,6 @@ import App from './App.vue'
 import router from './router'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap'
+import './brand.css'
 
 createApp(App).use(router).mount('#app')

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { Toast } from 'bootstrap'
 
@@ -94,6 +94,19 @@ async function approveUser(id) {
   await loadUsers()
 }
 
+function statusClass(status) {
+  switch (status) {
+    case 'ACTIVE':
+      return 'bg-success'
+    case 'INACTIVE':
+      return 'bg-danger'
+    case 'AWAITING_CONFIRMATION':
+      return 'bg-warning text-dark'
+    default:
+      return 'bg-secondary'
+  }
+}
+
 function toggleSort(field) {
   if (sortField.value === field) {
     sortOrder.value = sortOrder.value === 'asc' ? 'desc' : 'asc'
@@ -135,6 +148,12 @@ function copy(text) {
 
 <template>
   <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Пользователи</li>
+      </ol>
+    </nav>
     <h1 class="mb-4">Пользователи</h1>
     <div class="row g-2 mb-3">
       <div class="col">
@@ -153,8 +172,10 @@ function copy(text) {
           <option value="AWAITING_CONFIRMATION">Требуют подтверждения</option>
         </select>
       </div>
-      <div class="col-auto">
-        <button class="btn btn-primary w-100" @click="openCreate">Добавить</button>
+      <div class="col-auto order-md-last">
+        <button class="btn btn-brand w-100" @click="openCreate">
+          <i class="bi bi-plus-lg me-1"></i>Добавить
+        </button>
       </div>
     </div>
     <div v-if="error" class="alert alert-danger">{{ error }}</div>
@@ -162,14 +183,17 @@ function copy(text) {
       <div class="spinner-border" role="status"></div>
     </div>
     <div class="table-responsive" v-if="users.length">
-      <table class="table table-hover align-middle">
+      <table class="table table-hover table-striped align-middle">
         <thead>
           <tr>
             <th @click="toggleSort('last_name')" class="sortable">
               ФИО
               <i
                 v-if="sortField === 'last_name'"
-                :class="sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill'"
+                :class="[
+                  sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill',
+                  'icon-brand'
+                ]"
               ></i>
             </th>
             <th
@@ -179,7 +203,10 @@ function copy(text) {
               Телефон
               <i
                 v-if="sortField === 'phone'"
-                :class="sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill'"
+                :class="[
+                  sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill',
+                  'icon-brand'
+                ]"
               ></i>
             </th>
             <th
@@ -189,7 +216,10 @@ function copy(text) {
               Email
               <i
                 v-if="sortField === 'email'"
-                :class="sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill'"
+                :class="[
+                  sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill',
+                  'icon-brand'
+                ]"
               ></i>
             </th>
             <th
@@ -199,7 +229,10 @@ function copy(text) {
               Дата рождения
               <i
                 v-if="sortField === 'birth_date'"
-                :class="sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill'"
+                :class="[
+                  sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill',
+                  'icon-brand'
+                ]"
               ></i>
             </th>
             <th class="d-none d-lg-table-cell">Роли</th>
@@ -207,7 +240,10 @@ function copy(text) {
               Статус
               <i
                 v-if="sortField === 'status'"
-                :class="sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill'"
+                :class="[
+                  sortOrder === 'asc' ? 'bi bi-caret-up-fill' : 'bi bi-caret-down-fill',
+                  'icon-brand'
+                ]"
               ></i>
             </th>
             <th></th>
@@ -231,7 +267,7 @@ function copy(text) {
                 >{{ name }}</span
               >
             </td>
-            <td><span class="badge bg-secondary">{{ u.status_name }}</span></td>
+            <td><span class="badge" :class="statusClass(u.status)">{{ u.status_name }}</span></td>
             <td class="text-end">
               <button class="btn btn-sm btn-secondary me-2" @click="openEdit(u)">
                 Редактировать
@@ -298,6 +334,9 @@ function copy(text) {
 <style scoped>
 .sortable {
   cursor: pointer;
+}
+.sortable:hover {
+  color: var(--brand-color);
 }
 .sortable i {
   margin-left: 4px;

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -88,9 +88,6 @@ const greeting = computed(() => {
   transform: none;
   box-shadow: none;
 }
-.icon-brand {
-  color: #113867;
-}
 .fade-in {
   animation: fadeIn 0.4s ease-out;
 }

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -59,12 +59,19 @@ async function listUsers(options = {}) {
       { email: { [Op.iLike]: term } },
     ];
   }
+  const include = [Role];
   if (options.status) {
-    where['$UserStatus.alias$'] = options.status;
+    include.push({
+      model: UserStatus,
+      where: { alias: options.status },
+      required: true,
+    });
+  } else {
+    include.push(UserStatus);
   }
 
   return User.findAndCountAll({
-    include: [Role, UserStatus],
+    include,
     where,
     order: [[sortField, sortOrder]],
     limit,

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -52,7 +52,13 @@ test('listUsers applies status filter', async () => {
   await service.listUsers({ status: 'ACTIVE' });
   expect(findAndCountAllMock).toHaveBeenCalledWith(
     expect.objectContaining({
-      where: expect.objectContaining({ '$UserStatus.alias$': 'ACTIVE' })
+      include: expect.arrayContaining([
+        expect.objectContaining({
+          model: expect.anything(),
+          where: { alias: 'ACTIVE' },
+          required: true,
+        }),
+      ]),
     })
   );
 });


### PR DESCRIPTION
## Summary
- load global brand styles
- colorize navbar using brand variables
- enhance Admin Users page with breadcrumb and styled sorting
- adjust buttons and status badges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ed6324b00832d8b1e607547723af6