### PR TITLE
Add ServiceError for standardized API errors

### DIFF
--- a/src/controllers/addressAdminController.js
+++ b/src/controllers/addressAdminController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import addressService from '../services/addressService.js';
 import addressMapper from '../mappers/addressMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async get(req, res) {
@@ -15,7 +16,7 @@ export default {
       }
       return res.json({ address: addressMapper.toPublic(addr) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -33,8 +34,7 @@ export default {
       );
       return res.status(201).json({ address: addressMapper.toPublic(addr) });
     } catch (err) {
-      const status = err.message === 'user_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -52,7 +52,7 @@ export default {
       );
       return res.json({ address: addressMapper.toPublic(addr) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -61,7 +61,7 @@ export default {
       await addressService.removeForUser(req.params.id, req.params.type);
       return res.status(204).end();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -5,6 +5,7 @@ import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie, clearRefreshCookie } from '../utils/cookie.js';
 import { COOKIE_NAME } from '../config/auth.js';
 import { UserStatus } from '../models/index.js';
+import { sendError } from '../utils/api.js';
 
 /* ---------- controller ---------------------------------------------------- */
 export default {
@@ -41,15 +42,8 @@ export default {
         roles,
         ...extra,
       });
-    } catch (_err) {
-      if (_err.message === 'account_locked') {
-        return res.status(401).json({
-          error:
-            'Аккаунт заблокирован из-за многократных неудачных попыток входа',
-        });
-      }
-      void _err;
-      return res.status(401).json({ error: 'Неверные учётные данные' });
+    } catch (err) {
+      return sendError(res, err, 401);
     }
   },
 
@@ -92,11 +86,8 @@ export default {
         user: userMapper.toPublic(user),
         roles,
       });
-    } catch (_err) {
-      void _err;
-      return res
-        .status(401)
-        .json({ error: 'Некорректный или истёкший токен обновления' });
+    } catch (err) {
+      return sendError(res, err, 401);
     }
   },
 };

--- a/src/controllers/bankAccountAdminController.js
+++ b/src/controllers/bankAccountAdminController.js
@@ -3,6 +3,7 @@ import { validationResult } from 'express-validator';
 import bankAccountService from '../services/bankAccountService.js';
 import dadataService from '../services/dadataService.js';
 import bankAccountMapper from '../mappers/bankAccountMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async get(req, res) {
@@ -13,7 +14,7 @@ export default {
       }
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -42,8 +43,7 @@ export default {
       );
       return res.status(201).json({ account: bankAccountMapper.toPublic(acc) });
     } catch (err) {
-      const status = err.message === 'user_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -72,7 +72,7 @@ export default {
       );
       return res.json({ account: bankAccountMapper.toPublic(acc) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -81,7 +81,7 @@ export default {
       await bankAccountService.removeForUser(req.params.id);
       return res.status(204).end();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/bankAccountSelfController.js
+++ b/src/controllers/bankAccountSelfController.js
@@ -3,6 +3,7 @@ import { validationResult } from 'express-validator';
 import bankAccountService from '../services/bankAccountService.js';
 import dadataService from '../services/dadataService.js';
 import bankAccountMapper from '../mappers/bankAccountMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async create(req, res) {
@@ -30,8 +31,7 @@ export default {
       );
       return res.status(201).json({ account: bankAccountMapper.toPublic(acc) });
     } catch (err) {
-      const status = err.message === 'user_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -40,7 +40,7 @@ export default {
       await bankAccountService.removeForUser(req.user.id);
       return res.status(204).end();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/innAdminController.js
+++ b/src/controllers/innAdminController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import innService from '../services/innService.js';
 import innMapper from '../mappers/innMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async get(req, res) {
@@ -12,7 +13,7 @@ export default {
       }
       return res.json({ inn: innMapper.toPublic(inn) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
   async create(req, res) {
@@ -28,7 +29,7 @@ export default {
       );
       return res.status(201).json({ inn: innMapper.toPublic(inn) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -45,7 +46,7 @@ export default {
       );
       return res.json({ inn: innMapper.toPublic(inn) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -54,7 +55,7 @@ export default {
       await innService.remove(req.params.id);
       return res.status(204).end();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/innController.js
+++ b/src/controllers/innController.js
@@ -4,6 +4,7 @@ import innService from '../services/innService.js';
 import innMapper from '../mappers/innMapper.js';
 import legacyService from '../services/legacyUserService.js';
 import { UserExternalId } from '../models/index.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async me(req, res) {
@@ -37,7 +38,7 @@ export default {
       );
       return res.status(201).json({ inn: innMapper.toPublic(inn) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/passportSelfController.js
+++ b/src/controllers/passportSelfController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import passportService from '../services/passportService.js';
 import passportMapper from '../mappers/passportMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async create(req, res) {
@@ -19,7 +20,7 @@ export default {
         .status(201)
         .json({ passport: passportMapper.toPublic(passport) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -28,7 +29,7 @@ export default {
       await passportService.removeByUser(req.user.id);
       return res.status(204).send();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/profileCompletionController.js
+++ b/src/controllers/profileCompletionController.js
@@ -1,4 +1,5 @@
 import userService from '../services/userService.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async complete(req, res) {
@@ -11,7 +12,7 @@ export default {
         user: { id: user.id, status: 'AWAITING_CONFIRMATION' },
       });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -24,7 +25,7 @@ export default {
       const user = await userService.setStatus(req.user.id, status);
       return res.json({ user: { id: user.id, status } });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -12,6 +12,7 @@ import bankAccountService from '../services/bankAccountService.js';
 import { ExternalSystem, UserExternalId } from '../models/index.js';
 import userMapper from '../mappers/userMapper.js';
 import { setRefreshCookie } from '../utils/cookie.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async start(req, res) {
@@ -40,7 +41,7 @@ export default {
     try {
       user = await userService.createUser(data);
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
 
     const system = await ExternalSystem.findOne({
@@ -90,12 +91,7 @@ export default {
         roles,
       });
     } catch (err) {
-      if (err.message === 'too_many_attempts') {
-        return res.status(400).json({
-          error: 'Слишком много неверных попыток подтверждения',
-        });
-      }
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/snilsAdminController.js
+++ b/src/controllers/snilsAdminController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import snilsService from '../services/snilsService.js';
 import snilsMapper from '../mappers/snilsMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async get(req, res) {
@@ -12,7 +13,7 @@ export default {
       }
       return res.json({ snils: snilsMapper.toPublic(snils) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
   async create(req, res) {
@@ -28,7 +29,7 @@ export default {
       );
       return res.status(201).json({ snils: snilsMapper.toPublic(snils) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -45,7 +46,7 @@ export default {
       );
       return res.json({ snils: snilsMapper.toPublic(snils) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -54,7 +55,7 @@ export default {
       await snilsService.remove(req.params.id);
       return res.status(204).end();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/snilsController.js
+++ b/src/controllers/snilsController.js
@@ -4,6 +4,7 @@ import snilsService from '../services/snilsService.js';
 import snilsMapper from '../mappers/snilsMapper.js';
 import legacyService from '../services/legacyUserService.js';
 import { UserExternalId } from '../models/index.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async me(req, res) {
@@ -37,7 +38,7 @@ export default {
       );
       return res.status(201).json({ snils: snilsMapper.toPublic(snils) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/taxationAdminController.js
+++ b/src/controllers/taxationAdminController.js
@@ -1,5 +1,6 @@
 import taxationService from '../services/taxationService.js';
 import taxationMapper from '../mappers/taxationMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async get(req, res) {
@@ -8,7 +9,7 @@ export default {
       if (!tax) return res.status(404).json({ error: 'taxation_not_found' });
       return res.json({ taxation: taxationMapper.toPublic(tax) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -22,8 +23,7 @@ export default {
       const preview = await taxationService.previewForUser(req.params.id, opts);
       return res.json({ preview: taxationMapper.toPublic(preview) });
     } catch (err) {
-      const status = err.message === 'inn_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -35,8 +35,7 @@ export default {
       );
       return res.json({ taxation: taxationMapper.toPublic(tax) });
     } catch (err) {
-      const status = err.message === 'inn_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/taxationController.js
+++ b/src/controllers/taxationController.js
@@ -1,5 +1,6 @@
 import taxationService from '../services/taxationService.js';
 import taxationMapper from '../mappers/taxationMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async me(req, res) {
@@ -20,8 +21,7 @@ export default {
       const preview = await taxationService.previewForUser(req.user.id, opts);
       return res.json({ preview: taxationMapper.toPublic(preview) });
     } catch (err) {
-      const status = err.message === 'inn_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -30,8 +30,7 @@ export default {
       const tax = await taxationService.updateForUser(req.user.id, req.user.id);
       return res.json({ taxation: taxationMapper.toPublic(tax) });
     } catch (err) {
-      const status = err.message === 'inn_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -4,6 +4,7 @@ import userService from '../services/userService.js';
 import passportService from '../services/passportService.js';
 import userMapper from '../mappers/userMapper.js';
 import passportMapper from '../mappers/passportMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async list(req, res) {
@@ -34,7 +35,7 @@ export default {
       const user = await userService.getUser(req.params.id);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
   async create(req, res) {
@@ -55,7 +56,7 @@ export default {
       const user = await userService.updateUser(req.params.id, req.body);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -64,7 +65,7 @@ export default {
       const user = await userService.setStatus(req.params.id, 'INACTIVE');
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -73,7 +74,7 @@ export default {
       const user = await userService.setStatus(req.params.id, 'ACTIVE');
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -82,7 +83,7 @@ export default {
       const user = await userService.setStatus(req.params.id, 'ACTIVE');
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -98,7 +99,7 @@ export default {
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -110,7 +111,7 @@ export default {
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -122,7 +123,7 @@ export default {
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -141,8 +142,7 @@ export default {
         .status(201)
         .json({ passport: passportMapper.toPublic(passport) });
     } catch (err) {
-      const status = err.message === 'user_not_found' ? 404 : 400;
-      return res.status(status).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 
@@ -153,7 +153,7 @@ export default {
         return res.status(404).json({ error: 'passport_not_found' });
       return res.json({ passport: passportMapper.toPublic(passport) });
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 
@@ -162,7 +162,7 @@ export default {
       await passportService.removeByUser(req.params.id);
       return res.status(204).send();
     } catch (err) {
-      return res.status(404).json({ error: err.message });
+      return sendError(res, err, 404);
     }
   },
 };

--- a/src/controllers/userEmailController.js
+++ b/src/controllers/userEmailController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import emailVerificationService from '../services/emailVerificationService.js';
 import userMapper from '../mappers/userMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async send(req, res) {
@@ -23,12 +24,7 @@ export default {
       const user = await req.user.reload();
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      if (err.message === 'too_many_attempts') {
-        return res.status(400).json({
-          error: 'Слишком много неверных попыток подтверждения',
-        });
-      }
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/controllers/userSelfController.js
+++ b/src/controllers/userSelfController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import userService from '../services/userService.js';
 import userMapper from '../mappers/userMapper.js';
+import { sendError } from '../utils/api.js';
 
 export default {
   async update(req, res) {
@@ -13,7 +14,7 @@ export default {
       const user = await userService.updateUser(req.user.id, req.body);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
-      return res.status(400).json({ error: err.message });
+      return sendError(res, err);
     }
   },
 };

--- a/src/errors/ServiceError.js
+++ b/src/errors/ServiceError.js
@@ -1,0 +1,7 @@
+export default class ServiceError extends Error {
+  constructor(code, status = 400, message) {
+    super(message || code);
+    this.code = code;
+    this.status = status;
+  }
+}

--- a/src/services/snilsService.js
+++ b/src/services/snilsService.js
@@ -1,6 +1,7 @@
 import { Op } from 'sequelize';
 
 import { Snils } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
 
 async function getByUser(userId) {
   return Snils.findOne({ where: { user_id: userId } });
@@ -8,7 +9,7 @@ async function getByUser(userId) {
 
 async function create(userId, number, actorId) {
   const existing = await Snils.findOne({ where: { number } });
-  if (existing) throw new Error('snils_exists');
+  if (existing) throw new ServiceError('snils_exists');
   return Snils.create({
     user_id: userId,
     number,
@@ -24,15 +25,15 @@ async function update(userId, number, actorId) {
       where: { number, user_id: { [Op.ne]: userId } },
     }),
   ]);
-  if (!snils) throw new Error('snils_not_found');
-  if (duplicate) throw new Error('snils_exists');
+  if (!snils) throw new ServiceError('snils_not_found', 404);
+  if (duplicate) throw new ServiceError('snils_exists');
   await snils.update({ number, updated_by: actorId });
   return snils;
 }
 
 async function remove(userId) {
   const snils = await Snils.findOne({ where: { user_id: userId } });
-  if (!snils) throw new Error('snils_not_found');
+  if (!snils) throw new ServiceError('snils_not_found', 404);
   await snils.destroy();
 }
 

--- a/src/services/taxationService.js
+++ b/src/services/taxationService.js
@@ -1,4 +1,5 @@
 import { Taxation, TaxationType, Inn } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
 
 import dadataService from './dadataService.js';
 import fnsService from './fnsService.js';
@@ -88,13 +89,13 @@ async function removeByUser(userId) {
 
 async function previewForUser(userId, opts) {
   const inn = await Inn.findOne({ where: { user_id: userId } });
-  if (!inn) throw new Error('inn_not_found');
+  if (!inn) throw new ServiceError('inn_not_found', 404);
   return fetchByInn(inn.number, opts);
 }
 
 async function updateForUser(userId, actorId) {
   const inn = await Inn.findOne({ where: { user_id: userId } });
-  if (!inn) throw new Error('inn_not_found');
+  if (!inn) throw new ServiceError('inn_not_found', 404);
   return updateByInn(userId, inn.number, actorId);
 }
 

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,5 @@
+export function sendError(res, err, defaultStatus = 400) {
+  const status = err?.status || defaultStatus;
+  const code = err?.code || err?.message || 'internal_error';
+  return res.status(status).json({ error: code });
+}

--- a/src/utils/jwt.js
+++ b/src/utils/jwt.js
@@ -1,4 +1,5 @@
 import jwt from 'jsonwebtoken';
+import ServiceError from '../errors/ServiceError.js';
 
 import {
   JWT_SECRET,
@@ -30,7 +31,7 @@ export function verifyAccessToken(token) {
 export function verifyRefreshToken(token) {
   const payload = jwt.verify(token, JWT_SECRET, { algorithms: [JWT_ALG] });
   if (payload.type !== 'refresh') {
-    throw new Error('invalid_token_type');
+    throw new ServiceError('invalid_token_type', 401);
   }
   return payload;
 }


### PR DESCRIPTION
## Summary
- introduce `ServiceError` class for services
- provide `sendError` helper for controllers
- refactor services to throw `ServiceError`
- refactor controllers to use `sendError`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee3345248832d82f82e7c6696cff8