### PR TITLE
Add env validation

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -10,8 +10,11 @@ import debugLib from 'debug';
 import app from '../app.js';
 import { connectToDatabase } from '../src/config/database.js';
 import { connectLegacyDatabase } from '../src/config/legacyDatabase.js';
+import validateEnv from '../src/config/validateEnv.js';
 
 const debug = debugLib('fhmoscow-pulse:server');
+
+validateEnv();
 
 /**
  * Get port from environment and store in Express.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "express-rate-limit": "^7.5.0",
         "express-validator": "^7.2.1",
         "helmet": "^8.1.0",
+        "joi": "^17.9.2",
         "jsonwebtoken": "^9.0.2",
         "morgan": "~1.9.1",
         "mysql2": "^3.14.1",
@@ -709,6 +710,21 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hapi/hoek": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
+      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@hapi/topo": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
+      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1700,6 +1716,27 @@
       "version": "1.4.0",
       "hasInstallScript": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.33",
@@ -6835,6 +6872,19 @@
       "version": "0.27.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/joi": {
+      "version": "17.9.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
+      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/topo": "^5.0.0",
+        "@sideway/address": "^4.1.3",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
+      }
     },
     "node_modules/js-beautify": {
       "version": "1.15.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express-rate-limit": "^7.5.0",
     "express-validator": "^7.2.1",
     "helmet": "^8.1.0",
+    "joi": "^17.9.2",
     "jsonwebtoken": "^9.0.2",
     "morgan": "~1.9.1",
     "mysql2": "^3.14.1",

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -1,0 +1,26 @@
+import Joi from 'joi';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const schema = Joi.object({
+  DB_HOST: Joi.string().required(),
+  DB_PORT: Joi.string().required(),
+  DB_NAME: Joi.string().required(),
+  DB_USER: Joi.string().required(),
+  DB_PASS: Joi.string().required(),
+  LEGACY_DB_HOST: Joi.string().required(),
+  LEGACY_DB_PORT: Joi.string().required(),
+  LEGACY_DB_NAME: Joi.string().required(),
+  LEGACY_DB_USER: Joi.string().required(),
+  LEGACY_DB_PASS: Joi.string().required(),
+  JWT_SECRET: Joi.string().required(),
+}).unknown(true);
+
+export default function validateEnv() {
+  const { error } = schema.validate(process.env);
+  if (error) {
+    console.error(`Invalid environment configuration: ${error.message}`);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- validate required environment variables on startup
- call the validator when launching the server
- include joi dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ee31c5c30832d9023d98b06f92950