### PR TITLE
Use logger for DB connection messages

### DIFF
--- a/src/config/database.js
+++ b/src/config/database.js
@@ -26,11 +26,12 @@ const sequelize = new Sequelize(
  * Call this once at app bootstrap (e.g. in app.js) and fail fast on error.
  */
 export async function connectToDatabase() {
+  const { default: logger } = await import('../../logger.js');
   try {
     await sequelize.authenticate();
-    console.log('✅ DB connection established');
+    logger.info('✅ DB connection established');
   } catch (error) {
-    console.error('❌ Unable to connect to DB:', error);
+    logger.error('❌ Unable to connect to DB:', error);
     process.exit(1);
   }
 }

--- a/src/config/legacyDatabase.js
+++ b/src/config/legacyDatabase.js
@@ -14,11 +14,12 @@ const legacyPool = mysql.createPool({
 });
 
 export async function connectLegacyDatabase() {
+  const { default: logger } = await import('../../logger.js');
   try {
     await legacyPool.query('SELECT 1');
-    console.log('✅ Legacy DB connection established');
+    logger.info('✅ Legacy DB connection established');
   } catch (err) {
-    console.error('❌ Unable to connect to legacy DB:', err);
+    logger.error('❌ Unable to connect to legacy DB:', err);
     process.exit(1);
   }
 }

--- a/tests/database.test.js
+++ b/tests/database.test.js
@@ -17,6 +17,13 @@ jest.unstable_mockModule('dotenv', () => ({
   default: { config: jest.fn() },
 }));
 
+const infoMock = jest.fn();
+const errorMock = jest.fn();
+jest.unstable_mockModule('../logger.js', () => ({
+  __esModule: true,
+  default: { info: infoMock, error: errorMock },
+}));
+
 // eslint-disable-next-line no-undef
 process.env.DB_NAME = 'db';
 // eslint-disable-next-line no-undef


### PR DESCRIPTION
## Summary
- remove console usage in database and legacyDatabase modules
- mock logger in database tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ee31e1900832d88f8e342a4f00ea3