### PR TITLE
Use logger for warnings and log email success

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -70,7 +70,7 @@ const logger = createLogger({
               response_time: parsed.respTime,
             });
           } catch (err) {
-            console.warn('DB log persistence failed:', err.message);
+            logger.warn('DB log persistence failed:', err.message);
           } finally {
             cb();
           }

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -1,4 +1,5 @@
 import nodemailer from 'nodemailer';
+import logger from '../../logger.js';
 
 import {
   SMTP_HOST,
@@ -17,7 +18,7 @@ const transporter = nodemailer.createTransport({
 
 export async function sendMail(to, subject, text) {
   if (!SMTP_HOST) {
-    console.warn('Email not configured');
+    logger.warn('Email not configured');
     return;
   }
   await transporter.sendMail({
@@ -26,6 +27,7 @@ export async function sendMail(to, subject, text) {
     subject,
     text,
   });
+  logger.info('Email sent to %s', to);
 }
 
 export async function sendVerificationEmail(user, code) {


### PR DESCRIPTION
## Summary
- replace `console.warn` with `logger.warn`
- add info log after sending mail successfully

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ee3396a50832dba549c4bb1696bf3