### PR TITLE
Fix awaiting confirmation layout overflow

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -5,7 +5,7 @@ import NavBar from './components/NavBar.vue'
 import FooterBar from './components/FooterBar.vue'
 
 const route = useRoute()
-const showLayout = computed(() => !['/login', '/register'].includes(route.path))
+const showLayout = computed(() => !route.meta.hideLayout)
 const mainClass = computed(() =>
   showLayout.value ? 'flex-grow-1 container py-3' : 'flex-grow-1'
 )

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -18,10 +18,14 @@ const routes = [
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/login', component: Login },
-  { path: '/register', component: Register },
+  { path: '/login', component: Login, meta: { hideLayout: true } },
+  { path: '/register', component: Register, meta: { hideLayout: true } },
   { path: '/complete-profile', component: ProfileWizard, meta: { requiresAuth: true } },
-  { path: '/awaiting-confirmation', component: AwaitingConfirmation, meta: { requiresAuth: true } }
+  {
+    path: '/awaiting-confirmation',
+    component: AwaitingConfirmation,
+    meta: { requiresAuth: true, hideLayout: true }
+  }
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- hide NavBar and footer on login, register, and awaiting confirmation pages
- compute layout visibility based on `route.meta.hideLayout`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685ee931483c832d978a68cbf36f661c