### PR TITLE
Add password complexity meter to reset page

### DIFF
--- a/client/src/components/PasswordStrengthMeter.vue
+++ b/client/src/components/PasswordStrengthMeter.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <div class="progress" style="height: 6px;">
+      <div
+        class="progress-bar"
+        :class="strengthClass"
+        :style="{ width: strengthPercent + '%' }"
+      ></div>
+    </div>
+    <small class="text-muted password-strength-label">{{ strengthLabel }}</small>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  password: {
+    type: String,
+    default: ''
+  }
+})
+
+const strength = computed(() => {
+  const val = props.password || ''
+  let score = 0
+  if (val.length >= 8) score++
+  if (/[A-Z]/.test(val)) score++
+  if (/[0-9]/.test(val)) score++
+  if (/[^A-Za-z0-9]/.test(val)) score++
+  if (val.length >= 12) score++
+  return score
+})
+
+const strengthPercent = computed(() => (strength.value / 5) * 100)
+
+const strengthLabel = computed(() => {
+  if (strength.value <= 1) return 'Слабый'
+  if (strength.value === 2) return 'Средний'
+  if (strength.value === 3) return 'Хороший'
+  return 'Сильный'
+})
+
+const strengthClass = computed(() => {
+  if (strength.value <= 1) return 'bg-danger'
+  if (strength.value === 2) return 'bg-warning'
+  if (strength.value === 3) return 'bg-info'
+  return 'bg-success'
+})
+</script>
+
+<style scoped>
+.password-strength-label {
+  font-size: 0.875rem;
+}
+</style>

--- a/client/src/views/PasswordReset.vue
+++ b/client/src/views/PasswordReset.vue
@@ -2,6 +2,7 @@
 import { ref, watch } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
+import PasswordStrengthMeter from '../components/PasswordStrengthMeter.vue'
 
 const router = useRouter()
 const step = ref(1)
@@ -113,6 +114,7 @@ async function finish() {
           />
           <label for="password">Новый пароль</label>
         </div>
+        <PasswordStrengthMeter class="mb-3" :password="password" />
         <div class="form-floating mb-3">
           <input
             id="confirm"

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, watch, computed } from 'vue'
+import { ref, watch } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { auth } from '../auth.js'
+import PasswordStrengthMeter from '../components/PasswordStrengthMeter.vue'
 
 const router = useRouter()
 const step = ref(1)
@@ -13,32 +14,6 @@ const confirm = ref('')
 const error = ref('')
 const loading = ref(false)
 
-const strength = computed(() => {
-  const val = password.value
-  let score = 0
-  if (val.length >= 8) score++
-  if (/[A-Z]/.test(val)) score++
-  if (/[0-9]/.test(val)) score++
-  if (/[^A-Za-z0-9]/.test(val)) score++
-  if (val.length >= 12) score++
-  return score
-})
-
-const strengthPercent = computed(() => (strength.value / 5) * 100)
-
-const strengthLabel = computed(() => {
-  if (strength.value <= 1) return 'Слабый'
-  if (strength.value === 2) return 'Средний'
-  if (strength.value === 3) return 'Хороший'
-  return 'Сильный'
-})
-
-const strengthClass = computed(() => {
-  if (strength.value <= 1) return 'bg-danger'
-  if (strength.value === 2) return 'bg-warning'
-  if (strength.value === 3) return 'bg-info'
-  return 'bg-success'
-})
 
 watch(error, (val) => {
   if (val) {
@@ -146,16 +121,7 @@ async function finish() {
           />
           <label for="password">Пароль</label>
         </div>
-        <div class="mb-3">
-          <div class="progress" style="height: 6px;">
-            <div
-              class="progress-bar"
-              :class="strengthClass"
-              :style="{ width: strengthPercent + '%' }"
-            ></div>
-          </div>
-          <small class="text-muted password-strength-label">{{ strengthLabel }}</small>
-        </div>
+        <PasswordStrengthMeter class="mb-3" :password="password" />
         <div class="form-floating mb-3">
           <input
             id="confirm"
@@ -182,9 +148,6 @@ async function finish() {
   animation: fade-in 0.4s ease-out;
 }
 
-.password-strength-label {
-  font-size: 0.875rem;
-}
 
 @keyframes fade-in {
   from {


### PR DESCRIPTION
## Summary
- create `PasswordStrengthMeter` component
- reuse it on register and reset forms

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685eef20ac3c832da633b069f52051b2