### PR TITLE
Unify password reset email

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ DADATA_SECRET=your_dadata_secret
 # RATE_LIMIT_MAX=100
 ```
 
-Приложение отправляет HTML-письма для подтверждения адреса электронной почты.
-Настроить внешний вид и текст письма можно в файле
-`src/templates/verificationEmail.js`.
+Приложение отправляет HTML-письма для подтверждения электронной почты и сброса
+пароля. Настроить внешний вид и текст этих писем можно в файлах
+`src/templates/verificationEmail.js` и `src/templates/passwordResetEmail.js`.
 
 `PASSWORD_MIN_LENGTH` and `PASSWORD_PATTERN` allow customizing the
 password policy for user registration. By default passwords must be at

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -8,7 +8,10 @@ import {
   SMTP_PASS,
   EMAIL_FROM,
 } from '../config/email.js';
-import { renderVerificationEmail } from '../templates/verificationEmail.js';
+import {
+  renderVerificationEmail,
+} from '../templates/verificationEmail.js';
+import { renderPasswordResetEmail } from '../templates/passwordResetEmail.js';
 
 const transporter = nodemailer.createTransport({
   host: SMTP_HOST,
@@ -38,8 +41,8 @@ export async function sendVerificationEmail(user, code) {
 }
 
 export async function sendPasswordResetEmail(user, code) {
-  const text = `Your password reset code: ${code}`;
-  await sendMail(user.email, 'Password reset', text);
+  const { subject, text, html } = renderPasswordResetEmail(code);
+  await sendMail(user.email, subject, text, html);
 }
 
 export default { sendMail, sendVerificationEmail, sendPasswordResetEmail };

--- a/src/templates/passwordResetEmail.js
+++ b/src/templates/passwordResetEmail.js
@@ -1,0 +1,17 @@
+export function renderPasswordResetEmail(code) {
+  const subject = 'Сброс пароля';
+  const text =
+    `Ваш код для сброса пароля: ${code}\n\n` +
+    'Если вы не запрашивали этот код, просто проигнорируйте письмо.';
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">Для сброса пароля используйте код:</p>
+      <p style="font-size:24px;font-weight:bold;letter-spacing:4px;margin:0 0 16px;">${code}</p>
+      <p style="font-size:14px;margin:0 0 16px;">Код действует 15&nbsp;минут.</p>
+      <p style="font-size:12px;color:#777;margin:0;">Если вы не запрашивали этот код, просто проигнорируйте письмо.</p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderPasswordResetEmail };

--- a/tests/passwordResetService.test.js
+++ b/tests/passwordResetService.test.js
@@ -1,0 +1,57 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const createMock = jest.fn();
+const destroyMock = jest.fn();
+const findOneMock = jest.fn();
+const sendEmailMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  EmailCode: { create: createMock, destroy: destroyMock, findOne: findOneMock },
+}));
+
+jest.unstable_mockModule('../src/services/emailService.js', () => ({
+  __esModule: true,
+  default: { sendPasswordResetEmail: sendEmailMock },
+}));
+
+import * as attemptStore from '../src/services/emailCodeAttempts.js';
+
+const { sendCode, verifyCode } = await import('../src/services/passwordResetService.js');
+
+beforeEach(() => {
+  createMock.mockClear();
+  destroyMock.mockClear();
+  findOneMock.mockClear();
+  sendEmailMock.mockClear();
+  attemptStore._reset();
+});
+
+test('sendCode stores plain code and sends email', async () => {
+  const user = { id: '1' };
+  await sendCode(user);
+  expect(createMock).toHaveBeenCalled();
+  const data = createMock.mock.calls[0][0];
+  expect(data.user_id).toBe('1');
+  expect(data.code).toMatch(/^\d{6}$/);
+  expect(sendEmailMock).toHaveBeenCalledWith(user, expect.any(String));
+});
+
+test('verifyCode succeeds with correct code', async () => {
+  const user = { id: '1' };
+  findOneMock.mockResolvedValue({ code: '123456' });
+  destroyMock.mockResolvedValue();
+  await verifyCode(user, '123456');
+  expect(attemptStore.get('1')).toBe(0);
+});
+
+test('verifyCode counts failed attempts and locks after five', async () => {
+  const user = { id: '1' };
+  findOneMock.mockResolvedValue(null);
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('invalid_code');
+  await expect(verifyCode(user, '111111')).rejects.toThrow('too_many_attempts');
+  expect(attemptStore.get('1')).toBe(5);
+});


### PR DESCRIPTION
## Summary
- send password reset emails with same HTML layout as verification emails
- document both templates in README
- test password reset email logic

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685eef0a3664832d99af9af01c3dad3b