### PR TITLE
Fix layout visibility logic

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -5,9 +5,7 @@ import NavBar from './components/NavBar.vue'
 import FooterBar from './components/FooterBar.vue'
 
 const route = useRoute()
-const showLayout = computed(() =>
-  !['/login', '/register', '/password-reset', '/awaiting-confirmation'].includes(route.path)
-)
+const showLayout = computed(() => !route.matched.some((r) => r.meta.hideLayout))
 const mainClass = computed(() =>
   showLayout.value ? 'flex-grow-1 container py-3' : 'flex-grow-1'
 )

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -19,7 +19,7 @@ const routes = [
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/password-reset', component: PasswordReset },
+  { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },
   { path: '/register', component: Register, meta: { hideLayout: true } },
   { path: '/complete-profile', component: ProfileWizard, meta: { requiresAuth: true } },


### PR DESCRIPTION
## Summary
- rely on route meta to hide layout
- mark password reset screen to hide layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685eeeef8680832d8af6ae759e667441