### PR TITLE
Implement configurable CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ DADATA_SECRET=your_dadata_secret
 # REGISTRATION_RATE_MAX=5
 # RATE_LIMIT_WINDOW_MS=900000
 # RATE_LIMIT_MAX=100
+# ALLOWED_ORIGINS=http://localhost:5173,http://example.com
 ```
 
 Приложение отправляет HTML-письма для подтверждения электронной почты и сброса

--- a/app.js
+++ b/app.js
@@ -8,13 +8,27 @@ import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
 import rateLimiter from './src/middlewares/rateLimiter.js';
 import swaggerSpec from './src/docs/swagger.js';
+import { ALLOWED_ORIGINS } from './src/config/cors.js';
 
 const app = express();
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 app.use(cookieParser());
-app.use(cors({ origin: true, credentials: true }));
+const corsOptions = {
+  origin(origin, callback) {
+    if (!origin) {
+      return callback(null, true);
+    }
+    if (ALLOWED_ORIGINS.length === 0 || ALLOWED_ORIGINS.includes(origin)) {
+      return callback(null, true);
+    }
+    return callback(new Error('Not allowed by CORS'));
+  },
+  credentials: true,
+};
+
+app.use(cors(corsOptions));
 app.use(helmet());
 app.use(rateLimiter);
 app.use(requestLogger);

--- a/src/config/cors.js
+++ b/src/config/cors.js
@@ -1,0 +1,8 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const ALLOWED_ORIGINS = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(',').map((origin) => origin.trim()).filter(Boolean)
+  : [];
+


### PR DESCRIPTION
## Summary
- parse `ALLOWED_ORIGINS` env var in a new `src/config/cors.js`
- gate CORS requests against this list in `app.js`
- document the new variable in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef2bba47c832d927e17b7573a30ee