### PR TITLE
Use crypto.randomInt for code generation

### DIFF
--- a/src/services/emailVerificationService.js
+++ b/src/services/emailVerificationService.js
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Op } from 'sequelize';
+import crypto from 'crypto';
 
 import { EmailCode, UserStatus } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
@@ -8,7 +9,7 @@ import emailService from './emailService.js';
 import * as attempts from './emailCodeAttempts.js';
 
 function generateCode() {
-  return String(Math.floor(100000 + Math.random() * 900000));
+  return String(crypto.randomInt(100000, 1000000));
 }
 
 export async function sendCode(user) {

--- a/src/services/passwordResetService.js
+++ b/src/services/passwordResetService.js
@@ -1,5 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Op } from 'sequelize';
+import crypto from 'crypto';
 
 import { EmailCode } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
@@ -8,7 +9,7 @@ import emailService from './emailService.js';
 import * as attempts from './emailCodeAttempts.js';
 
 function generateCode() {
-  return String(Math.floor(100000 + Math.random() * 900000));
+  return String(crypto.randomInt(100000, 1000000));
 }
 
 export async function sendCode(user) {


### PR DESCRIPTION
## Summary
- use `crypto.randomInt` instead of `Math.random` for verification and password reset codes
- import `crypto` in the service files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef2bdf8ec832dbfa2993c9ba9f8be