### PR TITLE
Pin Node and Postgres versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ############################
 # 1️⃣ Build & verify stage #
 ############################
-FROM node:latest AS build
+FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 COPY package*.json ./
@@ -15,9 +15,9 @@ RUN npm run lint
 ###########################
 # 2️⃣  Production stage   #
 ###########################
-FROM node:latest AS prod
+FROM node:20-alpine AS prod
 
-RUN apt-get update &&  apt-get upgrade -y && npm install -g npm && apt-get install -y --no-install-recommends postgresql-client && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache postgresql-client && npm install -g npm
 
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,13 +1,11 @@
 ############################
 # 1️⃣ Build stage          #
 ############################
-FROM node:latest AS build
+FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 
 # Install build deps for optional native addons (rollup, esbuild, etc.)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends python3 make g++ && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache python3 make g++
 
 # Install dependencies
 COPY package*.json ./
@@ -20,7 +18,7 @@ RUN npm run build
 ############################
 # 2️⃣ Production stage     #
 ############################
-FROM node:latest AS prod
+FROM node:20-alpine AS prod
 WORKDIR /usr/src/app
 
 # Copy only runtime files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - backend
 
   db:
-    image: postgres:17
+    image: postgres:17.0
     container_name: db
     ports:
       - "5432:5432"


### PR DESCRIPTION
## Summary
- use Node `20-alpine` image for building and running server
- update client Dockerfile to use Node `20-alpine`
- switch from apt to apk package installs for Alpine base
- pin Postgres image to `17.0`

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef3111068832d8616a746a7f10789