### PR TITLE
Store auth tokens in memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - Express server with modular routing
 - PostgreSQL database managed with Sequelize
 - JSON Web Token authentication and refresh tokens
+- Access token kept only in memory and refreshed on startup when a refresh cookie is present
 - Security headers using `helmet`
 - Request/response logging persisted to the `logs` table
 - Swagger documentation available at `/api-docs`

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,15 +1,28 @@
 import { translateError } from './errors.js';
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:3000';
 
+let accessToken = null;
+
+export function setAccessToken(token) {
+  accessToken = token;
+}
+
+export function clearAccessToken() {
+  accessToken = null;
+}
+
+export function getAccessToken() {
+  return accessToken;
+}
+
 export async function apiFetch(path, options = {}) {
   const opts = { credentials: 'include', ...options };
   opts.headers = {
     'Content-Type': 'application/json',
     ...(opts.headers || {}),
   };
-  const token = localStorage.getItem('access_token');
-  if (token) {
-    opts.headers['Authorization'] = `Bearer ${token}`;
+  if (accessToken) {
+    opts.headers['Authorization'] = `Bearer ${accessToken}`;
   }
 
   let res;

--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -48,7 +48,6 @@ onMounted(async () => {
 
 function logout() {
   apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
-    localStorage.removeItem('access_token')
     clearAuth()
     router.push('/login')
   })

--- a/client/src/main.js
+++ b/client/src/main.js
@@ -4,5 +4,8 @@ import router from './router'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import 'bootstrap'
 import './brand.css'
+import { refreshFromCookie } from './auth.js'
 
-createApp(App).use(router).mount('#app')
+refreshFromCookie().finally(() => {
+  createApp(App).use(router).mount('#app')
+})

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -3,7 +3,7 @@ import Login from './views/Login.vue'
 import Register from './views/Register.vue'
 import ProfileWizard from './views/ProfileWizard.vue'
 import AwaitingConfirmation from './views/AwaitingConfirmation.vue'
-import { auth, fetchCurrentUser } from './auth.js'
+import { auth, fetchCurrentUser, clearAuth } from './auth.js'
 import Home from './views/Home.vue'
 import Profile from './views/Profile.vue'
 import AdminUsers from './views/AdminUsers.vue'
@@ -36,13 +36,13 @@ const router = createRouter({
 })
 
 router.beforeEach(async (to, _from, next) => {
-  const isAuthenticated = !!localStorage.getItem('access_token')
-  const roles = JSON.parse(localStorage.getItem('roles') || '[]')
+  const isAuthenticated = !!auth.token
+  const roles = auth.roles
   if (isAuthenticated && !auth.user) {
     try {
       await fetchCurrentUser()
     } catch (_) {
-      localStorage.removeItem('access_token')
+      clearAuth()
       return next('/login')
     }
   }

--- a/client/src/views/AwaitingConfirmation.vue
+++ b/client/src/views/AwaitingConfirmation.vue
@@ -25,7 +25,6 @@ async function checkStatus() {
 
 function logout() {
   apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
-    localStorage.removeItem('access_token')
     clearAuth()
     router.push('/login')
   })

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -3,7 +3,7 @@ import { ref, watch } from 'vue'
 import CookieNotice from '../components/CookieNotice.vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
-import { auth } from '../auth.js'
+import { auth, setAuthToken } from '../auth.js'
 import logo from '../assets/fhm-logo.svg'
 
 const router = useRouter()
@@ -59,8 +59,7 @@ async function login() {
       method: 'POST',
       body: JSON.stringify({ phone: phone.value, password: password.value })
     })
-    localStorage.setItem('access_token', data.access_token)
-    localStorage.setItem('roles', JSON.stringify(data.roles || []))
+    setAuthToken(data.access_token)
     auth.user = data.user
     auth.roles = data.roles || []
     if (data.awaiting_confirmation || auth.user.status === 'AWAITING_CONFIRMATION') {

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -2,7 +2,7 @@
 import { ref, watch } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
-import { auth } from '../auth.js'
+import { auth, setAuthToken } from '../auth.js'
 import PasswordStrengthMeter from '../components/PasswordStrengthMeter.vue'
 
 const router = useRouter()
@@ -55,8 +55,7 @@ async function finish() {
         password: password.value
       })
     })
-    localStorage.setItem('access_token', data.access_token)
-    localStorage.setItem('roles', JSON.stringify(data.roles || []))
+    setAuthToken(data.access_token)
     auth.user = data.user
     auth.roles = data.roles || []
     router.push('/complete-profile')


### PR DESCRIPTION
## Summary
- drop localStorage access token usage
- keep token in JS memory via `api.js`
- refresh access token on startup if refresh cookie exists
- update readme

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef32e2500832dbe3895cb069572b7