### PR TITLE
Implement Redis-based login attempt storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - Request/response logging persisted to the `logs` table
 - Swagger documentation available at `/api-docs`
 - Docker and docker-compose setup for local development
+- Redis-backed login attempt tracking
 - ESLint and Prettier for code quality
 - Jest unit tests
 - Admin panel for managing users and roles (create, edit, block)
@@ -26,6 +27,7 @@ requests should target `dev` first, and changes are later merged into
 
 - Node.js 20+
 - PostgreSQL 15+
+- Redis 7+
 - npm
 
 ## Environment variables
@@ -38,6 +40,10 @@ DB_PORT=5432
 DB_NAME=fhpulse
 DB_USER=postgres
 DB_PASS=secret
+# Redis connection
+REDIS_HOST=localhost
+REDIS_PORT=6379
+# Alternatively you can set REDIS_URL=redis://host:port
 # connection to legacy MySQL database
 LEGACY_DB_HOST=legacy-host
 LEGACY_DB_PORT=3306
@@ -78,7 +84,7 @@ least eight characters long and contain both letters and numbers.
 
 ## Running with Docker
 
-The easiest way to start the application together with PostgreSQL is using Docker Compose:
+The easiest way to start the application together with PostgreSQL and Redis is using Docker Compose:
 
 ```bash
 docker-compose up --build

--- a/bin/www
+++ b/bin/www
@@ -10,6 +10,7 @@ import debugLib from 'debug';
 import app from '../app.js';
 import { connectToDatabase } from '../src/config/database.js';
 import { connectLegacyDatabase } from '../src/config/legacyDatabase.js';
+import { connectRedis } from '../src/config/redis.js';
 import validateEnv from '../src/config/validateEnv.js';
 
 const debug = debugLib('fhmoscow-pulse:server');
@@ -35,6 +36,7 @@ const server = http.createServer(app);
 (async () => {
   await connectToDatabase();
   await connectLegacyDatabase();
+  await connectRedis();
   server.listen(port);
 })();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       - backend
     volumes:
@@ -44,6 +46,15 @@ services:
       retries: 5
     volumes:
       - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    restart: unless-stopped
+
+  redis:
+    image: redis:7
+    container_name: redis
+    ports:
+      - "6379:6379"
     networks:
       - backend
     restart: unless-stopped

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "on-finished": "^2.4.1",
         "pg": "^8.16.0",
         "pg-hstore": "^2.3.4",
+        "redis": "^5.5.6",
         "sequelize": "^6.37.7",
         "sequelize-cli": "^6.6.3",
         "swagger-jsdoc": "^6.2.8",
@@ -1707,6 +1708,66 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@redis/bloom": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/bloom/-/bloom-5.5.6.tgz",
+      "integrity": "sha512-bNR3mxkwtfuCxNOzfV8B3R5zA1LiN57EH6zK4jVBIgzMzliNuReZXBFGnXvsi80/SYohajn78YdpYI+XNpqL+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/client": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-5.5.6.tgz",
+      "integrity": "sha512-M3Svdwt6oSfyfQdqEr0L2HOJH2vK7GgCFx1NfAQvpWAT4+ljoT1L5S5cKT3dA9NJrxrOPDkdoTPWJnIrGCOcmw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@redis/json": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/json/-/json-5.5.6.tgz",
+      "integrity": "sha512-AIsoe3SsGQagqAmSQHaqxEinm5oCWr7zxPWL90kKaEdLJ+zw8KBznf2i9oK0WUFP5pFssSQUXqnscQKe2amfDQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/search": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/search/-/search-5.5.6.tgz",
+      "integrity": "sha512-JSqasYqO0mVcHL7oxvbySRBBZYRYhFl3W7f0Da7BW8M/r0Z9wCiVrdjnN4/mKBpWZkoJT/iuisLUdPGhpKxBew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
+    "node_modules/@redis/time-series": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/@redis/time-series/-/time-series-5.5.6.tgz",
+      "integrity": "sha512-jkpcgq3NOI3TX7xEAJ3JgesJTxAx7k0m6lNxNsYdEM8KOl+xj7GaB/0CbLkoricZDmFSEAz7ClA1iK9XkGHf+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@redis/client": "^5.5.6"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "dev": true,
@@ -2505,6 +2566,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/co": {
@@ -8203,6 +8273,22 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/redis": {
+      "version": "5.5.6",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-5.5.6.tgz",
+      "integrity": "sha512-hbpqBfcuhWHOS9YLNcXcJ4akNr7HFX61Dq3JuFZ9S7uU7C7kvnzuH2PDIXOP62A3eevvACoG8UacuXP3N07xdg==",
+      "license": "MIT",
+      "dependencies": {
+        "@redis/bloom": "5.5.6",
+        "@redis/client": "5.5.6",
+        "@redis/json": "5.5.6",
+        "@redis/search": "5.5.6",
+        "@redis/time-series": "5.5.6"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/reflect.getprototypeof": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "redis": "^5.5.6"
   },
   "devDependencies": {
     "@eslint/js": "^9.27.0",

--- a/src/config/redis.js
+++ b/src/config/redis.js
@@ -1,0 +1,28 @@
+import { createClient } from 'redis';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const url = process.env.REDIS_URL || `redis://${process.env.REDIS_HOST || 'localhost'}:${process.env.REDIS_PORT || 6379}`;
+const client = createClient({ url });
+
+client.on('error', (err) => {
+  console.error('Redis Client Error', err);
+});
+
+export async function connectRedis() {
+  const { default: logger } = await import('../../logger.js');
+  try {
+    await client.connect();
+    logger.info('✅ Redis connection established');
+  } catch (err) {
+    logger.error('❌ Unable to connect to Redis:', err);
+    process.exit(1);
+  }
+}
+
+export async function closeRedis() {
+  await client.quit();
+}
+
+export default client;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -23,16 +23,16 @@ async function verifyCredentials(phone, password) {
 
   const ok = await bcrypt.compare(password, user.password);
   if (!ok) {
-    const count = attempts.markFailed(user.id);
+    const count = await attempts.markFailed(user.id);
     if (count >= 5 && inactive) {
       await user.update({ status_id: inactive.id });
-      attempts.clear(user.id);
+      await attempts.clear(user.id);
       throw new ServiceError('account_locked', 401);
     }
     throw new ServiceError('invalid_credentials', 401);
   }
 
-  attempts.clear(user.id);
+  await attempts.clear(user.id);
 
   return user;
 }

--- a/src/services/loginAttempts.js
+++ b/src/services/loginAttempts.js
@@ -1,32 +1,48 @@
-const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
-const attempts = new Map();
+import redis from '../config/redis.js';
 
-export function markFailed(id, now = Date.now()) {
-  const entry = attempts.get(id);
-  if (!entry || now - entry.first > WINDOW_MS) {
-    attempts.set(id, { count: 1, first: now });
+const WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+const PREFIX = 'login_attempts:';
+
+function key(id) {
+  return `${PREFIX}${id}`;
+}
+
+export async function markFailed(id, now = Date.now()) {
+  const k = key(id);
+  const data = await redis.get(k);
+  if (!data) {
+    await redis.set(k, JSON.stringify({ count: 1, first: now }), { PX: WINDOW_MS });
+    return 1;
+  }
+  const entry = JSON.parse(data);
+  if (now - entry.first > WINDOW_MS) {
+    await redis.set(k, JSON.stringify({ count: 1, first: now }), { PX: WINDOW_MS });
     return 1;
   }
   entry.count += 1;
+  const ttl = WINDOW_MS - (now - entry.first);
+  await redis.set(k, JSON.stringify(entry), { PX: ttl });
   return entry.count;
 }
 
-export function clear(id) {
-  attempts.delete(id);
+export async function clear(id) {
+  await redis.del(key(id));
 }
 
-export function get(id, now = Date.now()) {
-  const entry = attempts.get(id);
-  if (!entry) return 0;
+export async function get(id, now = Date.now()) {
+  const data = await redis.get(key(id));
+  if (!data) return 0;
+  const entry = JSON.parse(data);
   if (now - entry.first > WINDOW_MS) {
-    attempts.delete(id);
+    await redis.del(key(id));
     return 0;
   }
   return entry.count;
 }
 
-export function _reset() {
-  attempts.clear();
+export async function _reset() {
+  const keys = await redis.keys(`${PREFIX}*`);
+  if (keys.length) await redis.del(keys);
 }
 
 export { WINDOW_MS };

--- a/tests/loginAttempts.test.js
+++ b/tests/loginAttempts.test.js
@@ -1,29 +1,54 @@
-import { beforeEach, describe, expect, test } from '@jest/globals';
-import { markFailed, clear, get, _reset, WINDOW_MS } from '../src/services/loginAttempts.js';
+import { beforeEach, describe, expect, test, jest } from '@jest/globals';
+
+const store = new Map();
+jest.unstable_mockModule('../src/config/redis.js', () => ({
+  __esModule: true,
+  default: {
+    async get(k) {
+      return store.has(k) ? store.get(k) : null;
+    },
+    async set(k, v) {
+      store.set(k, v);
+    },
+    async del(keys) {
+      if (Array.isArray(keys)) {
+        keys.forEach((k) => store.delete(k));
+      } else {
+        store.delete(keys);
+      }
+    },
+    async keys(pattern) {
+      const prefix = pattern.replace('*', '');
+      return [...store.keys()].filter((k) => k.startsWith(prefix));
+    },
+  },
+}));
+
+const { markFailed, clear, get, _reset, WINDOW_MS } = await import('../src/services/loginAttempts.js');
 
 describe('loginAttempts service', () => {
-  beforeEach(() => {
-    _reset();
+  beforeEach(async () => {
+    await _reset();
   });
 
-  test('markFailed increments attempts within window', () => {
-    expect(markFailed('u1', 0)).toBe(1);
-    expect(markFailed('u1', 1000)).toBe(2);
+  test('markFailed increments attempts within window', async () => {
+    await expect(markFailed('u1', 0)).resolves.toBe(1);
+    await expect(markFailed('u1', 1000)).resolves.toBe(2);
   });
 
-  test('markFailed resets after window passes', () => {
-    markFailed('u1', 0);
-    expect(markFailed('u1', WINDOW_MS + 1)).toBe(1);
+  test('markFailed resets after window passes', async () => {
+    await markFailed('u1', 0);
+    await expect(markFailed('u1', WINDOW_MS + 1)).resolves.toBe(1);
   });
 
-  test('clear removes stored attempts', () => {
-    markFailed('u1', 0);
-    clear('u1');
-    expect(get('u1', 0)).toBe(0);
+  test('clear removes stored attempts', async () => {
+    await markFailed('u1', 0);
+    await clear('u1');
+    await expect(get('u1', 0)).resolves.toBe(0);
   });
 
-  test('get returns zero after window expires', () => {
-    markFailed('u1', 0);
-    expect(get('u1', WINDOW_MS + 1)).toBe(0);
+  test('get returns zero after window expires', async () => {
+    await markFailed('u1', 0);
+    await expect(get('u1', WINDOW_MS + 1)).resolves.toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- persist login attempts in Redis instead of memory
- add Redis client utilities
- update authentication service and tests for async Redis API
- mock Redis in unit tests
- document Redis usage and provide docker-compose service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef2ebc8f4832d9bf647a2a267489d