### PR TITLE
Implement token refresh in API client

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,5 +1,8 @@
 import { translateError } from './errors.js';
-const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:3000';
+import { clearAuth } from './auth.js';
+const API_BASE =
+  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE) ||
+  'http://localhost:3000';
 
 let accessToken = null;
 
@@ -13,6 +16,25 @@ export function clearAccessToken() {
 
 export function getAccessToken() {
   return accessToken;
+}
+
+async function refreshToken() {
+  try {
+    const res = await fetch(`${API_BASE}/auth/refresh`, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    const data = await res.json().catch(() => ({}));
+    if (res.ok && data.access_token) {
+      setAccessToken(data.access_token);
+      return true;
+    }
+  } catch (_err) {
+    // ignore
+  }
+  return false;
 }
 
 export async function apiFetch(path, options = {}) {
@@ -33,6 +55,18 @@ export async function apiFetch(path, options = {}) {
   }
 
   const data = await res.json().catch(() => ({}));
+  if (res.status === 401) {
+    const refreshed = await refreshToken();
+    if (refreshed) {
+      return apiFetch(path, options);
+    }
+    clearAuth();
+    if (typeof window !== 'undefined' && window.location) {
+      window.location.href = '/login';
+    }
+    const message = translateError(data.error) || `Ошибка запроса, код ${res.status}`;
+    throw new Error(message);
+  }
   if (!res.ok) {
     const message = translateError(data.error) || `Ошибка запроса, код ${res.status}`;
     throw new Error(message);

--- a/tests/clientApi.test.js
+++ b/tests/clientApi.test.js
@@ -1,0 +1,48 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+// mock auth module to monitor clearAuth
+const clearAuthMock = jest.fn();
+
+jest.unstable_mockModule('../client/src/auth.js', () => ({
+  __esModule: true,
+  clearAuth: clearAuthMock,
+}));
+
+// prepare globals
+global.fetch = jest.fn();
+// jsdom not available, emulate minimal window
+global.window = { location: { href: '' } };
+
+const { apiFetch, setAccessToken, clearAccessToken } = await import('../client/src/api.js');
+
+beforeEach(() => {
+  fetch.mockReset();
+  clearAuthMock.mockClear();
+  window.location.href = '';
+  clearAccessToken();
+});
+
+test('refresh token and retry on 401', async () => {
+  setAccessToken('old');
+  fetch
+    .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+    .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ access_token: 'new' }) })
+    .mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({ ok: true }) });
+
+  const data = await apiFetch('/foo');
+
+  expect(fetch).toHaveBeenNthCalledWith(1, 'http://localhost:3000/foo', expect.any(Object));
+  expect(fetch).toHaveBeenNthCalledWith(2, 'http://localhost:3000/auth/refresh', expect.any(Object));
+  expect(fetch).toHaveBeenNthCalledWith(3, 'http://localhost:3000/foo', expect.any(Object));
+  expect(data).toEqual({ ok: true });
+});
+
+test('redirect to login when refresh fails', async () => {
+  fetch
+    .mockResolvedValueOnce({ ok: false, status: 401, json: () => Promise.resolve({}) })
+    .mockResolvedValueOnce({ ok: false, status: 400, json: () => Promise.resolve({}) });
+
+  await expect(apiFetch('/foo')).rejects.toThrow('Ошибка запроса, код 401');
+  expect(clearAuthMock).toHaveBeenCalled();
+  expect(window.location.href).toBe('/login');
+});


### PR DESCRIPTION
## Summary
- refresh token when API requests return 401
- redirect to login on refresh failure
- test client API refresh logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685ef5a8568c832db77af3dc0e39d2e2