### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@eslint/js": "^9.27.0",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
-        "eslint-import-resolver-typescript": "^4.3.5",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-prettier": "^5.4.0",
         "globals": "^16.1.0",
@@ -3380,15 +3380,16 @@
       "license": "MIT"
     },
     "node_modules/eslint-import-resolver-typescript": {
-      "version": "4.4.3",
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "debug": "^4.4.1",
         "eslint-import-context": "^0.1.8",
         "get-tsconfig": "^4.10.1",
         "is-bun-module": "^2.0.0",
-        "stable-hash-x": "^0.1.1",
+        "stable-hash-x": "^0.2.0",
         "tinyglobby": "^0.2.14",
         "unrs-resolver": "^1.7.11"
       },
@@ -3432,6 +3433,15 @@
       "version": "2.1.3",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint-import-resolver-typescript/node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/eslint-module-utils": {
       "version": "2.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "fhmoscow-pulse",
       "version": "0.0.0",
       "dependencies": {
-        "@jest/globals": "^30.0.0-beta.3",
+        "@jest/globals": "^30.0.3",
         "bcryptjs": "^3.0.2",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
@@ -1261,87 +1261,95 @@
       }
     },
     "node_modules/@jest/diff-sequences": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/environment": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.0.2.tgz",
+      "integrity": "sha512-hRLhZRJNxBiOhxIKSq2UkrlhMt3/zVFQOAi5lvS8T9I03+kxsbflwHJEF+eXEYXCrRGRhHwECT7CDk6DyngsRA==",
       "dependencies": {
-        "@jest/fake-timers": "30.0.0",
-        "@jest/types": "30.0.0",
+        "@jest/fake-timers": "30.0.2",
+        "@jest/types": "30.0.1",
         "@types/node": "*",
-        "jest-mock": "30.0.0"
+        "jest-mock": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-30.0.3.tgz",
+      "integrity": "sha512-73BVLqfCeWjYWPEQoYjiRZ4xuQRhQZU0WdgvbyXGRHItKQqg5e6mt2y1kVhzLSuZpmUnccZHbGynoaL7IcLU3A==",
       "dependencies": {
-        "expect": "30.0.0",
-        "jest-snapshot": "30.0.0"
+        "expect": "30.0.3",
+        "jest-snapshot": "30.0.3"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.0.3.tgz",
+      "integrity": "sha512-SMtBvf2sfX2agcT0dA9pXwcUrKvOSDqBY4e4iRfT+Hya33XzV35YVg+98YQFErVGA/VR1Gto5Y2+A6G9LSQ3Yg==",
       "dependencies": {
-        "@jest/get-type": "30.0.0"
+        "@jest/get-type": "30.0.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.0.2.tgz",
+      "integrity": "sha512-jfx0Xg7l0gmphTY9UKm5RtH12BlLYj/2Plj6wXjVW5Era4FZKfXeIvwC67WX+4q8UCFxYS20IgnMcFBcEU0DtA==",
       "dependencies": {
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@sinonjs/fake-timers": "^13.0.0",
         "@types/node": "*",
-        "jest-message-util": "30.0.0",
-        "jest-mock": "30.0.0",
-        "jest-util": "30.0.0"
+        "jest-message-util": "30.0.2",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/get-type": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.0.1.tgz",
+      "integrity": "sha512-AyYdemXCptSRFirI5EPazNxyPwAL0jXt3zceFjaj8NFiKP9pOi0bfXonf6qkf82z2t3QWPeLCWWw4stPBzctLw==",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/globals": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-30.0.3.tgz",
+      "integrity": "sha512-fIduqNyYpMeeSr5iEAiMn15KxCzvrmxl7X7VwLDRGj7t5CoHtbF+7K3EvKk32mOUIJ4kIvFRlaixClMH2h/Vaw==",
       "dependencies": {
-        "@jest/environment": "30.0.0",
-        "@jest/expect": "30.0.0",
-        "@jest/types": "30.0.0",
-        "jest-mock": "30.0.0"
+        "@jest/environment": "30.0.2",
+        "@jest/expect": "30.0.3",
+        "@jest/types": "30.0.1",
+        "jest-mock": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/pattern": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
       "dependencies": {
         "@types/node": "*",
-        "jest-regex-util": "30.0.0"
+        "jest-regex-util": "30.0.1"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1457,8 +1465,9 @@
       }
     },
     "node_modules/@jest/schemas": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.1.tgz",
+      "integrity": "sha512-+g/1TKjFuGrf1Hh0QPCv0gISwBxJ+MQSNXmG9zjHy7BmFhtoJ9fdNhWJp3qUKRi93AOZHXtdxZgJ1vAtz6z65w==",
       "dependencies": {
         "@sinclair/typebox": "^0.34.0"
       },
@@ -1467,10 +1476,11 @@
       }
     },
     "node_modules/@jest/snapshot-utils": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/snapshot-utils/-/snapshot-utils-30.0.1.tgz",
+      "integrity": "sha512-6Dpv7vdtoRiISEFwYF8/c7LIvqXD7xDXtLPNzC2xqAfBznKip0MQM+rkseKwUPUpv2PJ7KW/YsnwWXrIL2xF+A==",
       "dependencies": {
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "natural-compare": "^1.4.0"
@@ -1634,11 +1644,12 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.1.tgz",
+      "integrity": "sha512-HGwoYRVF0QSKJu1ZQX0o5ZrUrrhj0aOOFA8hXrumD7SIzjouevhawbTjmXdwOmURdGluU9DM/XvGm3NyFoiQjw==",
       "dependencies": {
-        "@jest/pattern": "30.0.0",
-        "@jest/schemas": "30.0.0",
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.1",
         "@types/istanbul-lib-coverage": "^2.0.6",
         "@types/istanbul-reports": "^3.0.4",
         "@types/node": "*",
@@ -1805,8 +1816,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.33",
-      "license": "MIT"
+      "version": "0.34.37",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.37.tgz",
+      "integrity": "sha512-2TRuQVgQYfy+EzHRTIvkhv2ADEouJ2xNS/Vq+W5EuuewBdOrvATvljZTxHWZSTYr2sTjTHpGvucaGAt67S2akw=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1817,7 +1829,8 @@
     },
     "node_modules/@sinonjs/fake-timers": {
       "version": "13.0.5",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
+      "integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
@@ -1942,7 +1955,8 @@
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
-      "license": "ISC"
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
     },
     "node_modules/@unrs/resolver-binding-darwin-arm64": {
       "version": "1.7.13",
@@ -3670,15 +3684,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.0.3.tgz",
+      "integrity": "sha512-HXg6NvK35/cSYZCUKAtmlgCFyqKM4frEPbzrav5hRqb0GMz0E0lS5hfzYjSaiaE5ysnp/qI2aeZkeyeIAOeXzQ==",
       "dependencies": {
-        "@jest/expect-utils": "30.0.0",
-        "@jest/get-type": "30.0.0",
-        "jest-matcher-utils": "30.0.0",
-        "jest-message-util": "30.0.0",
-        "jest-mock": "30.0.0",
-        "jest-util": "30.0.0"
+        "@jest/expect-utils": "30.0.3",
+        "@jest/get-type": "30.0.1",
+        "jest-matcher-utils": "30.0.3",
+        "jest-message-util": "30.0.2",
+        "jest-mock": "30.0.2",
+        "jest-util": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -3932,6 +3947,19 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -5379,13 +5407,14 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.0.3.tgz",
+      "integrity": "sha512-Q1TAV0cUcBTic57SVnk/mug0/ASyAqtSIOkr7RAlxx97llRYsM74+E8N5WdGJUlwCKwgxPAkVjKh653h1+HA9A==",
       "dependencies": {
-        "@jest/diff-sequences": "30.0.0",
-        "@jest/get-type": "30.0.0",
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.0.1",
         "chalk": "^4.1.2",
-        "pretty-format": "30.0.0"
+        "pretty-format": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5393,7 +5422,8 @@
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "engines": {
         "node": ">=10"
       },
@@ -5402,10 +5432,11 @@
       }
     },
     "node_modules/jest-diff/node_modules/pretty-format": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
       "dependencies": {
-        "@jest/schemas": "30.0.0",
+        "@jest/schemas": "30.0.1",
         "ansi-styles": "^5.2.0",
         "react-is": "^18.3.1"
       },
@@ -5722,13 +5753,14 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.0.3.tgz",
+      "integrity": "sha512-hMpVFGFOhYmIIRGJ0HgM9htC5qUiJ00famcc9sRFchJJiLZbbVKrAztcgE6VnXLRxA3XZ0bvNA7hQWh3oHXo/A==",
       "dependencies": {
-        "@jest/get-type": "30.0.0",
+        "@jest/get-type": "30.0.1",
         "chalk": "^4.1.2",
-        "jest-diff": "30.0.0",
-        "pretty-format": "30.0.0"
+        "jest-diff": "30.0.3",
+        "pretty-format": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5736,7 +5768,8 @@
     },
     "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "engines": {
         "node": ">=10"
       },
@@ -5745,10 +5778,11 @@
       }
     },
     "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
       "dependencies": {
-        "@jest/schemas": "30.0.0",
+        "@jest/schemas": "30.0.1",
         "ansi-styles": "^5.2.0",
         "react-is": "^18.3.1"
       },
@@ -5757,16 +5791,17 @@
       }
     },
     "node_modules/jest-message-util": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.0.2.tgz",
+      "integrity": "sha512-vXywcxmr0SsKXF/bAD7t7nMamRvPuJkras00gqYeB1V0WllxZrbZ0paRr3XqpFU2sYYjD0qAaG2fRyn/CGZ0aw==",
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@types/stack-utils": "^2.0.3",
         "chalk": "^4.1.2",
         "graceful-fs": "^4.2.11",
         "micromatch": "^4.0.8",
-        "pretty-format": "30.0.0",
+        "pretty-format": "30.0.2",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.6"
       },
@@ -5776,7 +5811,8 @@
     },
     "node_modules/jest-message-util/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "engines": {
         "node": ">=10"
       },
@@ -5785,10 +5821,11 @@
       }
     },
     "node_modules/jest-message-util/node_modules/pretty-format": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
       "dependencies": {
-        "@jest/schemas": "30.0.0",
+        "@jest/schemas": "30.0.1",
         "ansi-styles": "^5.2.0",
         "react-is": "^18.3.1"
       },
@@ -5797,12 +5834,13 @@
       }
     },
     "node_modules/jest-mock": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.2.tgz",
+      "integrity": "sha512-PnZOHmqup/9cT/y+pXIVbbi8ID6U1XHRmbvR7MvUy4SLqhCbwpkmXhLbsWbGewHrV5x/1bF7YDjs+x24/QSvFA==",
       "dependencies": {
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@types/node": "*",
-        "jest-util": "30.0.0"
+        "jest-util": "30.0.2"
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5825,8 +5863,9 @@
       }
     },
     "node_modules/jest-regex-util": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
@@ -6509,28 +6548,29 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.3",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.0.3.tgz",
+      "integrity": "sha512-F05JCohd3OA1N9+5aEPXA6I0qOfZDGIx0zTq5Z4yMBg2i1p5ELfBusjYAWwTkC12c7dHcbyth4QAfQbS7cRjow==",
       "dependencies": {
         "@babel/core": "^7.27.4",
         "@babel/generator": "^7.27.5",
         "@babel/plugin-syntax-jsx": "^7.27.1",
         "@babel/plugin-syntax-typescript": "^7.27.1",
         "@babel/types": "^7.27.3",
-        "@jest/expect-utils": "30.0.0",
-        "@jest/get-type": "30.0.0",
-        "@jest/snapshot-utils": "30.0.0",
-        "@jest/transform": "30.0.0",
-        "@jest/types": "30.0.0",
+        "@jest/expect-utils": "30.0.3",
+        "@jest/get-type": "30.0.1",
+        "@jest/snapshot-utils": "30.0.1",
+        "@jest/transform": "30.0.2",
+        "@jest/types": "30.0.1",
         "babel-preset-current-node-syntax": "^1.1.0",
         "chalk": "^4.1.2",
-        "expect": "30.0.0",
+        "expect": "30.0.3",
         "graceful-fs": "^4.2.11",
-        "jest-diff": "30.0.0",
-        "jest-matcher-utils": "30.0.0",
-        "jest-message-util": "30.0.0",
-        "jest-util": "30.0.0",
-        "pretty-format": "30.0.0",
+        "jest-diff": "30.0.3",
+        "jest-matcher-utils": "30.0.3",
+        "jest-message-util": "30.0.2",
+        "jest-util": "30.0.2",
+        "pretty-format": "30.0.2",
         "semver": "^7.7.2",
         "synckit": "^0.11.8"
       },
@@ -6539,20 +6579,21 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/@jest/transform": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-30.0.2.tgz",
+      "integrity": "sha512-kJIuhLMTxRF7sc0gPzPtCDib/V9KwW3I2U25b+lYCYMVqHHSrcZopS8J8H+znx9yixuFv+Iozl8raLt/4MoxrA==",
       "dependencies": {
         "@babel/core": "^7.27.4",
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@jridgewell/trace-mapping": "^0.3.25",
         "babel-plugin-istanbul": "^7.0.0",
         "chalk": "^4.1.2",
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.11",
-        "jest-haste-map": "30.0.0",
-        "jest-regex-util": "30.0.0",
-        "jest-util": "30.0.0",
+        "jest-haste-map": "30.0.2",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.0.2",
         "micromatch": "^4.0.8",
         "pirates": "^4.0.7",
         "slash": "^3.0.0",
@@ -6564,7 +6605,8 @@
     },
     "node_modules/jest-snapshot/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "engines": {
         "node": ">=10"
       },
@@ -6574,7 +6616,8 @@
     },
     "node_modules/jest-snapshot/node_modules/babel-plugin-istanbul": {
       "version": "7.0.0",
-      "license": "BSD-3-Clause",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz",
+      "integrity": "sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.0.0",
         "@istanbuljs/load-nyc-config": "^1.0.0",
@@ -6587,17 +6630,18 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/jest-haste-map": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.0.2.tgz",
+      "integrity": "sha512-telJBKpNLeCb4MaX+I5k496556Y2FiKR/QLZc0+MGBYl4k3OO0472drlV2LUe7c1Glng5HuAu+5GLYp//GpdOQ==",
       "dependencies": {
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@types/node": "*",
         "anymatch": "^3.1.3",
         "fb-watchman": "^2.0.2",
         "graceful-fs": "^4.2.11",
-        "jest-regex-util": "30.0.0",
-        "jest-util": "30.0.0",
-        "jest-worker": "30.0.0",
+        "jest-regex-util": "30.0.1",
+        "jest-util": "30.0.2",
+        "jest-worker": "30.0.2",
         "micromatch": "^4.0.8",
         "walker": "^1.0.8"
       },
@@ -6609,12 +6653,13 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/jest-worker": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.0.2.tgz",
+      "integrity": "sha512-RN1eQmx7qSLFA+o9pfJKlqViwL5wt+OL3Vff/A+/cPsmuw7NPwfgl33AP+/agRmHzPOFgXviRycR9kYwlcRQXg==",
       "dependencies": {
         "@types/node": "*",
         "@ungap/structured-clone": "^1.3.0",
-        "jest-util": "30.0.0",
+        "jest-util": "30.0.2",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.1.1"
       },
@@ -6623,10 +6668,11 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/pretty-format": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.2.tgz",
+      "integrity": "sha512-yC5/EBSOrTtqhCKfLHqoUIAXVRZnukHPwWBJWR7h84Q3Be1DRQZLncwcfLoPA5RPQ65qfiCMqgYwdUuQ//eVpg==",
       "dependencies": {
-        "@jest/schemas": "30.0.0",
+        "@jest/schemas": "30.0.1",
         "ansi-styles": "^5.2.0",
         "react-is": "^18.3.1"
       },
@@ -6636,7 +6682,8 @@
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.7.2",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -6646,7 +6693,8 @@
     },
     "node_modules/jest-snapshot/node_modules/signal-exit": {
       "version": "4.1.0",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "engines": {
         "node": ">=14"
       },
@@ -6656,7 +6704,8 @@
     },
     "node_modules/jest-snapshot/node_modules/supports-color": {
       "version": "8.1.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -6669,7 +6718,8 @@
     },
     "node_modules/jest-snapshot/node_modules/write-file-atomic": {
       "version": "5.0.1",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+      "integrity": "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
@@ -6679,10 +6729,11 @@
       }
     },
     "node_modules/jest-util": {
-      "version": "30.0.0",
-      "license": "MIT",
+      "version": "30.0.2",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.2.tgz",
+      "integrity": "sha512-8IyqfKS4MqprBuUpZNlFB5l+WFehc8bfCe1HSZFHzft2mOuND8Cvi9r1musli+u6F3TqanCZ/Ik4H4pXUolZIg==",
       "dependencies": {
-        "@jest/types": "30.0.0",
+        "@jest/types": "30.0.1",
         "@types/node": "*",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
@@ -6695,20 +6746,22 @@
     },
     "node_modules/jest-util/node_modules/ci-info": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
+      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/jest-util/node_modules/picomatch": {
       "version": "4.0.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "engines": {
         "node": ">=12"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "winston": "^3.17.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.27.0",
+        "@eslint/js": "^9.30.0",
         "eslint": "^9.29.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -686,9 +686,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/js": {
-      "version": "9.29.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
-      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+      "version": "9.30.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.0.tgz",
+      "integrity": "sha512-Wzw3wQwPvc9sHM+NjakWTcPx11mbZyiYHuwWa/QfZ7cIRX7WK54PSk7bdyXDaoaopUcMatv1zaQvOAAO8hCdww==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3570,6 +3570,18 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.29.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.29.0.tgz",
+      "integrity": "sha512-3PIF4cBw/y+1u2EazflInpV+lYsSG0aByVIQzAgb1m1MhHFSbqTyNqtBKHgWf/9Ykud+DhILS9EGkmekVhbKoQ==",
+      "dev": true,
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/eslint/node_modules/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "eslint-plugin-prettier": "^5.4.0",
         "globals": "^16.1.0",
         "jest": "^29.7.0",
-        "prettier": "^3.5.3"
+        "prettier": "^3.6.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -8185,9 +8185,10 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.5.3",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
     "eslint-plugin-prettier": "^5.4.0",
     "globals": "^16.1.0",
     "jest": "^29.7.0",
-    "prettier": "^3.5.3"
+    "prettier": "^3.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "seed:create": "sequelize-cli seed:generate --name"
   },
   "dependencies": {
-    "@jest/globals": "^30.0.0-beta.3",
+    "@jest/globals": "^30.0.3",
     "bcryptjs": "^3.0.2",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@eslint/js": "^9.27.0",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
-    "eslint-import-resolver-typescript": "^4.3.5",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-prettier": "^5.4.0",
     "globals": "^16.1.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "redis": "^5.5.6"
   },
   "devDependencies": {
-    "@eslint/js": "^9.27.0",
+    "@eslint/js": "^9.30.0",
     "eslint": "^9.29.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-import-resolver-typescript": "^4.4.4",


### PR DESCRIPTION
Potential fix for [https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/1](https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to read-only access to repository contents. Since none of the jobs in the workflow require write permissions, the minimal permissions block will be:

```yaml
permissions:
  contents: read
```

This change ensures that the workflow adheres to the principle of least privilege and avoids relying on default permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
