### PR TITLE
Potential fix for code scanning alert no. 11: Regular expression injection

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0",
     "winston": "^3.17.0",
-    "redis": "^5.5.6"
+    "redis": "^5.5.6",
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -5,8 +5,10 @@ export const JWT_SECRET = process.env.JWT_SECRET;
 
 export const PASSWORD_MIN_LENGTH =
   parseInt(process.env.PASSWORD_MIN_LENGTH, 10) || 8;
+import _ from 'lodash';
+
 export const PASSWORD_PATTERN = new RegExp(
-  process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)'
+  _.escapeRegExp(process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)')
 );
 
 export const COOKIE_NAME = 'refresh_token';


### PR DESCRIPTION
Potential fix for [https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/11](https://github.com/R0kko/fhmoscow-pulse/security/code-scanning/11)

To fix the issue, the environment variable `process.env.PASSWORD_PATTERN` should be sanitized before being used to construct the regular expression. The best way to achieve this is by using a library like `lodash` and its `_.escapeRegExp` function, which escapes special characters in the input string that have special meaning in regular expressions. This ensures that the constructed regular expression is safe and cannot be manipulated by malicious input.

The fix involves:
1. Importing the `lodash` library.
2. Escaping the environment variable `process.env.PASSWORD_PATTERN` using `_.escapeRegExp`.
3. Using the sanitized value to construct the regular expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
