### PR TITLE
Add express-session and fix Lusca CSRF

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ LEGACY_DB_USER=root
 LEGACY_DB_PASS=secret
 
 JWT_SECRET=your_jwt_secret
+SESSION_SECRET=supersecret
 
 # Optional overrides
 # Remove the leading '#' to enable and adjust the values.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ LEGACY_DB_NAME=legacydb
 LEGACY_DB_USER=root
 LEGACY_DB_PASS=secret
 JWT_SECRET=your_jwt_secret
+SESSION_SECRET=your_session_secret
 # optional overrides
 # token for DaData suggestions
 VITE_DADATA_TOKEN=your_dadata_api_token

--- a/app.js
+++ b/app.js
@@ -5,6 +5,7 @@ import swaggerUi from 'swagger-ui-express';
 import helmet from 'helmet';
 import lusca from 'lusca';
 
+import session from './src/config/session.js';
 import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
 import rateLimiter from './src/middlewares/rateLimiter.js';
@@ -32,6 +33,7 @@ const corsOptions = {
 app.use(cors(corsOptions));
 app.use(helmet());
 app.use(rateLimiter);
+app.use(session);
 app.use(lusca.csrf());
 app.use(requestLogger);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@jest/globals": "^30.0.3",
         "bcryptjs": "^3.0.2",
+        "connect-redis": "^7.0.0",
         "cookie-parser": "~1.4.4",
         "cors": "^2.8.5",
         "debug": "~2.6.9",
         "dotenv": "^16.5.0",
         "express": "^4.21.2",
         "express-rate-limit": "^7.5.0",
+        "express-session": "^1.17.3",
         "express-validator": "^7.2.1",
         "helmet": "^8.1.0",
         "joi": "^17.13.3",
@@ -2680,6 +2682,18 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/connect-redis": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/connect-redis/-/connect-redis-7.1.1.tgz",
+      "integrity": "sha512-M+z7alnCJiuzKa8/1qAYdGUXHYfDnLolOGAUjOioB07pP39qxjG+X9ibsud7qUBc4jMV5Mcy3ugGv8eFcgamJQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "express-session": ">=1"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "license": "MIT",
@@ -3781,6 +3795,31 @@
       "peerDependencies": {
         "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
+    },
+    "node_modules/express-session": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.18.1.tgz",
+      "integrity": "sha512-a5mtTqEaZvBCL9A9aqkrtfz+3SMDhOVUnjafjo+s7A9Txkq+SVX2DLvSp1Zrv4uCXa3lMSK3viWnh9Gg07PBUA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.7",
+        "debug": "2.6.9",
+        "depd": "~2.0.0",
+        "on-headers": "~1.0.2",
+        "parseurl": "~1.3.3",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "~2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/express-session/node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/express-validator": {
       "version": "7.2.1",
@@ -8338,6 +8377,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
@@ -9539,6 +9587,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/umzug": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,9 @@
     "winston": "^3.17.0",
     "redis": "^5.5.6",
     "lodash": "^4.17.21",
-    "lusca": "^1.7.0"
+    "lusca": "^1.7.0",
+    "express-session": "^1.17.3",
+    "connect-redis": "^7.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.30.0",

--- a/src/config/session.js
+++ b/src/config/session.js
@@ -1,0 +1,18 @@
+import session from 'express-session';
+import { RedisStore } from 'connect-redis';
+import dotenv from 'dotenv';
+
+import redisClient from './redis.js';
+dotenv.config();
+const store = new RedisStore({ client: redisClient });
+export default session({
+  store,
+  secret: process.env.SESSION_SECRET,
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+  },
+});

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -15,6 +15,7 @@ const schema = Joi.object({
   LEGACY_DB_USER: Joi.string().required(),
   LEGACY_DB_PASS: Joi.string().required(),
   JWT_SECRET: Joi.string().required(),
+  SESSION_SECRET: Joi.string().required(),
 }).unknown(true);
 
 export default function validateEnv() {


### PR DESCRIPTION
## Summary
- add express-session with Redis store and middleware setup
- require SESSION_SECRET in env validation
- update example env and README with new variable
- install connect-redis and express-session
- fix Redis session store initialization

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68617f190828832d80711a6954a0325e