### PR TITLE
Enable CSRF token for frontend

### DIFF
--- a/app.js
+++ b/app.js
@@ -34,7 +34,8 @@ app.use(cors(corsOptions));
 app.use(helmet());
 app.use(rateLimiter);
 app.use(session);
-app.use(lusca.csrf());
+// Expose CSRF token in a cookie so the Vue client can read it
+app.use(lusca.csrf({ angular: true }));
 app.use(requestLogger);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -6,6 +6,14 @@ const API_BASE =
 
 let accessToken = null;
 
+function getXsrfToken() {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie
+    .split('; ')
+    .find((row) => row.startsWith('XSRF-TOKEN='));
+  return match ? decodeURIComponent(match.split('=')[1]) : null;
+}
+
 export function setAccessToken(token) {
   accessToken = token;
 }
@@ -43,6 +51,10 @@ export async function apiFetch(path, options = {}) {
     'Content-Type': 'application/json',
     ...(opts.headers || {}),
   };
+  const xsrf = getXsrfToken();
+  if (xsrf) {
+    opts.headers['X-XSRF-TOKEN'] = xsrf;
+  }
   if (accessToken) {
     opts.headers['Authorization'] = `Bearer ${accessToken}`;
   }


### PR DESCRIPTION
## Summary
- expose CSRF token via cookie in Express
- automatically send CSRF header from Vue client

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686186d65714832db4129bf6c4bcc120