### PR TITLE
Add client-side 403 and 500 pages

### DIFF
--- a/client/src/components/ErrorPage.vue
+++ b/client/src/components/ErrorPage.vue
@@ -1,0 +1,35 @@
+<script setup>
+import { RouterLink } from 'vue-router'
+import { defineProps } from 'vue'
+import logo from '../assets/fhm-logo.svg'
+
+defineProps({
+  code: { type: String, required: true },
+  message: { type: String, required: true }
+})
+</script>
+
+<template>
+  <div class="d-flex flex-column align-items-center justify-content-center vh-100 text-center p-3">
+    <img :src="logo" alt="FHM" class="mb-4" style="max-height: 100px" />
+    <h1 class="display-3 fw-bold">{{ code }}</h1>
+    <p class="lead mb-4">{{ message }}</p>
+    <RouterLink to="/" class="btn btn-brand">На главную</RouterLink>
+  </div>
+</template>
+
+<style scoped>
+.display-3 {
+  animation: fadeIn 0.6s ease-out;
+}
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -11,6 +11,9 @@ import AdminHome from './views/AdminHome.vue'
 import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
 import PasswordReset from './views/PasswordReset.vue'
+import NotFound from './views/NotFound.vue'
+import Forbidden from './views/Forbidden.vue'
+import ServerError from './views/ServerError.vue'
 
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true } },
@@ -27,6 +30,21 @@ const routes = [
     path: '/awaiting-confirmation',
     component: AwaitingConfirmation,
     meta: { requiresAuth: true, hideLayout: true }
+  },
+  {
+    path: '/forbidden',
+    component: Forbidden,
+    meta: { hideLayout: true }
+  },
+  {
+    path: '/error',
+    component: ServerError,
+    meta: { hideLayout: true }
+  },
+  {
+    path: '/:pathMatch(.*)*',
+    component: NotFound,
+    meta: { hideLayout: true }
   }
 ]
 
@@ -49,7 +67,7 @@ router.beforeEach(async (to, _from, next) => {
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/login')
   } else if (to.meta.requiresAdmin && !roles.includes('ADMIN')) {
-    next('/')
+    next('/forbidden')
   } else if (
     isAuthenticated &&
     auth.user?.status &&

--- a/client/src/views/Forbidden.vue
+++ b/client/src/views/Forbidden.vue
@@ -1,0 +1,8 @@
+<script setup>
+import ErrorPage from '../components/ErrorPage.vue'
+</script>
+
+<template>
+  <ErrorPage code="403" message="Доступ запрещён" />
+</template>
+

--- a/client/src/views/NotFound.vue
+++ b/client/src/views/NotFound.vue
@@ -1,0 +1,8 @@
+<script setup>
+import ErrorPage from '../components/ErrorPage.vue'
+</script>
+
+<template>
+  <ErrorPage code="404" message="Страница не найдена" />
+</template>
+

--- a/client/src/views/ServerError.vue
+++ b/client/src/views/ServerError.vue
@@ -1,0 +1,8 @@
+<script setup>
+import ErrorPage from '../components/ErrorPage.vue'
+</script>
+
+<template>
+  <ErrorPage code="500" message="Внутренняя ошибка сервера" />
+</template>
+


### PR DESCRIPTION
## Summary
- factor common markup into ErrorPage component
- add Forbidden and ServerError views
- register new routes and redirect missing admin rights

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68618f4fde60832da01c558eaa38e2de