### PR TITLE
Fix refresh token validation and cookie config

### DIFF
--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -16,10 +16,13 @@ export const COOKIE_HTTP_ONLY = true;
 export const COOKIE_SAME_SITE = 'strict';
 export const COOKIE_SECURE = process.env.NODE_ENV === 'production';
 export const COOKIE_MAX_AGE = 30 * 24 * 60 * 60 * 1000; // 30 days in ms
+export const COOKIE_DOMAIN = process.env.COOKIE_DOMAIN;
 
 export const COOKIE_OPTIONS = {
   httpOnly: COOKIE_HTTP_ONLY,
   sameSite: COOKIE_SAME_SITE,
   secure: COOKIE_SECURE,
   maxAge: COOKIE_MAX_AGE,
+  path: '/',
+  ...(COOKIE_DOMAIN ? { domain: COOKIE_DOMAIN } : {}),
 };

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -67,6 +67,11 @@ export default {
 
   /* POST /auth/refresh */
   async refresh(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+
     const token =
       req.cookies?.[COOKIE_NAME] ??
       req.body?.[COOKIE_NAME] ??

--- a/src/utils/cookie.js
+++ b/src/utils/cookie.js
@@ -16,5 +16,8 @@ export function setRefreshCookie(res, token) {
  * @param {import('express').Response} res
  */
 export function clearRefreshCookie(res) {
-  res.clearCookie(COOKIE_NAME, COOKIE_OPTIONS);
+  const { path, domain, httpOnly, sameSite, secure } = COOKIE_OPTIONS;
+  const options = { path, httpOnly, sameSite, secure };
+  if (domain) options.domain = domain;
+  res.clearCookie(COOKIE_NAME, options);
 }

--- a/src/validators/authValidators.js
+++ b/src/validators/authValidators.js
@@ -15,8 +15,5 @@ export const loginRules = [
  * /auth/refresh – refresh_token
  * -------------------------------------------------------------------------*/
 export const refreshRules = [
-  body('refresh_token')
-    .isString()
-    .notEmpty()
-    .withMessage('refresh_token is required'),
+  body('refresh_token').optional().isString().notEmpty(),
 ];

--- a/tests/cookie.test.js
+++ b/tests/cookie.test.js
@@ -4,19 +4,20 @@ import { setRefreshCookie, clearRefreshCookie } from '../src/utils/cookie.js';
  test('setRefreshCookie calls res.cookie with options', () => {
   const res = { cookie: jest.fn() };
   setRefreshCookie(res, 'token');
-  expect(res.cookie).toHaveBeenCalledWith(
-    'refresh_token',
-    'token',
-    expect.objectContaining({
-      httpOnly: true,
-      sameSite: 'strict',
-      secure: false,
-      maxAge: expect.any(Number),
-    })
-  );
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refresh_token',
+      'token',
+      expect.objectContaining({
+        httpOnly: true,
+        sameSite: 'strict',
+        secure: false,
+        maxAge: expect.any(Number),
+        path: '/',
+      })
+    );
 });
 
- test('clearRefreshCookie calls res.clearCookie with options', () => {
+test('clearRefreshCookie calls res.clearCookie with options', () => {
   const res = { clearCookie: jest.fn() };
   clearRefreshCookie(res);
   expect(res.clearCookie).toHaveBeenCalledWith(
@@ -25,6 +26,9 @@ import { setRefreshCookie, clearRefreshCookie } from '../src/utils/cookie.js';
       httpOnly: true,
       sameSite: 'strict',
       secure: false,
+      path: '/',
     })
   );
+  const options = res.clearCookie.mock.calls[0][1];
+  expect(options).not.toHaveProperty('maxAge');
 });


### PR DESCRIPTION
## Summary
- validate `auth/refresh` requests
- relax refresh token validator to allow empty body
- include path and optional domain in cookie config
- avoid maxAge when clearing refresh cookies
- test updated cookie options

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861956488a4832d8a15fea7d2201b2c