### PR TITLE
Fix csrf cookie for cross-site

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,8 +3,8 @@ import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import helmet from 'helmet';
-import lusca from 'lusca';
 
+import csrfMiddleware from './src/middlewares/csrf.js';
 import session from './src/config/session.js';
 import indexRouter from './src/routes/index.js';
 import requestLogger from './src/middlewares/requestLogger.js';
@@ -35,7 +35,7 @@ app.use(helmet());
 app.use(rateLimiter);
 app.use(session);
 // Expose CSRF token in a cookie so the Vue client can read it
-app.use(lusca.csrf({ angular: true }));
+app.use(csrfMiddleware);
 app.use(requestLogger);
 
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));

--- a/client/src/auth.js
+++ b/client/src/auth.js
@@ -20,7 +20,6 @@ export async function fetchCurrentUser() {
 
 export async function refreshFromCookie() {
   try {
-    await initCsrf()
     const data = await apiFetch('/auth/refresh', {
       method: 'POST',
       body: '{}',

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -58,7 +58,8 @@ async function login() {
     await initCsrf()
     const data = await apiFetch('/auth/login', {
       method: 'POST',
-      body: JSON.stringify({ phone: phone.value, password: password.value })
+      body: JSON.stringify({ phone: phone.value, password: password.value }),
+      redirectOn401: false
     })
     setAuthToken(data.access_token)
     auth.user = data.user

--- a/src/config/csrf.js
+++ b/src/config/csrf.js
@@ -1,0 +1,13 @@
+import lusca from 'lusca';
+
+const csrfOptions = {
+  angular: true,
+  cookie: {
+    options: {
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'strict',
+      secure: process.env.NODE_ENV === 'production',
+    },
+  },
+};
+
+export default lusca.csrf(csrfOptions);

--- a/src/config/session.js
+++ b/src/config/session.js
@@ -13,6 +13,6 @@ export default session({
   cookie: {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
-    sameSite: 'lax',
+    sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
   },
 });

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -48,7 +48,10 @@ export default {
   },
 
   /* POST /auth/logout */
-  async logout(_req, res) {
+  async logout(req, res) {
+    if (req.session) {
+      req.session.destroy(() => {});
+    }
     clearRefreshCookie(res);
     return res.status(200).json({ message: 'Logged out' });
   },

--- a/src/middlewares/csrf.js
+++ b/src/middlewares/csrf.js
@@ -1,0 +1,8 @@
+import csrf from '../config/csrf.js';
+
+export default function csrfMiddleware(req, res, next) {
+  if (req.path === '/csrf-token') {
+    return next();
+  }
+  return csrf(req, res, next);
+}

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 
 import auth from '../middlewares/auth.js';
 import requireActive from '../middlewares/requireActive.js';
+import csrf from '../config/csrf.js';
 
 import authRouter from './auth.js';
 import usersRouter from './users.js';
@@ -33,7 +34,7 @@ router.use('/register', registerRouter);
 router.use('/profile', profileRouter);
 router.use('/password-reset', passwordResetRouter);
 
-router.get('/csrf-token', (req, res) => {
+router.get('/csrf-token', csrf, (req, res) => {
   res.json({ csrfToken: req.csrfToken() });
 });
 

--- a/tests/authController.test.js
+++ b/tests/authController.test.js
@@ -167,12 +167,14 @@ test('login returns awaiting_confirmation flag', async () => {
   });
 });
 
-test('logout clears refresh cookie', async () => {
-  const req = {};
+test('logout clears refresh cookie and destroys session', async () => {
+  const destroy = jest.fn();
+  const req = { session: { destroy } };
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
 
   await authController.logout(req, res);
 
+  expect(destroy).toHaveBeenCalled();
   expect(clearRefreshCookieMock).toHaveBeenCalledWith(res);
   expect(res.status).toHaveBeenCalledWith(200);
   expect(res.json).toHaveBeenCalledWith({ message: 'Logged out' });

--- a/tests/csrf.test.js
+++ b/tests/csrf.test.js
@@ -1,0 +1,42 @@
+/* global process */
+import { expect, jest, test } from '@jest/globals';
+
+function buildReq(method = 'GET') {
+  return { method, session: {}, path: '/' };
+}
+
+function buildRes() {
+  return { cookie: jest.fn(), locals: {} };
+}
+
+test('csrf middleware sets strict cookie in development', async () => {
+  process.env.NODE_ENV = 'development';
+  jest.resetModules();
+  const { default: csrf } = await import('../src/config/csrf.js');
+  const req = buildReq();
+  const res = buildRes();
+  const next = jest.fn();
+  csrf(req, res, next);
+  expect(res.cookie).toHaveBeenCalledWith(
+    'XSRF-TOKEN',
+    expect.any(String),
+    expect.objectContaining({ sameSite: 'strict', secure: false })
+  );
+  expect(next).toHaveBeenCalled();
+});
+
+test('csrf middleware uses sameSite none and secure cookie in production', async () => {
+  process.env.NODE_ENV = 'production';
+  jest.resetModules();
+  const { default: csrf } = await import('../src/config/csrf.js');
+  const req = buildReq();
+  const res = buildRes();
+  const next = jest.fn();
+  csrf(req, res, next);
+  expect(res.cookie).toHaveBeenCalledWith(
+    'XSRF-TOKEN',
+    expect.any(String),
+    expect.objectContaining({ sameSite: 'none', secure: true })
+  );
+  expect(next).toHaveBeenCalled();
+});

--- a/tests/csrfMiddleware.test.js
+++ b/tests/csrfMiddleware.test.js
@@ -1,0 +1,36 @@
+import { expect, jest, test } from '@jest/globals';
+
+const csrfMock = jest.fn((_req, _res, next) => next());
+
+jest.unstable_mockModule('../src/config/csrf.js', () => ({
+  __esModule: true,
+  default: csrfMock,
+}));
+
+const { default: csrfMiddleware } = await import('../src/middlewares/csrf.js');
+
+function buildRes() {
+  return {};
+}
+
+function buildReq(path = '/') {
+  return { path };
+}
+
+test('delegates to csrf for normal paths', () => {
+  const req = buildReq('/login');
+  const res = buildRes();
+  const next = jest.fn();
+  csrfMiddleware(req, res, next);
+  expect(csrfMock).toHaveBeenCalledWith(req, res, next);
+});
+
+test('bypasses middleware for /csrf-token', () => {
+  csrfMock.mockClear();
+  const req = buildReq('/csrf-token');
+  const res = buildRes();
+  const next = jest.fn();
+  csrfMiddleware(req, res, next);
+  expect(csrfMock).not.toHaveBeenCalled();
+  expect(next).toHaveBeenCalled();
+});

--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -1,0 +1,46 @@
+/* global process */
+import { expect, jest, test } from '@jest/globals';
+
+function buildMocks() {
+  const middleware = jest.fn();
+  const sessionMock = jest.fn(() => middleware);
+  jest.unstable_mockModule('express-session', () => ({
+    __esModule: true,
+    default: sessionMock,
+  }));
+  jest.unstable_mockModule('connect-redis', () => ({
+    __esModule: true,
+    default: jest.fn(() => jest.fn()),
+  }));
+  jest.unstable_mockModule('../src/config/redis.js', () => ({
+    __esModule: true,
+    default: {},
+  }));
+  return { sessionMock, middleware };
+}
+
+test('session cookie secure and sameSite none in production', async () => {
+  process.env.NODE_ENV = 'production';
+  jest.resetModules();
+  const { sessionMock } = buildMocks();
+  const { default: session } = await import('../src/config/session.js');
+  expect(sessionMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      cookie: expect.objectContaining({ secure: true, sameSite: 'none' }),
+    })
+  );
+  expect(typeof session).toBe('function');
+});
+
+test('session cookie lax in development', async () => {
+  process.env.NODE_ENV = 'development';
+  jest.resetModules();
+  const { sessionMock } = buildMocks();
+  const { default: session } = await import('../src/config/session.js');
+  expect(sessionMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      cookie: expect.objectContaining({ secure: false, sameSite: 'lax' }),
+    })
+  );
+  expect(typeof session).toBe('function');
+});


### PR DESCRIPTION
## Summary
- use SameSite=None for csrf cookie in production
- update csrf middleware tests
- avoid redirect loop when login request fails
- skip global csrf check for the `/csrf-token` endpoint
- fetch refresh token without a redundant csrf request

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68618c7a22bc832d9b4135a41874d765