### PR TITLE
Fix auth refresh loop

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -77,9 +77,11 @@ export async function apiFetch(path, options = {}) {
 
   const data = await res.json().catch(() => ({}));
   if (res.status === 401) {
-    const refreshed = await refreshToken();
-    if (refreshed) {
-      return apiFetch(path, options);
+    if (path !== '/auth/refresh') {
+      const refreshed = await refreshToken();
+      if (refreshed) {
+        return apiFetch(path, options);
+      }
     }
     clearAuth();
     if (redirectOn401 && typeof window !== 'undefined' && window.location) {


### PR DESCRIPTION
## Summary
- prevent infinite refresh calls if `/auth/refresh` returns 401

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68619c3144a0832db4d241f6c95bbe74