### PR TITLE
Improve test coverage

### DIFF
--- a/tests/passportMapper.test.js
+++ b/tests/passportMapper.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, test } from '@jest/globals';
+import mapper from '../src/mappers/passportMapper.js';
+
+describe('passportMapper', () => {
+  test('toPublic unwraps passport model and includes associations', () => {
+    const passport = {
+      get: () => ({
+        id: 'p1',
+        series: '11',
+        number: '22',
+        issue_date: '2020-01-01',
+        valid_until: '2030-01-01',
+        issuing_authority: 'OVD',
+        issuing_authority_code: '770-000',
+        place_of_birth: 'Moscow',
+        createdAt: 't',
+        DocumentType: { alias: 'CIVIL', name: 'Civil' },
+        Country: { alias: 'RU', name: 'Russia' },
+      }),
+    };
+    expect(mapper.toPublic(passport)).toEqual({
+      id: 'p1',
+      series: '11',
+      number: '22',
+      issue_date: '2020-01-01',
+      valid_until: '2030-01-01',
+      issuing_authority: 'OVD',
+      issuing_authority_code: '770-000',
+      place_of_birth: 'Moscow',
+      document_type: 'CIVIL',
+      document_type_name: 'Civil',
+      country: 'RU',
+      country_name: 'Russia',
+    });
+  });
+
+  test('toPublic returns null when input is null', () => {
+    expect(mapper.toPublic(null)).toBeNull();
+  });
+});

--- a/tests/userAdminController.test.js
+++ b/tests/userAdminController.test.js
@@ -1,16 +1,43 @@
 import { expect, jest, test } from '@jest/globals';
 
 const setStatusMock = jest.fn();
+const resetPasswordMock = jest.fn();
+const assignRoleMock = jest.fn();
+const removeRoleMock = jest.fn();
 const toPublicMock = jest.fn((u) => u);
 
 jest.unstable_mockModule('../src/services/userService.js', () => ({
   __esModule: true,
-  default: { setStatus: setStatusMock },
+  default: {
+    setStatus: setStatusMock,
+    resetPassword: resetPasswordMock,
+    assignRole: assignRoleMock,
+    removeRole: removeRoleMock,
+  },
 }));
 
 jest.unstable_mockModule('../src/mappers/userMapper.js', () => ({
   __esModule: true,
   default: { toPublic: toPublicMock },
+}));
+
+const createPassportMock = jest.fn();
+const getPassportMock = jest.fn();
+const removePassportMock = jest.fn();
+const passportToPublicMock = jest.fn((p) => p);
+
+jest.unstable_mockModule('../src/services/passportService.js', () => ({
+  __esModule: true,
+  default: {
+    createForUser: createPassportMock,
+    getByUser: getPassportMock,
+    removeByUser: removePassportMock,
+  },
+}));
+
+jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
+  __esModule: true,
+  default: { toPublic: passportToPublicMock },
 }));
 
 const { default: controller } = await import('../src/controllers/userAdminController.js');
@@ -23,3 +50,69 @@ test('approve updates user status to ACTIVE', async () => {
   expect(setStatusMock).toHaveBeenCalledWith('1', 'ACTIVE');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
 });
+
+test('block updates user status to INACTIVE', async () => {
+  setStatusMock.mockResolvedValue({ id: '2' });
+  const req = { params: { id: '2' } };
+  const res = { json: jest.fn() };
+  await controller.block(req, res);
+  expect(setStatusMock).toHaveBeenCalledWith('2', 'INACTIVE');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '2' } });
+});
+
+test('unblock updates user status to ACTIVE', async () => {
+  setStatusMock.mockResolvedValue({ id: '3' });
+  const req = { params: { id: '3' } };
+  const res = { json: jest.fn() };
+  await controller.unblock(req, res);
+  expect(setStatusMock).toHaveBeenCalledWith('3', 'ACTIVE');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '3' } });
+});
+
+
+test('resetPassword returns updated user', async () => {
+  resetPasswordMock.mockResolvedValue({ id: '4' });
+  const req = { params: { id: '4' }, body: { password: 'P' } };
+  const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
+  await controller.resetPassword(req, res);
+  expect(resetPasswordMock).toHaveBeenCalledWith('4', 'P');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '4' } });
+});
+
+test('assignRole assigns role to user', async () => {
+  assignRoleMock.mockResolvedValue({ id: '5' });
+  const req = { params: { id: '5', roleAlias: 'ADMIN' } };
+  const res = { json: jest.fn() };
+  await controller.assignRole(req, res);
+  expect(assignRoleMock).toHaveBeenCalledWith('5', 'ADMIN');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '5' } });
+});
+
+test('removeRole removes role from user', async () => {
+  removeRoleMock.mockResolvedValue({ id: '6' });
+  const req = { params: { id: '6', roleAlias: 'ADMIN' } };
+  const res = { json: jest.fn() };
+  await controller.removeRole(req, res);
+  expect(removeRoleMock).toHaveBeenCalledWith('6', 'ADMIN');
+  expect(res.json).toHaveBeenCalledWith({ user: { id: '6' } });
+});
+
+test('getPassport returns 404 when not found', async () => {
+  getPassportMock.mockResolvedValue(null);
+  const req = { params: { id: '7' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await controller.getPassport(req, res);
+  expect(res.status).toHaveBeenCalledWith(404);
+  expect(res.json).toHaveBeenCalledWith({ error: 'passport_not_found' });
+});
+
+test('addPassport stores new passport', async () => {
+  createPassportMock.mockResolvedValue({ id: 'p1' });
+  const req = { params: { id: '8' }, user: { id: 'admin' }, body: { number: '12' } };
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  await controller.addPassport(req, res);
+  expect(createPassportMock).toHaveBeenCalledWith('8', { number: '12' }, 'admin');
+  expect(res.status).toHaveBeenCalledWith(201);
+  expect(res.json).toHaveBeenCalledWith({ passport: { id: 'p1' } });
+});
+


### PR DESCRIPTION
## Summary
- expand unit tests for `userAdminController`
- add unit tests for `passportMapper`

## Testing
- `npm test`
- `NODE_OPTIONS=--experimental-vm-modules npx jest --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68618f81d230832d990d79318b5f97b6