### PR TITLE
Handle clipboard errors

### DIFF
--- a/client/src/views/AdminUserCreate.vue
+++ b/client/src/views/AdminUserCreate.vue
@@ -3,7 +3,7 @@ import { ref, onMounted } from 'vue'
 import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import UserForm from '../components/UserForm.vue'
-import { Modal } from 'bootstrap'
+import { Modal, Toast } from 'bootstrap'
 
 const router = useRouter()
 
@@ -18,7 +18,10 @@ const user = ref({
 const formRef = ref(null)
 const generatedPassword = ref('')
 const passwordModalRef = ref(null)
+const toastRef = ref(null)
+const toastMessage = ref('')
 let passwordModal
+let toast
 
 function generatePassword(len = 8) {
   const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnpqrstuvwxyz23456789'
@@ -45,6 +48,23 @@ async function save() {
 
 function close() {
   router.push('/users')
+}
+
+function showToast(message) {
+  toastMessage.value = message
+  if (!toast) {
+    toast = new Toast(toastRef.value)
+  }
+  toast.show()
+}
+
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text)
+    showToast('Скопировано')
+  } catch (_err) {
+    showToast('Не удалось скопировать')
+  }
 }
 </script>
 
@@ -77,14 +97,25 @@ function close() {
             <p>Сгенерированный пароль:</p>
             <div class="input-group">
               <input type="text" class="form-control" :value="generatedPassword" readonly />
-              <button type="button" class="btn btn-outline-secondary" @click="navigator.clipboard.writeText(generatedPassword)">Копировать</button>
+              <button type="button" class="btn btn-outline-secondary" @click="copyToClipboard(generatedPassword)">Копировать</button>
             </div>
           </div>
           <div class="modal-footer">
             <button type="button" class="btn btn-primary" @click="passwordModal.hide()">OK</button>
           </div>
         </div>
-      </div>
     </div>
   </div>
+  <div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div
+      ref="toastRef"
+      class="toast text-bg-secondary"
+      role="status"
+      data-bs-delay="1500"
+      data-bs-autohide="true"
+    >
+      <div class="toast-body">{{ toastMessage }}</div>
+    </div>
+  </div>
+</div>
 </template>

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -18,6 +18,7 @@ const sortField = ref('last_name')
 const sortOrder = ref('asc')
 
 const toastRef = ref(null)
+const toastMessage = ref('')
 let toast
 
 const totalPages = computed(() =>
@@ -133,16 +134,21 @@ function formatDate(str) {
   return `${day}.${month}.${year}`
 }
 
-function showToast() {
+function showToast(message) {
+  toastMessage.value = message
   if (!toast) {
     toast = new Toast(toastRef.value)
   }
   toast.show()
 }
 
-function copy(text) {
-  navigator.clipboard.writeText(text)
-  showToast()
+async function copy(text) {
+  try {
+    await navigator.clipboard.writeText(text)
+    showToast('Скопировано')
+  } catch (_err) {
+    showToast('Не удалось скопировать')
+  }
 }
 </script>
 
@@ -325,7 +331,7 @@ function copy(text) {
         data-bs-delay="1500"
         data-bs-autohide="true"
       >
-        <div class="toast-body">Скопировано</div>
+        <div class="toast-body">{{ toastMessage }}</div>
       </div>
     </div>
   </div>

--- a/client/src/views/Profile.vue
+++ b/client/src/views/Profile.vue
@@ -11,6 +11,7 @@ const noDataPlaceholder = '—';
 
 const user = ref(null);
 const toastRef = ref(null);
+const toastMessage = ref('');
 const code = ref('');
 const codeSent = ref(false);
 const verifyError = ref('');
@@ -60,16 +61,21 @@ function maskPassportNumber(num) {
   return start + '*'.repeat(num.length - 2) + end;
 }
 
-function showToast() {
+function showToast(message) {
+  toastMessage.value = message;
   if (!toast) {
     toast = new Toast(toastRef.value);
   }
   toast.show();
 }
 
-function copyToClipboard(text) {
-  navigator.clipboard.writeText(text);
-  showToast();
+async function copyToClipboard(text) {
+  try {
+    await navigator.clipboard.writeText(text);
+    showToast('Скопировано');
+  } catch (_err) {
+    showToast('Не удалось скопировать');
+  }
 }
 
 async function sendCode() {
@@ -682,7 +688,7 @@ onMounted(() => {
         data-bs-delay="1500"
         data-bs-autohide="true"
       >
-        <div class="toast-body">Скопировано</div>
+        <div class="toast-body">{{ toastMessage }}</div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add toastMessage state to copy actions
- wrap navigator.clipboard usage in try/catch and show error toast

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6861a9eee864832dabe85e0cf98b3ebd