### PR TITLE
Combine registration and residence addresses

### DIFF
--- a/client/src/components/UserAddressForm.vue
+++ b/client/src/components/UserAddressForm.vue
@@ -159,9 +159,9 @@ function applySuggestion(sug) {
           </div>
           <div
             v-if="addresses[type.alias]"
-            class="row row-cols-1 row-cols-sm-3 g-3"
+            class="row g-3 align-items-end"
           >
-            <div class="col">
+            <div class="col-auto" style="width: 8ch">
               <div class="form-floating">
                 <input
                   :id="`zip-${type.alias}`"
@@ -174,7 +174,7 @@ function applySuggestion(sug) {
                 <label :for="`zip-${type.alias}`">Индекс</label>
               </div>
             </div>
-            <div class="col">
+            <div class="col-auto" style="width: 12ch">
               <div class="form-floating">
                 <input
                   :id="`country-${type.alias}`"

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -312,7 +312,7 @@ async function save() {
 
     <InnSnilsForm v-if="user" :userId="route.params.id" />
     <BankAccountForm v-if="user" :userId="route.params.id" />
-    <UserAddressForm v-if="user" :userId="route.params.id" />
+    <UserAddressForm v-if="user" :userId="route.params.id" isAdmin />
     <TaxationInfo v-if="user" :userId="route.params.id" />
 
     <div

--- a/src/migrations/20250704000000-update-user-address-unique-index.js
+++ b/src/migrations/20250704000000-update-user-address-unique-index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeConstraint(
+      'user_addresses',
+      'uq_user_address_type'
+    );
+    await queryInterface.addIndex(
+      'user_addresses',
+      ['user_id', 'address_type_id'],
+      {
+        name: 'uq_user_address_type',
+        unique: true,
+        where: { deleted_at: null },
+      }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('user_addresses', 'uq_user_address_type');
+    await queryInterface.addConstraint('user_addresses', {
+      fields: ['user_id', 'address_type_id'],
+      type: 'unique',
+      name: 'uq_user_address_type',
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- merge registration and residence address display into a single card
- split postal code, country and address into separate floating inputs
- add checkbox for admins to reuse residence address when adding registration address

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862d1f9c3c8832d857c2690b5213686