### PR TITLE
Add medical certificate admin management

### DIFF
--- a/client/src/dadata.js
+++ b/client/src/dadata.js
@@ -94,3 +94,16 @@ export async function findBankByBic(bic) {
     return null
   }
 }
+
+export async function findOrganizationByInn(inn) {
+  if (!inn) return null
+  try {
+    const { organization } = await apiFetch('/dadata/find-organization', {
+      method: 'POST',
+      body: JSON.stringify({ inn })
+    })
+    return organization
+  } catch (_err) {
+    return null
+  }
+}

--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -26,6 +26,8 @@ export const ERROR_MESSAGES = {
   status_not_found: 'Статус не найден',
   status_required: 'Не указан статус',
   taxation_not_found: 'Налоговый статус не найден',
+  certificate_not_found: 'Медицинское заключение не найдено',
+  certificate_exists: 'Медицинское заключение уже существует',
   user_exists: 'Пользователь уже существует',
   user_not_found: 'Пользователь не найден',
   not_found: 'Не найдено'

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -11,6 +11,7 @@ import AdminUsers from './views/AdminUsers.vue'
 import AdminHome from './views/AdminHome.vue'
 import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
+import AdminMedicalCertificates from './views/AdminMedicalCertificates.vue'
 import PasswordReset from './views/PasswordReset.vue'
 import NotFound from './views/NotFound.vue'
 import Forbidden from './views/Forbidden.vue'
@@ -24,6 +25,7 @@ const routes = [
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/medical-certificates', component: AdminMedicalCertificates, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },
   { path: '/register', component: Register, meta: { hideLayout: true } },

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -2,7 +2,12 @@
 import { RouterLink } from 'vue-router'
 
 const tiles = [
-  { title: 'Управление пользователями', icon: 'bi-people', to: '/users' }
+  { title: 'Управление пользователями', icon: 'bi-people', to: '/users' },
+  {
+    title: 'Медицинские справки',
+    icon: 'bi-file-earmark-medical',
+    to: '/medical-certificates'
+  }
 ]
 </script>
 

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -1,0 +1,192 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import { Modal } from 'bootstrap'
+import { apiFetch } from '../api.js'
+
+const certificates = ref([])
+const total = ref(0)
+const currentPage = ref(1)
+const pageSize = 8
+const isLoading = ref(false)
+const error = ref('')
+
+const form = ref({
+  user_id: '',
+  inn: '',
+  organization: '',
+  certificate_number: '',
+  issue_date: '',
+  valid_until: ''
+})
+const editing = ref(null)
+const modalRef = ref(null)
+let modal
+const formError = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+
+onMounted(() => {
+  modal = new Modal(modalRef.value)
+  load()
+})
+
+watch(currentPage, load)
+
+async function load() {
+  try {
+    isLoading.value = true
+    const params = new URLSearchParams({ page: currentPage.value, limit: pageSize })
+    const data = await apiFetch(`/medical-certificates?${params}`)
+    certificates.value = data.certificates
+    total.value = data.total
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function openCreate() {
+  editing.value = null
+  Object.keys(form.value).forEach(k => (form.value[k] = ''))
+  formError.value = ''
+  modal.show()
+}
+
+function openEdit(cert) {
+  editing.value = cert
+  Object.assign(form.value, cert)
+  formError.value = ''
+  modal.show()
+}
+
+async function save() {
+  try {
+    formError.value = ''
+    const path = `/users/${form.value.user_id}/medical-certificate`
+    const method = editing.value ? 'PUT' : 'POST'
+    await apiFetch(path, { method, body: JSON.stringify(form.value) })
+    modal.hide()
+    await load()
+  } catch (e) {
+    formError.value = e.message
+  }
+}
+
+async function removeCert(cert) {
+  if (!confirm('Удалить запись?')) return
+  await apiFetch(`/medical-certificates/${cert.id}`, { method: 'DELETE' })
+  await load()
+}
+
+function formatDate(str) {
+  if (!str) return ''
+  const [y, m, d] = str.split('-')
+  return `${d}.${m}.${y}`
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Медицинские справки</li>
+      </ol>
+    </nav>
+    <h1 class="mb-4">Медицинские заключения</h1>
+    <div class="mb-3 text-end">
+      <button class="btn btn-brand" @click="openCreate"><i class="bi bi-plus-lg me-1"></i>Добавить</button>
+    </div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="isLoading" class="text-center my-3">
+      <div class="spinner-border" role="status"></div>
+    </div>
+    <div v-if="certificates.length" class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Пользователь</th>
+            <th>Номер</th>
+            <th>Учреждение</th>
+            <th>ИНН</th>
+            <th>Период действия</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="c in certificates" :key="c.id">
+            <td>{{ c.user ? c.user.last_name + ' ' + c.user.first_name : c.user_id }}</td>
+            <td>{{ c.certificate_number }}</td>
+            <td>{{ c.organization }}</td>
+            <td>{{ c.inn }}</td>
+            <td>{{ formatDate(c.issue_date) }} - {{ formatDate(c.valid_until) }}</td>
+            <td class="text-end">
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(c)">Изменить</button>
+              <button class="btn btn-sm btn-danger" @click="removeCert(c)">Удалить</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-else-if="!isLoading" class="text-muted">Записей нет.</p>
+    <nav class="mt-3" v-if="totalPages > 1">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: currentPage === 1 }">
+          <button class="page-link" @click="currentPage--" :disabled="currentPage === 1">Пред</button>
+        </li>
+        <li class="page-item" v-for="p in totalPages" :key="p" :class="{ active: currentPage === p }">
+          <button class="page-link" @click="currentPage = p">{{ p }}</button>
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+          <button class="page-link" @click="currentPage++" :disabled="currentPage === totalPages">След</button>
+        </li>
+      </ul>
+    </nav>
+
+    <div ref="modalRef" class="modal fade" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form @submit.prevent="save">
+            <div class="modal-header">
+              <h5 class="modal-title">{{ editing ? 'Изменить' : 'Добавить' }} справку</h5>
+              <button type="button" class="btn-close" @click="modal.hide()"></button>
+            </div>
+            <div class="modal-body">
+              <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
+              <div class="form-floating mb-3">
+                <input id="userId" v-model="form.user_id" class="form-control" placeholder="ID пользователя" />
+                <label for="userId">ID пользователя</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="certNumber" v-model="form.certificate_number" class="form-control" placeholder="Номер" />
+                <label for="certNumber">Номер</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="certOrg" v-model="form.organization" class="form-control" placeholder="Учреждение" />
+                <label for="certOrg">Учреждение</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="certInn" v-model="form.inn" class="form-control" placeholder="ИНН" />
+                <label for="certInn">ИНН</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="issue" type="date" v-model="form.issue_date" class="form-control" />
+                <label for="issue">Дата выдачи</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="valid" type="date" v-model="form.valid_until" class="form-control" />
+                <label for="valid">Действительно до</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+              <button type="submit" class="btn btn-primary">Сохранить</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -120,6 +120,10 @@ function selectUser(u) {
 async function save() {
   try {
     formError.value = ''
+    if (!form.value.user_id) {
+      formError.value = 'Выберите пользователя'
+      return
+    }
     const path = `/users/${form.value.user_id}/medical-certificate`
     const method = editing.value ? 'PUT' : 'POST'
     await apiFetch(path, { method, body: JSON.stringify(form.value) })
@@ -243,12 +247,12 @@ function formatDate(str) {
                 <label for="certNumber">Номер</label>
               </div>
               <div class="form-floating mb-3">
-                <input id="certOrg" v-model="form.organization" class="form-control" placeholder="Учреждение" readonly />
-                <label for="certOrg">Учреждение</label>
-              </div>
-              <div class="form-floating mb-3">
                 <input id="certInn" v-model="form.inn" class="form-control" placeholder="ИНН" />
                 <label for="certInn">ИНН</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="certOrg" v-model="form.organization" class="form-control" placeholder="Учреждение" disabled />
+                <label for="certOrg">Учреждение</label>
               </div>
               <div class="form-floating mb-3">
                 <input id="issue" type="date" v-model="form.issue_date" class="form-control" />

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -27,6 +27,7 @@ const formError = ref('')
 const userQuery = ref('')
 const userSuggestions = ref([])
 let userTimeout
+let skipUserWatch = false
 
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
 
@@ -39,6 +40,10 @@ watch(currentPage, load)
 
 watch(userQuery, () => {
   clearTimeout(userTimeout)
+  if (skipUserWatch) {
+    skipUserWatch = false
+    return
+  }
   form.value.user_id = ''
   if (!userQuery.value || userQuery.value.length < 2) {
     userSuggestions.value = []
@@ -94,6 +99,7 @@ async function load() {
 function openCreate() {
   editing.value = null
   Object.keys(form.value).forEach(k => (form.value[k] = ''))
+  skipUserWatch = true
   userQuery.value = ''
   userSuggestions.value = []
   formError.value = ''
@@ -103,6 +109,7 @@ function openCreate() {
 function openEdit(cert) {
   editing.value = cert
   Object.assign(form.value, cert)
+  skipUserWatch = true
   userQuery.value = cert.user
     ? `${cert.user.last_name} ${cert.user.first_name}`
     : ''
@@ -113,6 +120,7 @@ function openEdit(cert) {
 
 function selectUser(u) {
   form.value.user_id = u.id
+  skipUserWatch = true
   userQuery.value = `${u.last_name} ${u.first_name}`
   userSuggestions.value = []
 }

--- a/src/controllers/dadataController.js
+++ b/src/controllers/dadataController.js
@@ -38,4 +38,9 @@ export default {
     const bank = await dadata.findBankByBic(req.body.bic);
     return res.json({ bank });
   },
+
+  async findOrganization(req, res) {
+    const organization = await dadata.findOrganizationByInn(req.body.inn);
+    return res.json({ organization });
+  },
 };

--- a/src/controllers/medicalCertificateAdminController.js
+++ b/src/controllers/medicalCertificateAdminController.js
@@ -1,0 +1,90 @@
+import { validationResult } from 'express-validator';
+
+import medicalCertificateService from '../services/medicalCertificateService.js';
+import medicalCertificateMapper from '../mappers/medicalCertificateMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await medicalCertificateService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({
+      certificates: rows.map(medicalCertificateMapper.toPublic),
+      total: count,
+    });
+  },
+
+  async get(req, res) {
+    try {
+      const cert = await medicalCertificateService.getById(req.params.id);
+      return res.json({ certificate: medicalCertificateMapper.toPublic(cert) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const cert = await medicalCertificateService.createForUser(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res
+        .status(201)
+        .json({ certificate: medicalCertificateMapper.toPublic(cert) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const cert = await medicalCertificateService.updateForUser(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ certificate: medicalCertificateMapper.toPublic(cert) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async updateById(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const cert = await medicalCertificateService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ certificate: medicalCertificateMapper.toPublic(cert) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await medicalCertificateService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/mappers/medicalCertificateMapper.js
+++ b/src/mappers/medicalCertificateMapper.js
@@ -1,14 +1,36 @@
 function sanitize(obj) {
-  const { id, inn, organization, certificate_number, issue_date, valid_until } =
-    obj;
-  return { id, inn, organization, certificate_number, issue_date, valid_until };
+  const {
+    id,
+    inn,
+    organization,
+    certificate_number,
+    issue_date,
+    valid_until,
+  } = obj;
+  return {
+    id,
+    inn,
+    organization,
+    certificate_number,
+    issue_date,
+    valid_until,
+  };
 }
 
 function toPublic(cert) {
   if (!cert) return null;
-  const plain =
-    typeof cert.get === 'function' ? cert.get({ plain: true }) : cert;
-  return sanitize(plain);
+  const plain = typeof cert.get === 'function' ? cert.get({ plain: true }) : cert;
+  const result = sanitize(plain);
+  if (plain.user_id) result.user_id = plain.user_id;
+  if (plain.User) {
+    result.user = {
+      id: plain.User.id,
+      last_name: plain.User.last_name,
+      first_name: plain.User.first_name,
+      patronymic: plain.User.patronymic,
+    };
+  }
+  return result;
 }
 
 export default { toPublic };

--- a/src/routes/dadata.js
+++ b/src/routes/dadata.js
@@ -96,4 +96,17 @@ router.post('/clean-passport', auth, controller.cleanPassport);
  */
 router.post('/find-bank', auth, controller.findBank);
 
+/**
+ * @swagger
+ * /dadata/find-organization:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Find organization by INN
+ *     responses:
+ *       200:
+ *         description: Organization information
+ */
+router.post('/find-organization', auth, controller.findOrganization);
+
 export default router;

--- a/src/routes/medicalCertificates.js
+++ b/src/routes/medicalCertificates.js
@@ -1,8 +1,10 @@
 import express from 'express';
 
 import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
 import medicalCertificateController from '../controllers/medicalCertificateController.js';
 import selfController from '../controllers/medicalCertificateSelfController.js';
+import adminController from '../controllers/medicalCertificateAdminController.js';
 import { medicalCertificateRules } from '../validators/medicalCertificateValidators.js';
 
 const router = express.Router();
@@ -11,5 +13,16 @@ router.get('/me', auth, medicalCertificateController.me);
 router.get('/me/history', auth, medicalCertificateController.history);
 router.post('/', auth, medicalCertificateRules, selfController.create);
 router.delete('/', auth, selfController.remove);
+
+router.get('/', auth, authorize('ADMIN'), adminController.list);
+router.get('/:id', auth, authorize('ADMIN'), adminController.get);
+router.put(
+  '/:id',
+  auth,
+  authorize('ADMIN'),
+  medicalCertificateRules,
+  adminController.updateById
+);
+router.delete('/:id', auth, authorize('ADMIN'), adminController.remove);
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -10,6 +10,7 @@ import snilsAdmin from '../controllers/snilsAdminController.js';
 import bankAccountAdmin from '../controllers/bankAccountAdminController.js';
 import taxationAdmin from '../controllers/taxationAdminController.js';
 import addressAdmin from '../controllers/addressAdminController.js';
+import medicalCertificateAdmin from '../controllers/medicalCertificateAdminController.js';
 import {
   createUserRules,
   updateUserRules,
@@ -18,6 +19,7 @@ import {
 import { innRules, snilsRules } from '../validators/personalValidators.js';
 import { bankAccountRules } from '../validators/bankAccountValidators.js';
 import { addressRules } from '../validators/addressValidators.js';
+import { medicalCertificateRules } from '../validators/medicalCertificateValidators.js';
 import { createPassportRules } from '../validators/passportValidators.js';
 
 const router = express.Router();
@@ -731,5 +733,100 @@ router.delete(
  *         description: Address info
  */
 router.get('/:id/address/:type', auth, authorize('ADMIN'), addressAdmin.get);
+
+/**
+ * @swagger
+ * /users/{id}/medical-certificate:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Add medical certificate for user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       201:
+ *         description: Created
+ */
+router.post(
+  '/:id/medical-certificate',
+  auth,
+  authorize('ADMIN'),
+  medicalCertificateRules,
+  medicalCertificateAdmin.create
+);
+/**
+ * @swagger
+ * /users/{id}/medical-certificate:
+ *   put:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Update user's medical certificate
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated
+ */
+router.put(
+  '/:id/medical-certificate',
+  auth,
+  authorize('ADMIN'),
+  medicalCertificateRules,
+  medicalCertificateAdmin.update
+);
+/**
+ * @swagger
+ * /users/{id}/medical-certificate:
+ *   delete:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Remove user's medical certificate
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       204:
+ *         description: Removed
+ */
+router.delete(
+  '/:id/medical-certificate',
+  auth,
+  authorize('ADMIN'),
+  medicalCertificateAdmin.remove
+);
+/**
+ * @swagger
+ * /users/{id}/medical-certificate:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Get user's medical certificate
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Certificate info
+ */
+router.get(
+  '/:id/medical-certificate',
+  auth,
+  authorize('ADMIN'),
+  medicalCertificateAdmin.get
+);
 
 export default router;

--- a/src/services/dadataService.js
+++ b/src/services/dadataService.js
@@ -110,6 +110,13 @@ export async function findPartyByInn(inn) {
   return data.suggestions[0];
 }
 
+export async function findOrganizationByInn(inn) {
+  if (!inn) return null;
+  const data = await request('/findById/party', { query: inn, type: 'LEGAL' });
+  if (!data?.suggestions?.length) return null;
+  return data.suggestions[0];
+}
+
 export async function findPartyByInnWithStatus(inn) {
   if (!inn) return { data: null, status: 400 };
   const { data, status } = await requestRaw('/findById/party', {
@@ -130,4 +137,5 @@ export default {
   findBankByBic,
   findPartyByInn,
   findPartyByInnWithStatus,
+  findOrganizationByInn,
 };

--- a/src/services/medicalCertificateService.js
+++ b/src/services/medicalCertificateService.js
@@ -39,4 +39,68 @@ async function removeForUser(userId) {
   await cert.destroy();
 }
 
-export default { getByUser, listByUser, createForUser, removeForUser };
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+
+  return MedicalCertificate.findAndCountAll({
+    include: [User],
+    order: [['issue_date', 'DESC']],
+    limit,
+    offset,
+    paranoid: false,
+  });
+}
+
+async function getById(id) {
+  const cert = await MedicalCertificate.findByPk(id, { include: [User], paranoid: false });
+  if (!cert) throw new ServiceError('certificate_not_found', 404);
+  return cert;
+}
+
+async function updateForUser(userId, data, actorId) {
+  const cert = await MedicalCertificate.findOne({ where: { user_id: userId } });
+  if (!cert) throw new ServiceError('certificate_not_found', 404);
+  await cert.update({
+    inn: data.inn,
+    organization: data.organization,
+    certificate_number: data.certificate_number,
+    issue_date: data.issue_date,
+    valid_until: data.valid_until,
+    updated_by: actorId,
+  });
+  return cert;
+}
+
+async function update(id, data, actorId) {
+  const cert = await MedicalCertificate.findByPk(id);
+  if (!cert) throw new ServiceError('certificate_not_found', 404);
+  await cert.update({
+    inn: data.inn,
+    organization: data.organization,
+    certificate_number: data.certificate_number,
+    issue_date: data.issue_date,
+    valid_until: data.valid_until,
+    updated_by: actorId,
+  });
+  return cert;
+}
+
+async function remove(id) {
+  const cert = await MedicalCertificate.findByPk(id);
+  if (!cert) throw new ServiceError('certificate_not_found', 404);
+  await cert.destroy();
+}
+
+export default {
+  getByUser,
+  listByUser,
+  createForUser,
+  removeForUser,
+  listAll,
+  getById,
+  updateForUser,
+  update,
+  remove,
+};

--- a/tests/dadataService.test.js
+++ b/tests/dadataService.test.js
@@ -19,6 +19,7 @@ const {
   suggestFmsUnit,
   cleanPassport,
   findBankByBic,
+  findOrganizationByInn,
 } = await import('../src/services/dadataService.js');
 
 test('suggestFio returns array from API', async () => {
@@ -87,6 +88,21 @@ test('findBankByBic returns first suggestion', async () => {
     })
   );
   expect(res).toEqual({ value: 'bank' });
+});
+
+test('findOrganizationByInn returns first suggestion', async () => {
+  fetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ suggestions: [{ value: 'org' }] }),
+  });
+  const res = await findOrganizationByInn('7707083893');
+  expect(fetch).toHaveBeenCalledWith(
+    expect.stringContaining('/findById/party'),
+    expect.objectContaining({
+      body: JSON.stringify({ query: '7707083893', type: 'LEGAL' }),
+    })
+  );
+  expect(res).toEqual({ value: 'org' });
 });
 
 test('returns null when token missing', async () => {


### PR DESCRIPTION
## Summary
- implement admin page for managing medical certificates
- include tile on admin home page
- expose admin route handler for updating certificate by ID
- extend service and mapper with admin support
- add client error messages

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862d4771868832dbe38d41a9221722f