### PR TITLE
Fix registration password validation

### DIFF
--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -5,10 +5,8 @@ export const JWT_SECRET = process.env.JWT_SECRET;
 
 export const PASSWORD_MIN_LENGTH =
   parseInt(process.env.PASSWORD_MIN_LENGTH, 10) || 8;
-import _ from 'lodash';
-
 export const PASSWORD_PATTERN = new RegExp(
-  _.escapeRegExp(process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)')
+  process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)'
 );
 
 export const COOKIE_NAME = 'refresh_token';

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -21,7 +21,7 @@ export default {
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const { email } = req.body;
+    const email = String(req.body.email).trim().toLowerCase();
     const existing = await User.findOne({ where: { email } });
     if (existing) return res.status(400).json({ error: 'user_exists' });
 
@@ -67,7 +67,8 @@ export default {
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const { email, code, password } = req.body;
+    const email = String(req.body.email).trim().toLowerCase();
+    const { code, password } = req.body;
     const user = await User.findOne({ where: { email } });
     if (!user) return res.status(404).json({ error: 'not_found' });
 

--- a/tests/passwordPattern.test.js
+++ b/tests/passwordPattern.test.js
@@ -1,0 +1,7 @@
+import { expect, test } from '@jest/globals';
+import { PASSWORD_PATTERN } from '../src/config/auth.js';
+
+test('default password pattern matches mixed letters and digits', () => {
+  expect(PASSWORD_PATTERN.test('Passw0rd1')).toBe(true);
+});
+


### PR DESCRIPTION
## Summary
- correct PASSWORD_PATTERN in config to actually apply regex
- normalize email case in registration controller
- test default password regex

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e07b40e4832db04c4d027ceb7316