### PR TITLE
Improve medical certificate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - ESLint and Prettier for code quality
 - Jest unit tests
 - Admin panel for managing users and roles (create, edit, block)
+- Soft deletion of records using Sequelize paranoid mode
+- Users can have multiple medical certificates; the active one with the
+  longest validity is returned in personal APIs
 
 ## Branching strategy
 

--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -27,7 +27,6 @@ export const ERROR_MESSAGES = {
   status_required: 'Не указан статус',
   taxation_not_found: 'Налоговый статус не найден',
   certificate_not_found: 'Медицинское заключение не найдено',
-  certificate_exists: 'Медицинское заключение уже существует',
   user_exists: 'Пользователь уже существует',
   user_not_found: 'Пользователь не найден',
   not_found: 'Не найдено'

--- a/src/migrations/20250730000001-drop-unique-med-cert-index.js
+++ b/src/migrations/20250730000001-drop-unique-med-cert-index.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeIndex('medical_certificates', 'uq_medical_certificates_user_id_not_deleted');
+  },
+
+  async down(queryInterface) {
+    await queryInterface.addIndex('medical_certificates', ['user_id'], {
+      name: 'uq_medical_certificates_user_id_not_deleted',
+      unique: true,
+      where: { deleted_at: null },
+    });
+  },
+};

--- a/tests/medicalCertificateService.test.js
+++ b/tests/medicalCertificateService.test.js
@@ -1,0 +1,44 @@
+import { expect, jest, test } from '@jest/globals';
+
+const findOneMock = jest.fn();
+const createMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  MedicalCertificate: { findOne: findOneMock, create: createMock },
+  User: { findByPk: jest.fn().mockResolvedValue({ id: 'u1' }) },
+}));
+
+const { default: service } = await import('../src/services/medicalCertificateService.js');
+
+test('getByUser selects latest valid certificate', async () => {
+  const cert = { id: 'c2' };
+  findOneMock.mockResolvedValue(cert);
+  const res = await service.getByUser('u1');
+  expect(res).toBe(cert);
+  const opts = findOneMock.mock.calls[0][0];
+  expect(opts.order).toEqual([["valid_until", "DESC"]]);
+  expect(opts.where.user_id).toBe('u1');
+  const key = Object.getOwnPropertySymbols(opts.where.valid_until)[0];
+  expect(key.toString()).toContain('gte');
+  expect(opts.where.valid_until[key]).toBeInstanceOf(Date);
+});
+
+test('createForUser creates certificate for existing user', async () => {
+  const data = {
+    inn: '1',
+    organization: 'Org',
+    certificate_number: 'num',
+    issue_date: '2024-01-01',
+    valid_until: '2025-01-01',
+  };
+  createMock.mockResolvedValue(data);
+  const res = await service.createForUser('u1', data, 'a1');
+  expect(createMock).toHaveBeenCalledWith({
+    user_id: 'u1',
+    ...data,
+    created_by: 'a1',
+    updated_by: 'a1',
+  });
+  expect(res).toBe(data);
+});


### PR DESCRIPTION
## Summary
- support multiple medical certificates per user
- return latest active certificate in personal section
- drop uniqueness constraint on medical certificates
- add unit tests for the medical certificate service
- document soft deletes and certificate behaviour

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6862e2bf3284832db8a44f4c697040cb