### PR TITLE
Add camp stadium management

### DIFF
--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -27,6 +27,8 @@ export const ERROR_MESSAGES = {
   status_required: 'Не указан статус',
   taxation_not_found: 'Налоговый статус не найден',
   certificate_not_found: 'Медицинское заключение не найдено',
+  stadium_not_found: 'Спортсооружение не найдено',
+  invalid_address: 'Некорректный адрес',
   user_exists: 'Пользователь уже существует',
   user_not_found: 'Пользователь не найден',
   not_found: 'Не найдено'

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -12,6 +12,7 @@ import AdminHome from './views/AdminHome.vue'
 import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
 import AdminMedicalCertificates from './views/AdminMedicalCertificates.vue'
+import AdminCampStadiums from './views/AdminCampStadiums.vue'
 import PasswordReset from './views/PasswordReset.vue'
 import NotFound from './views/NotFound.vue'
 import Forbidden from './views/Forbidden.vue'
@@ -26,6 +27,7 @@ const routes = [
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/medical-certificates', component: AdminMedicalCertificates, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/camp-stadiums', component: AdminCampStadiums, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },
   { path: '/register', component: Register, meta: { hideLayout: true } },

--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -1,0 +1,317 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue';
+import { RouterLink } from 'vue-router';
+import { Modal } from 'bootstrap';
+import { apiFetch } from '../api.js';
+import { suggestAddress, cleanAddress } from '../dadata.js';
+
+const stadiums = ref([]);
+const total = ref(0);
+const currentPage = ref(1);
+const pageSize = 8;
+const isLoading = ref(false);
+const error = ref('');
+
+const parkingTypes = ref([]);
+
+const form = ref({
+  name: '',
+  address: { result: '' },
+  yandex_url: '',
+  capacity: '',
+  phone: '',
+  website: '',
+  parking: [],
+});
+const editing = ref(null);
+const modalRef = ref(null);
+let modal;
+const formError = ref('');
+const addressSuggestions = ref([]);
+let addrTimeout;
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)));
+
+onMounted(() => {
+  modal = new Modal(modalRef.value);
+  load();
+  loadParkingTypes();
+});
+
+watch(currentPage, load);
+
+watch(
+  () => form.value.address.result,
+  (val) => {
+    clearTimeout(addrTimeout);
+    if (!val || val.length < 3) {
+      addressSuggestions.value = [];
+      return;
+    }
+    const query = val.trim();
+    addrTimeout = setTimeout(async () => {
+      addressSuggestions.value = await suggestAddress(query);
+    }, 300);
+  }
+);
+
+async function loadParkingTypes() {
+  try {
+    const data = await apiFetch('/camp-stadiums/parking-types');
+    parkingTypes.value = data.parkingTypes;
+  } catch (_) {
+    parkingTypes.value = [];
+  }
+}
+
+async function load() {
+  try {
+    isLoading.value = true;
+    const params = new URLSearchParams({
+      page: currentPage.value,
+      limit: pageSize,
+    });
+    const data = await apiFetch(`/camp-stadiums?${params}`);
+    stadiums.value = data.stadiums;
+    total.value = data.total;
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+function makeParkingForm() {
+  return parkingTypes.value.map((t) => ({ type: t.alias, price: '', enabled: false }));
+}
+
+function openCreate() {
+  editing.value = null;
+  form.value = {
+    name: '',
+    address: { result: '' },
+    yandex_url: '',
+    capacity: '',
+    phone: '',
+    website: '',
+    parking: makeParkingForm(),
+  };
+  formError.value = '';
+  addressSuggestions.value = [];
+  modal.show();
+}
+
+function openEdit(s) {
+  editing.value = s;
+  form.value = {
+    name: s.name,
+    address: { result: s.address?.result || '' },
+    yandex_url: s.yandex_url || '',
+    capacity: s.capacity || '',
+    phone: s.phone || '',
+    website: s.website || '',
+    parking: parkingTypes.value.map((t) => {
+      const found = (s.parking || []).find((p) => p.type === t.alias);
+      return { type: t.alias, price: found?.price || '', enabled: !!found };
+    }),
+  };
+  formError.value = '';
+  addressSuggestions.value = [];
+  modal.show();
+}
+
+async function save() {
+  const payload = {
+    name: form.value.name,
+    address: { result: form.value.address.result },
+    yandex_url: form.value.yandex_url || undefined,
+    capacity: form.value.capacity || undefined,
+    phone: form.value.phone || undefined,
+    website: form.value.website || undefined,
+    parking: form.value.parking
+      .filter((p) => p.enabled)
+      .map((p) => ({ type: p.type, price: p.price || null })),
+  };
+  try {
+    if (editing.value) {
+      await apiFetch(`/camp-stadiums/${editing.value.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await apiFetch('/camp-stadiums', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    }
+    modal.hide();
+    await load();
+  } catch (e) {
+    formError.value = e.message;
+  }
+}
+
+async function removeStadium(s) {
+  if (!confirm('Удалить стадион?')) return;
+  await apiFetch(`/camp-stadiums/${s.id}`, { method: 'DELETE' });
+  await load();
+}
+
+function applyAddressSuggestion(sug) {
+  form.value.address.result = sug.value;
+  addressSuggestions.value = [];
+}
+
+async function onAddressBlur() {
+  const cleaned = await cleanAddress(form.value.address.result);
+  if (cleaned && cleaned.result) {
+    form.value.address.result = cleaned.result;
+  }
+  addressSuggestions.value = [];
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item">
+          <RouterLink to="/admin">Администрирование</RouterLink>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">Стадионы</li>
+      </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Стадионы</h1>
+      <button class="btn btn-brand" @click="openCreate">
+        <i class="bi bi-plus-lg me-1"></i>Добавить
+      </button>
+    </div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="isLoading" class="text-center my-3">
+      <div class="spinner-border" role="status"></div>
+    </div>
+    <div v-if="stadiums.length" class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Название</th>
+            <th>Адрес</th>
+            <th class="text-center">Вместимость</th>
+            <th>Телефон</th>
+            <th class="d-none d-md-table-cell">Сайт</th>
+            <th class="d-none d-lg-table-cell">Парковка</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="st in stadiums" :key="st.id">
+            <td>{{ st.name }}</td>
+            <td>{{ st.address?.result }}</td>
+            <td class="text-center">{{ st.capacity }}</td>
+            <td>{{ st.phone }}</td>
+            <td class="d-none d-md-table-cell">
+              <a v-if="st.website" :href="st.website" target="_blank">{{ st.website }}</a>
+            </td>
+            <td class="d-none d-lg-table-cell">
+              <div v-if="st.parking?.length">
+                <span v-for="p in st.parking" :key="p.type" class="d-block">
+                  {{ p.type_name }}<span v-if="p.price"> — {{ p.price }} ₽</span>
+                </span>
+              </div>
+              <span v-else class="text-muted">Нет</span>
+            </td>
+            <td class="text-end">
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(st)">Изменить</button>
+              <button class="btn btn-sm btn-danger" @click="removeStadium(st)">Удалить</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-else-if="!isLoading" class="text-muted">Записей нет.</p>
+    <nav class="mt-3" v-if="totalPages > 1">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: currentPage === 1 }">
+          <button class="page-link" @click="currentPage--" :disabled="currentPage === 1">Пред</button>
+        </li>
+        <li class="page-item" v-for="p in totalPages" :key="p" :class="{ active: currentPage === p }">
+          <button class="page-link" @click="currentPage = p">{{ p }}</button>
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+          <button class="page-link" @click="currentPage++" :disabled="currentPage === totalPages">След</button>
+        </li>
+      </ul>
+    </nav>
+
+    <div ref="modalRef" class="modal fade" tabindex="-1">
+      <div class="modal-dialog modal-lg">
+        <div class="modal-content">
+          <form @submit.prevent="save">
+            <div class="modal-header">
+              <h5 class="modal-title">{{ editing ? 'Изменить стадион' : 'Добавить стадион' }}</h5>
+              <button type="button" class="btn-close" @click="modal.hide()"></button>
+            </div>
+            <div class="modal-body">
+              <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
+              <div class="form-floating mb-3">
+                <input id="stadName" v-model="form.name" class="form-control" placeholder="Название" required />
+                <label for="stadName">Наименование</label>
+              </div>
+              <div class="form-floating mb-3 position-relative">
+                <textarea id="stadAddr" v-model="form.address.result" @blur="onAddressBlur" class="form-control" rows="2" placeholder="Адрес"></textarea>
+                <label for="stadAddr">Адрес</label>
+                <ul v-if="addressSuggestions.length" class="list-group position-absolute w-100" style="z-index: 1050">
+                  <li v-for="s in addressSuggestions" :key="s.value" class="list-group-item list-group-item-action" @mousedown.prevent="applyAddressSuggestion(s)">
+                    {{ s.value }}
+                  </li>
+                </ul>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="stadYandex" v-model="form.yandex_url" class="form-control" placeholder="URL в Яндекс.Картах" />
+                <label for="stadYandex">URL в Яндекс.Картах</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="stadCapacity" v-model="form.capacity" type="number" class="form-control" placeholder="Вместимость" />
+                <label for="stadCapacity">Вместимость</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="stadPhone" v-model="form.phone" class="form-control" placeholder="Телефон" />
+                <label for="stadPhone">Телефон</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="stadWebsite" v-model="form.website" class="form-control" placeholder="Сайт" />
+                <label for="stadWebsite">Сайт</label>
+              </div>
+              <div class="mb-3" v-if="parkingTypes.length">
+                <h6 class="mb-2">Парковка</h6>
+                <div v-for="(p, idx) in form.parking" :key="p.type" class="row g-2 align-items-center mb-2">
+                  <div class="col-auto">
+                    <div class="form-check form-switch">
+                      <input class="form-check-input" type="checkbox" v-model="p.enabled" :id="`p-${idx}`" />
+                      <label class="form-check-label" :for="`p-${idx}`">{{ parkingTypes[idx].name }}</label>
+                    </div>
+                  </div>
+                  <div class="col" v-if="p.enabled">
+                    <input v-model="p.price" type="number" min="0" step="0.01" class="form-control" placeholder="Цена" />
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+              <button type="submit" class="btn btn-primary">Сохранить</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.list-group {
+  max-height: 200px;
+  overflow-y: auto;
+}
+</style>

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -7,6 +7,11 @@ const tiles = [
     title: 'Медицинские справки',
     icon: 'bi-file-earmark-medical',
     to: '/medical-certificates'
+  },
+  {
+    title: 'Управление сборами',
+    icon: 'bi-building',
+    to: '/camp-stadiums'
   }
 ]
 </script>

--- a/src/controllers/campStadiumAdminController.js
+++ b/src/controllers/campStadiumAdminController.js
@@ -1,0 +1,71 @@
+import { validationResult } from 'express-validator';
+
+import campStadiumService from '../services/campStadiumService.js';
+import mapper from '../mappers/campStadiumMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await campStadiumService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({ stadiums: rows.map(mapper.toPublic), total: count });
+  },
+
+  async get(req, res) {
+    try {
+      const stadium = await campStadiumService.getById(req.params.id);
+      return res.json({ stadium: mapper.toPublic(stadium) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const stadium = await campStadiumService.create(req.body, req.user.id);
+      return res.status(201).json({ stadium: mapper.toPublic(stadium) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const stadium = await campStadiumService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ stadium: mapper.toPublic(stadium) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await campStadiumService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async parkingTypes(_req, res) {
+    const types = await campStadiumService.listParkingTypes();
+    return res.json({
+      parkingTypes: types.map((t) => ({ id: t.id, name: t.name, alias: t.alias })),
+    });
+  },
+};

--- a/src/mappers/campStadiumMapper.js
+++ b/src/mappers/campStadiumMapper.js
@@ -1,0 +1,44 @@
+function sanitize(obj) {
+  const {
+    id,
+    name,
+    yandex_url,
+    capacity,
+    phone,
+    website,
+    Address,
+    ParkingTypes,
+    ...rest
+  } = obj;
+  void rest.createdAt;
+  void rest.updatedAt;
+  void rest.deletedAt;
+  void rest.created_at;
+  void rest.updated_at;
+  void rest.deleted_at;
+  const res = { id, name, yandex_url, capacity, phone, website };
+  if (Address) {
+    res.address = {
+      id: Address.id,
+      result: Address.result,
+      geo_lat: Address.geo_lat,
+      geo_lon: Address.geo_lon,
+    };
+  }
+  if (ParkingTypes) {
+    res.parking = ParkingTypes.map((p) => ({
+      type: p.alias,
+      type_name: p.name,
+      price: p.CampStadiumParkingType.price,
+    }));
+  }
+  return res;
+}
+
+function toPublic(stadium) {
+  if (!stadium) return null;
+  const plain = typeof stadium.get === 'function' ? stadium.get({ plain: true }) : stadium;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/migrations/20250705000000-create-parking-types.js
+++ b/src/migrations/20250705000000-create-parking-types.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('parking_types', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('parking_types');
+  },
+};

--- a/src/migrations/20250705001000-create-camp-stadiums.js
+++ b/src/migrations/20250705001000-create-camp-stadiums.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('camp_stadiums', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(255), allowNull: false },
+      address_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'addresses', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      yandex_url: { type: Sequelize.STRING(500) },
+      capacity: { type: Sequelize.INTEGER },
+      phone: { type: Sequelize.STRING(50) },
+      website: { type: Sequelize.STRING(255) },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('camp_stadiums');
+  },
+};

--- a/src/migrations/20250705002000-create-camp-stadium-parking-types.js
+++ b/src/migrations/20250705002000-create-camp-stadium-parking-types.js
@@ -1,0 +1,59 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('camp_stadium_parking_types', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      camp_stadium_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'camp_stadiums', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      parking_type_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'parking_types', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      price: { type: Sequelize.DECIMAL(10, 2) },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+    await queryInterface.addConstraint('camp_stadium_parking_types', {
+      fields: ['camp_stadium_id', 'parking_type_id'],
+      type: 'unique',
+      name: 'uq_camp_stadium_parking_types_pair',
+      where: { deleted_at: null },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('camp_stadium_parking_types');
+  },
+};

--- a/src/models/campStadium.js
+++ b/src/models/campStadium.js
@@ -1,0 +1,30 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class CampStadium extends Model {}
+
+CampStadium.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(255), allowNull: false },
+    address_id: { type: DataTypes.UUID, allowNull: false },
+    yandex_url: { type: DataTypes.STRING(500) },
+    capacity: { type: DataTypes.INTEGER },
+    phone: { type: DataTypes.STRING(50) },
+    website: { type: DataTypes.STRING(255) },
+  },
+  {
+    sequelize,
+    modelName: 'CampStadium',
+    tableName: 'camp_stadiums',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default CampStadium;

--- a/src/models/campStadiumParkingType.js
+++ b/src/models/campStadiumParkingType.js
@@ -1,0 +1,28 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class CampStadiumParkingType extends Model {}
+
+CampStadiumParkingType.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    price: { type: DataTypes.DECIMAL(10, 2) },
+  },
+  {
+    sequelize,
+    modelName: 'CampStadiumParkingType',
+    tableName: 'camp_stadium_parking_types',
+    paranoid: true,
+    underscored: true,
+    indexes: [
+      { unique: true, fields: ['camp_stadium_id', 'parking_type_id'] },
+    ],
+  }
+);
+
+export default CampStadiumParkingType;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -18,6 +18,9 @@ import UserExternalId from './userExternalId.js';
 import AddressType from './addressType.js';
 import Address from './address.js';
 import UserAddress from './userAddress.js';
+import ParkingType from './parkingType.js';
+import CampStadium from './campStadium.js';
+import CampStadiumParkingType from './campStadiumParkingType.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -54,6 +57,26 @@ Address.hasMany(UserAddress, { foreignKey: 'address_id' });
 UserAddress.belongsTo(Address, { foreignKey: 'address_id' });
 AddressType.hasMany(UserAddress, { foreignKey: 'address_type_id' });
 UserAddress.belongsTo(AddressType, { foreignKey: 'address_type_id' });
+
+/* camp stadiums */
+CampStadium.belongsTo(Address, { foreignKey: 'address_id' });
+Address.hasMany(CampStadium, { foreignKey: 'address_id' });
+CampStadium.belongsToMany(ParkingType, {
+  through: CampStadiumParkingType,
+  foreignKey: 'camp_stadium_id',
+});
+ParkingType.belongsToMany(CampStadium, {
+  through: CampStadiumParkingType,
+  foreignKey: 'parking_type_id',
+});
+CampStadium.hasMany(CampStadiumParkingType, { foreignKey: 'camp_stadium_id' });
+CampStadiumParkingType.belongsTo(CampStadium, {
+  foreignKey: 'camp_stadium_id',
+});
+ParkingType.hasMany(CampStadiumParkingType, { foreignKey: 'parking_type_id' });
+CampStadiumParkingType.belongsTo(ParkingType, {
+  foreignKey: 'parking_type_id',
+});
 
 /* external systems */
 User.hasMany(UserExternalId, { foreignKey: 'user_id' });
@@ -93,4 +116,7 @@ export {
   Address,
   UserAddress,
   MedicalCertificate,
+  ParkingType,
+  CampStadium,
+  CampStadiumParkingType,
 };

--- a/src/models/parkingType.js
+++ b/src/models/parkingType.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class ParkingType extends Model {}
+
+ParkingType.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'ParkingType',
+    tableName: 'parking_types',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default ParkingType;

--- a/src/routes/campStadiums.js
+++ b/src/routes/campStadiums.js
@@ -1,0 +1,17 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/campStadiumAdminController.js';
+import { campStadiumCreateRules, campStadiumUpdateRules } from '../validators/campStadiumValidators.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+router.get('/parking-types', auth, authorize('ADMIN'), controller.parkingTypes);
+router.post('/', auth, authorize('ADMIN'), campStadiumCreateRules, controller.create);
+router.get('/:id', auth, authorize('ADMIN'), controller.get);
+router.put('/:id', auth, authorize('ADMIN'), campStadiumUpdateRules, controller.update);
+router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -19,6 +19,7 @@ import rolesRouter from './roles.js';
 import registerRouter from './register.js';
 import profileRouter from './profile.js';
 import passwordResetRouter from './passwordReset.js';
+import campStadiumsRouter from './campStadiums.js';
 
 const router = express.Router();
 
@@ -37,6 +38,7 @@ router.use('/roles', rolesRouter);
 router.use('/register', registerRouter);
 router.use('/profile', profileRouter);
 router.use('/password-reset', passwordResetRouter);
+router.use('/camp-stadiums', campStadiumsRouter);
 
 /**
  * @swagger

--- a/src/seeders/20250705000000-create-parking-types.js
+++ b/src/seeders/20250705000000-create-parking-types.js
@@ -1,0 +1,47 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      // eslint-disable-next-line quotes
+      "SELECT COUNT(*) AS cnt FROM parking_types WHERE alias IN ('FREE','PAID','NONE');"
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'parking_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Бесплатная',
+          alias: 'FREE',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Платная',
+          alias: 'PAID',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Отсутствует',
+          alias: 'NONE',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('parking_types', {
+      alias: ['FREE', 'PAID', 'NONE'],
+    });
+  },
+};

--- a/src/services/campStadiumService.js
+++ b/src/services/campStadiumService.js
@@ -1,0 +1,127 @@
+import {
+  CampStadium,
+  Address,
+  ParkingType,
+  CampStadiumParkingType,
+} from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+import * as dadataService from './dadataService.js';
+
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  return CampStadium.findAndCountAll({
+    include: [
+      { model: Address },
+      { model: ParkingType },
+    ],
+    limit,
+    offset,
+    order: [['name', 'ASC']],
+  });
+}
+
+async function getById(id) {
+  const stadium = await CampStadium.findByPk(id, {
+    include: [
+      { model: Address },
+      { model: ParkingType },
+    ],
+  });
+  if (!stadium) throw new ServiceError('stadium_not_found', 404);
+  return stadium;
+}
+
+async function create(data, actorId) {
+  const cleaned = await dadataService.cleanAddress(data.address.result);
+  if (!cleaned) throw new ServiceError('invalid_address');
+  const address = await Address.create({
+    ...cleaned,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  const stadium = await CampStadium.create({
+    name: data.name,
+    address_id: address.id,
+    yandex_url: data.yandex_url,
+    capacity: data.capacity,
+    phone: data.phone,
+    website: data.website,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  if (Array.isArray(data.parking)) {
+    for (const p of data.parking) {
+      const type = await ParkingType.findOne({ where: { alias: p.type } });
+      if (!type) continue;
+      await CampStadiumParkingType.create({
+        camp_stadium_id: stadium.id,
+        parking_type_id: type.id,
+        price: p.price,
+        created_by: actorId,
+        updated_by: actorId,
+      });
+    }
+  }
+  return getById(stadium.id);
+}
+
+async function update(id, data, actorId) {
+  const stadium = await CampStadium.findByPk(id, { include: [Address] });
+  if (!stadium) throw new ServiceError('stadium_not_found', 404);
+  if (data.address) {
+    const cleaned = await dadataService.cleanAddress(data.address.result);
+    if (!cleaned) throw new ServiceError('invalid_address');
+    await stadium.Address.update({ ...cleaned, updated_by: actorId });
+  }
+  await stadium.update(
+    {
+      name: data.name ?? stadium.name,
+      yandex_url: data.yandex_url ?? stadium.yandex_url,
+      capacity: data.capacity ?? stadium.capacity,
+      phone: data.phone ?? stadium.phone,
+      website: data.website ?? stadium.website,
+      updated_by: actorId,
+    },
+    { returning: false }
+  );
+  if (Array.isArray(data.parking)) {
+    await CampStadiumParkingType.destroy({
+      where: { camp_stadium_id: id },
+    });
+    for (const p of data.parking) {
+      const type = await ParkingType.findOne({ where: { alias: p.type } });
+      if (!type) continue;
+      await CampStadiumParkingType.create({
+        camp_stadium_id: id,
+        parking_type_id: type.id,
+        price: p.price,
+        created_by: actorId,
+        updated_by: actorId,
+      });
+    }
+  }
+  return getById(id);
+}
+
+async function remove(id) {
+  const stadium = await CampStadium.findByPk(id, { include: [Address] });
+  if (!stadium) throw new ServiceError('stadium_not_found', 404);
+  if (stadium.Address) await stadium.Address.destroy();
+  await stadium.destroy();
+}
+
+async function listParkingTypes() {
+  return ParkingType.findAll({ order: [['name', 'ASC']] });
+}
+
+export default {
+  listAll,
+  getById,
+  create,
+  update,
+  remove,
+  listParkingTypes,
+};

--- a/src/validators/campStadiumValidators.js
+++ b/src/validators/campStadiumValidators.js
@@ -1,0 +1,21 @@
+import { body } from 'express-validator';
+
+export const campStadiumCreateRules = [
+  body('name').isString().notEmpty(),
+  body('address.result').notEmpty().withMessage('invalid_address'),
+  body('yandex_url').optional().isURL(),
+  body('capacity').optional().isInt({ min: 0 }),
+  body('phone').optional().isMobilePhone('ru-RU'),
+  body('website').optional().isURL(),
+  body('parking').optional().isArray(),
+];
+
+export const campStadiumUpdateRules = [
+  body('name').optional().isString().notEmpty(),
+  body('address.result').optional().notEmpty(),
+  body('yandex_url').optional().isURL(),
+  body('capacity').optional().isInt({ min: 0 }),
+  body('phone').optional().isMobilePhone('ru-RU'),
+  body('website').optional().isURL(),
+  body('parking').optional().isArray(),
+];


### PR DESCRIPTION
## Summary
- implement admin UI for managing camp stadiums
- add parking types endpoint and service method
- register new admin route
- include new tile and route in client admin panel
- translate stadium errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68643218698c832d9f3b0d36a00aed54