### PR TITLE
Add admin email notifications

### DIFF
--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -4,6 +4,7 @@ import userService from '../services/userService.js';
 import passportService from '../services/passportService.js';
 import userMapper from '../mappers/userMapper.js';
 import passportMapper from '../mappers/passportMapper.js';
+import emailService from '../services/emailService.js';
 import { sendError } from '../utils/api.js';
 
 export default {
@@ -72,6 +73,7 @@ export default {
   async unblock(req, res) {
     try {
       const user = await userService.setStatus(req.params.id, 'ACTIVE');
+      await emailService.sendAccountActivatedEmail(user);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
       return sendError(res, err, 404);
@@ -81,6 +83,7 @@ export default {
   async approve(req, res) {
     try {
       const user = await userService.setStatus(req.params.id, 'ACTIVE');
+      await emailService.sendAccountActivatedEmail(user);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -10,6 +10,8 @@ import {
 } from '../config/email.js';
 import { renderVerificationEmail } from '../templates/verificationEmail.js';
 import { renderPasswordResetEmail } from '../templates/passwordResetEmail.js';
+import { renderMedicalCertificateAddedEmail } from '../templates/medicalCertificateAddedEmail.js';
+import { renderAccountActivatedEmail } from '../templates/accountActivatedEmail.js';
 
 const transporter = nodemailer.createTransport({
   host: SMTP_HOST,
@@ -43,4 +45,19 @@ export async function sendPasswordResetEmail(user, code) {
   await sendMail(user.email, subject, text, html);
 }
 
-export default { sendMail, sendVerificationEmail, sendPasswordResetEmail };
+export async function sendMedicalCertificateAddedEmail(user) {
+  const { subject, text, html } = renderMedicalCertificateAddedEmail();
+  await sendMail(user.email, subject, text, html);
+}
+
+export async function sendAccountActivatedEmail(user) {
+  const { subject, text, html } = renderAccountActivatedEmail();
+  await sendMail(user.email, subject, text, html);
+}
+export default {
+  sendMail,
+  sendVerificationEmail,
+  sendPasswordResetEmail,
+  sendMedicalCertificateAddedEmail,
+  sendAccountActivatedEmail,
+};

--- a/src/templates/accountActivatedEmail.js
+++ b/src/templates/accountActivatedEmail.js
@@ -1,0 +1,22 @@
+export function renderAccountActivatedEmail() {
+  const subject = 'Учетная запись активирована';
+  const text =
+    'Здравствуйте!\n\n' +
+    'Администратор подтвердил вашу учетную запись в системе FH Moscow Pulse. ' +
+    'Теперь вы можете войти в личный кабинет и использовать все функции сервиса.\n\n' +
+    'Если вы не подавали запрос на активацию или у вас возникли вопросы, пожалуйста, свяжитесь со службой поддержки.\n\n' +
+    'С уважением,\nкоманда FH Moscow Pulse.';
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">
+        Администратор подтвердил вашу учетную запись в системе <strong>FH Moscow Pulse</strong>.
+      </p>
+      <p style="font-size:16px;margin:0 0 16px;">Теперь вы можете войти в личный кабинет и использовать все функции сервиса.</p>
+      <p style="font-size:14px;margin:0 0 16px;">Если вы не подавали запрос на активацию или у вас возникли вопросы, пожалуйста, свяжитесь со службой поддержки.</p>
+      <p style="font-size:16px;margin:0;">С уважением,<br/>команда FH Moscow Pulse</p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderAccountActivatedEmail };

--- a/src/templates/medicalCertificateAddedEmail.js
+++ b/src/templates/medicalCertificateAddedEmail.js
@@ -1,0 +1,22 @@
+export function renderMedicalCertificateAddedEmail() {
+  const subject = 'Добавлено медицинское заключение';
+  const text =
+    'Здравствуйте!\n\n' +
+    'Администратор добавил в ваш профиль новое медицинское заключение в системе FH Moscow Pulse. ' +
+    'Вы можете ознакомиться с документом в личном кабинете.\n\n' +
+    'Если вы считаете это добавление ошибочным или у вас есть вопросы, пожалуйста, обратитесь в службу поддержки.\n\n' +
+    'С уважением,\nкоманда FH Moscow Pulse.';
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">
+        Администратор добавил в ваш профиль новое медицинское заключение в системе <strong>FH Moscow Pulse</strong>.
+      </p>
+      <p style="font-size:16px;margin:0 0 16px;">Ознакомиться с документом можно в личном кабинете.</p>
+      <p style="font-size:14px;margin:0 0 16px;">Если вы считаете это добавление ошибочным или у вас есть вопросы, пожалуйста, обратитесь в службу поддержки.</p>
+      <p style="font-size:16px;margin:0;">С уважением,<br/>команда FH Moscow Pulse</p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderMedicalCertificateAddedEmail };

--- a/tests/userAdminController.test.js
+++ b/tests/userAdminController.test.js
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const setStatusMock = jest.fn();
 const resetPasswordMock = jest.fn();
@@ -25,6 +25,7 @@ const createPassportMock = jest.fn();
 const getPassportMock = jest.fn();
 const removePassportMock = jest.fn();
 const passportToPublicMock = jest.fn((p) => p);
+const sendActivationEmailMock = jest.fn();
 
 jest.unstable_mockModule('../src/services/passportService.js', () => ({
   __esModule: true,
@@ -40,7 +41,17 @@ jest.unstable_mockModule('../src/mappers/passportMapper.js', () => ({
   default: { toPublic: passportToPublicMock },
 }));
 
+jest.unstable_mockModule('../src/services/emailService.js', () => ({
+  __esModule: true,
+  default: { sendAccountActivatedEmail: sendActivationEmailMock },
+}));
+
 const { default: controller } = await import('../src/controllers/userAdminController.js');
+
+beforeEach(() => {
+  sendActivationEmailMock.mockClear();
+  setStatusMock.mockClear();
+});
 
 test('approve updates user status to ACTIVE', async () => {
   setStatusMock.mockResolvedValue({ id: '1' });
@@ -48,6 +59,7 @@ test('approve updates user status to ACTIVE', async () => {
   const res = { json: jest.fn() };
   await controller.approve(req, res);
   expect(setStatusMock).toHaveBeenCalledWith('1', 'ACTIVE');
+  expect(sendActivationEmailMock).toHaveBeenCalledWith({ id: '1' });
   expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
 });
 
@@ -66,6 +78,7 @@ test('unblock updates user status to ACTIVE', async () => {
   const res = { json: jest.fn() };
   await controller.unblock(req, res);
   expect(setStatusMock).toHaveBeenCalledWith('3', 'ACTIVE');
+  expect(sendActivationEmailMock).toHaveBeenCalledWith({ id: '3' });
   expect(res.json).toHaveBeenCalledWith({ user: { id: '3' } });
 });
 


### PR DESCRIPTION
## Summary
- add templates for account activation and medical certificate email notifications
- send emails on admin actions
- cover new cases with tests
- refine templates with more formal corporate style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686443f6bbc0832dbd6dca257071ab0c