### PR TITLE
Fix card hover animations

### DIFF
--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -31,3 +31,16 @@
   background-color: var(--brand-color);
 }
 
+/*
+ * Consistent tile hover behaviour across the application
+ */
+.tile,
+.file-tile {
+  transition: transform 0.1s ease-in-out, box-shadow 0.1s ease-in-out;
+}
+.tile:hover,
+.file-tile:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
+}
+

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -32,12 +32,3 @@ const tiles = [
   </div>
 </template>
 
-<style scoped>
-.tile {
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-.tile:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-}
-</style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -72,13 +72,6 @@ const greeting = computed(() => {
 </template>
 
 <style scoped>
-.tile {
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-.tile:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-}
 .placeholder-card {
   background-color: #f8f9fa;
   opacity: 0.6;

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -206,24 +206,11 @@ onMounted(async () => {
 </template>
 
 <style scoped>
-.tile {
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-.tile:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-}
 .fade-in {
   animation: fadeIn 0.4s ease-out;
 }
-
 .file-tile {
   background-color: #f8f9fa;
-  transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-}
-.file-tile:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
 }
 @keyframes fadeIn {
   from {

--- a/client/src/views/Profile.vue
+++ b/client/src/views/Profile.vue
@@ -723,21 +723,17 @@ onMounted(() => {
 </template>
 
 <style scoped>
-.tile {
-  transition:
-    transform 0.2s ease-in-out,
-    box-shadow 0.2s ease-in-out;
-}
-.tile:hover {
-  transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
-}
 .fade-in {
   animation: fadeIn 0.4s ease-out;
 }
 
 .placeholder-card {
   opacity: 0.6;
+  cursor: default;
+}
+.placeholder-card:hover {
+  transform: none;
+  box-shadow: none;
 }
 
 @keyframes fadeIn {


### PR DESCRIPTION
## Summary
- unify tile hover effect in brand.css
- remove duplicate tile styles from views
- disable hover animation for placeholder cards

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68644d5e18e8832d832d68d155d072a9