### PR TITLE
Implement single parking type selection

### DIFF
--- a/src/services/campStadiumService.js
+++ b/src/services/campStadiumService.js
@@ -46,14 +46,14 @@ async function create(data, actorId) {
     created_by: actorId,
     updated_by: actorId,
   });
-  if (Array.isArray(data.parking)) {
-    for (const p of data.parking) {
-      const type = await ParkingType.findOne({ where: { alias: p.type } });
-      if (!type) continue;
+  if (Array.isArray(data.parking) && data.parking.length) {
+    const p = data.parking[0];
+    const type = await ParkingType.findOne({ where: { alias: p.type } });
+    if (type) {
       await CampStadiumParkingType.create({
         camp_stadium_id: stadium.id,
         parking_type_id: type.id,
-        price: p.price,
+        price: p.type === 'PAID' ? p.price : null,
         created_by: actorId,
         updated_by: actorId,
       });
@@ -85,19 +85,19 @@ async function update(id, data, actorId) {
     { returning: false }
   );
   if (Array.isArray(data.parking)) {
-    await CampStadiumParkingType.destroy({
-      where: { camp_stadium_id: id },
-    });
-    for (const p of data.parking) {
+    await CampStadiumParkingType.destroy({ where: { camp_stadium_id: id } });
+    if (data.parking.length) {
+      const p = data.parking[0];
       const type = await ParkingType.findOne({ where: { alias: p.type } });
-      if (!type) continue;
-      await CampStadiumParkingType.create({
-        camp_stadium_id: id,
-        parking_type_id: type.id,
-        price: p.price,
-        created_by: actorId,
-        updated_by: actorId,
-      });
+      if (type) {
+        await CampStadiumParkingType.create({
+          camp_stadium_id: id,
+          parking_type_id: type.id,
+          price: p.type === 'PAID' ? p.price : null,
+          created_by: actorId,
+          updated_by: actorId,
+        });
+      }
     }
   }
   return getById(id);

--- a/src/validators/campStadiumValidators.js
+++ b/src/validators/campStadiumValidators.js
@@ -18,7 +18,23 @@ export const campStadiumCreateRules = [
       }
       return v;
     }),
-  body('parking').optional().isArray(),
+  body('parking')
+    .optional()
+    .isArray({ max: 1 })
+    .custom((arr) => {
+      if (arr.length === 0) return true;
+      const p = arr[0];
+      if (!p || typeof p.type !== 'string') {
+        throw new Error('invalid_parking');
+      }
+      if (p.type === 'PAID' && (p.price === undefined || p.price === null)) {
+        throw new Error('parking_price_required');
+      }
+      if (p.type !== 'PAID' && p.price) {
+        throw new Error('parking_price_forbidden');
+      }
+      return true;
+    }),
 ];
 
 export const campStadiumUpdateRules = [
@@ -39,5 +55,21 @@ export const campStadiumUpdateRules = [
       }
       return v;
     }),
-  body('parking').optional().isArray(),
+  body('parking')
+    .optional()
+    .isArray({ max: 1 })
+    .custom((arr) => {
+      if (arr.length === 0) return true;
+      const p = arr[0];
+      if (!p || typeof p.type !== 'string') {
+        throw new Error('invalid_parking');
+      }
+      if (p.type === 'PAID' && (p.price === undefined || p.price === null)) {
+        throw new Error('parking_price_required');
+      }
+      if (p.type !== 'PAID' && p.price) {
+        throw new Error('parking_price_forbidden');
+      }
+      return true;
+    }),
 ];


### PR DESCRIPTION
## Summary
- enforce selecting at most one parking type for camp stadiums
- require price only for paid parking
- update create/edit forms to use a dropdown instead of multiple switches
- adjust service logic to handle single parking object
- expand validation rules for new parking logic

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_68644df56898832d9c501dbaa6a41d14