### PR TITLE
Add training type management

### DIFF
--- a/src/controllers/trainingTypeAdminController.js
+++ b/src/controllers/trainingTypeAdminController.js
@@ -1,0 +1,64 @@
+import { validationResult } from 'express-validator';
+
+import trainingTypeService from '../services/trainingTypeService.js';
+import mapper from '../mappers/trainingTypeMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await trainingTypeService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({ types: rows.map(mapper.toPublic), total: count });
+  },
+
+  async get(req, res) {
+    try {
+      const type = await trainingTypeService.getById(req.params.id);
+      return res.json({ type: mapper.toPublic(type) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const type = await trainingTypeService.create(req.body, req.user.id);
+      return res.status(201).json({ type: mapper.toPublic(type) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const type = await trainingTypeService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ type: mapper.toPublic(type) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await trainingTypeService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/mappers/trainingTypeMapper.js
+++ b/src/mappers/trainingTypeMapper.js
@@ -1,0 +1,12 @@
+function sanitize(obj) {
+  const { id, name, alias, default_capacity } = obj;
+  return { id, name, alias, default_capacity };
+}
+
+function toPublic(type) {
+  if (!type) return null;
+  const plain = typeof type.get === 'function' ? type.get({ plain: true }) : type;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/mappers/trainingTypeMapper.js
+++ b/src/mappers/trainingTypeMapper.js
@@ -5,7 +5,8 @@ function sanitize(obj) {
 
 function toPublic(type) {
   if (!type) return null;
-  const plain = typeof type.get === 'function' ? type.get({ plain: true }) : type;
+  const plain =
+    typeof type.get === 'function' ? type.get({ plain: true }) : type;
   return sanitize(plain);
 }
 

--- a/src/migrations/20250706000000-create-training-types.js
+++ b/src/migrations/20250706000000-create-training-types.js
@@ -1,0 +1,41 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_types', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      default_capacity: { type: Sequelize.INTEGER },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('training_types');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -24,6 +24,7 @@ import UserAddress from './userAddress.js';
 import ParkingType from './parkingType.js';
 import CampStadium from './campStadium.js';
 import CampStadiumParkingType from './campStadiumParkingType.js';
+import TrainingType from './trainingType.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -136,6 +137,7 @@ export {
   ParkingType,
   CampStadium,
   CampStadiumParkingType,
+  TrainingType,
   File,
   MedicalCertificateType,
   MedicalCertificateFile,

--- a/src/models/trainingType.js
+++ b/src/models/trainingType.js
@@ -1,0 +1,27 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TrainingType extends Model {}
+
+TrainingType.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    default_capacity: { type: DataTypes.INTEGER },
+  },
+  {
+    sequelize,
+    modelName: 'TrainingType',
+    tableName: 'training_types',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default TrainingType;

--- a/src/routes/campTrainingTypes.js
+++ b/src/routes/campTrainingTypes.js
@@ -11,9 +11,21 @@ import {
 const router = express.Router();
 
 router.get('/', auth, authorize('ADMIN'), controller.list);
-router.post('/', auth, authorize('ADMIN'), trainingTypeCreateRules, controller.create);
+router.post(
+  '/',
+  auth,
+  authorize('ADMIN'),
+  trainingTypeCreateRules,
+  controller.create
+);
 router.get('/:id', auth, authorize('ADMIN'), controller.get);
-router.put('/:id', auth, authorize('ADMIN'), trainingTypeUpdateRules, controller.update);
+router.put(
+  '/:id',
+  auth,
+  authorize('ADMIN'),
+  trainingTypeUpdateRules,
+  controller.update
+);
 router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
 
 export default router;

--- a/src/routes/campTrainingTypes.js
+++ b/src/routes/campTrainingTypes.js
@@ -1,0 +1,19 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/trainingTypeAdminController.js';
+import {
+  trainingTypeCreateRules,
+  trainingTypeUpdateRules,
+} from '../validators/trainingTypeValidators.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+router.post('/', auth, authorize('ADMIN'), trainingTypeCreateRules, controller.create);
+router.get('/:id', auth, authorize('ADMIN'), controller.get);
+router.put('/:id', auth, authorize('ADMIN'), trainingTypeUpdateRules, controller.update);
+router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -20,6 +20,7 @@ import registerRouter from './register.js';
 import profileRouter from './profile.js';
 import passwordResetRouter from './passwordReset.js';
 import campStadiumsRouter from './campStadiums.js';
+import campTrainingTypesRouter from './campTrainingTypes.js';
 
 const router = express.Router();
 
@@ -39,6 +40,7 @@ router.use('/register', registerRouter);
 router.use('/profile', profileRouter);
 router.use('/password-reset', passwordResetRouter);
 router.use('/camp-stadiums', campStadiumsRouter);
+router.use('/camp-training-types', campTrainingTypesRouter);
 
 /**
  * @swagger

--- a/src/seeders/20250802000000-create-training-types.js
+++ b/src/seeders/20250802000000-create-training-types.js
@@ -5,6 +5,7 @@ const { v4: uuidv4 } = require('uuid');
 module.exports = {
   async up(queryInterface) {
     const now = new Date();
+    // prettier-ignore
     const [existing] = await queryInterface.sequelize.query(
       'SELECT COUNT(*) AS cnt FROM training_types WHERE alias IN (\'ICE\',\'BASIC_FIT\',\'THEORY\');'
     );

--- a/src/seeders/20250802000000-create-training-types.js
+++ b/src/seeders/20250802000000-create-training-types.js
@@ -1,0 +1,49 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM training_types WHERE alias IN (\'ICE\',\'BASIC_FIT\',\'THEORY\');'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'training_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Ледовая подготовка',
+          alias: 'ICE',
+          default_capacity: 20,
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Основы физической подготовки',
+          alias: 'BASIC_FIT',
+          default_capacity: 20,
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Теоретическая подготовка',
+          alias: 'THEORY',
+          default_capacity: 20,
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('training_types', {
+      alias: ['ICE', 'BASIC_FIT', 'THEORY'],
+    });
+  },
+};

--- a/src/services/trainingTypeService.js
+++ b/src/services/trainingTypeService.js
@@ -5,7 +5,11 @@ async function listAll(options = {}) {
   const page = Math.max(1, parseInt(options.page || 1, 10));
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
   const offset = (page - 1) * limit;
-  return TrainingType.findAndCountAll({ order: [['name', 'ASC']], limit, offset });
+  return TrainingType.findAndCountAll({
+    order: [['name', 'ASC']],
+    limit,
+    offset,
+  });
 }
 
 async function getById(id) {

--- a/src/services/trainingTypeService.js
+++ b/src/services/trainingTypeService.js
@@ -1,0 +1,49 @@
+import { TrainingType } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  return TrainingType.findAndCountAll({ order: [['name', 'ASC']], limit, offset });
+}
+
+async function getById(id) {
+  const type = await TrainingType.findByPk(id);
+  if (!type) throw new ServiceError('training_type_not_found', 404);
+  return type;
+}
+
+async function create(data, actorId) {
+  const type = await TrainingType.create({
+    name: data.name,
+    alias: data.alias,
+    default_capacity: data.default_capacity,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return type;
+}
+
+async function update(id, data, actorId) {
+  const type = await TrainingType.findByPk(id);
+  if (!type) throw new ServiceError('training_type_not_found', 404);
+  await type.update(
+    {
+      name: data.name ?? type.name,
+      alias: data.alias ?? type.alias,
+      default_capacity: data.default_capacity ?? type.default_capacity,
+      updated_by: actorId,
+    },
+    { returning: false }
+  );
+  return type;
+}
+
+async function remove(id) {
+  const type = await TrainingType.findByPk(id);
+  if (!type) throw new ServiceError('training_type_not_found', 404);
+  await type.destroy();
+}
+
+export default { listAll, getById, create, update, remove };

--- a/src/validators/trainingTypeValidators.js
+++ b/src/validators/trainingTypeValidators.js
@@ -1,0 +1,13 @@
+import { body } from 'express-validator';
+
+export const trainingTypeCreateRules = [
+  body('name').isString().notEmpty(),
+  body('alias').isString().notEmpty(),
+  body('default_capacity').optional().isInt({ min: 0 }),
+];
+
+export const trainingTypeUpdateRules = [
+  body('name').optional().isString().notEmpty(),
+  body('alias').optional().isString().notEmpty(),
+  body('default_capacity').optional().isInt({ min: 0 }),
+];


### PR DESCRIPTION
## Summary
- add TrainingType model, migration and seeder
- implement CRUD service and controller
- expose `/camp-training-types` API routes
- extend admin camps page with Training Types tab

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68644fe6eda0832dadff695708dda001