### PR TITLE
Fix medical certificate history

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,13 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - Jest unit tests
 - Admin panel for managing users and roles (create, edit, block)
 - Soft deletion of records using Sequelize paranoid mode
- - Users can have multiple medical certificates. The API returns the
-   certificate that is currently valid (issue date in the past and not yet
-   expired) while a separate endpoint provides a history of expired
-   certificates.
+- Users can have multiple medical certificates. The API returns the
+  certificate that is currently valid (issue date in the past and not yet
+  expired) while a separate endpoint provides a history of expired
+  certificates.
+- The personal page warns when a valid certificate is missing and lists
+  expired certificates without displaying the taxpayer ID to keep the layout
+  compact on small screens.
 
 ## Branching strategy
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ A Node.js REST API built with Express and Sequelize. The project provides JWT-ba
 - Jest unit tests
 - Admin panel for managing users and roles (create, edit, block)
 - Soft deletion of records using Sequelize paranoid mode
-- Users can have multiple medical certificates; the active one with the
-  longest validity is returned in personal APIs
+ - Users can have multiple medical certificates. The API returns the
+   certificate that is currently valid (issue date in the past and not yet
+   expired) while a separate endpoint provides a history of expired
+   certificates.
 
 ## Branching strategy
 

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -44,16 +44,13 @@ onMounted(async () => {
   try {
     const [current, hist] = await Promise.all([
       apiFetch('/medical-certificates/me').catch((e) => {
-        if (e.message.includes('не найдена')) return null;
+        if (e.message.includes('не найден')) return null;
         throw e;
       }),
       apiFetch('/medical-certificates/me/history'),
     ]);
     certificate.value = current ? current.certificate : null;
-    const allHistory = hist.certificates || [];
-    const activeId =
-      certificate.value && isValid(certificate.value) ? certificate.value.id : null;
-    history.value = activeId ? allHistory.filter((c) => c.id !== activeId) : allHistory;
+    history.value = hist.certificates || [];
     if (certificate.value) {
       const data = await apiFetch('/medical-certificates/me/files').catch(() => ({ files: [] }));
       files.value = data.files;

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -152,8 +152,10 @@ onMounted(async () => {
         </div>
       </div>
     </div>
-    <p v-else-if="!error" class="text-muted">Действующее медицинское заключение отсутствует</p>
-    <p v-else class="text-muted">{{ error }}</p>
+    <div v-else-if="!error" class="alert alert-danger" role="alert">
+      Действующее медицинское заключение отсутствует
+    </div>
+    <div v-else class="alert alert-danger" role="alert">{{ error }}</div>
     <div class="card tile fade-in shadow-sm mt-4">
       <div class="card-body">
         <h5 class="card-title mb-3">Архив медицинских заключений</h5>
@@ -163,7 +165,6 @@ onMounted(async () => {
               <tr>
                 <th>Номер</th>
                 <th>Учреждение</th>
-                <th>ИНН</th>
                 <th>Период действия</th>
                 <th>Файлы</th>
               </tr>
@@ -172,8 +173,7 @@ onMounted(async () => {
               <tr v-for="item in history" :key="item.id">
                 <td>{{ item.certificate_number }}</td>
                 <td>{{ item.organization }}</td>
-                <td>{{ item.inn }}</td>
-                <td>{{ formatDate(item.issue_date) }} - {{ formatDate(item.valid_until) }}</td>
+                <td class="text-nowrap">{{ formatDate(item.issue_date) }} - {{ formatDate(item.valid_until) }}</td>
                 <td>
                   <div
                     v-if="item.files && item.files.length"

--- a/src/services/medicalCertificateService.js
+++ b/src/services/medicalCertificateService.js
@@ -6,18 +6,24 @@ import ServiceError from '../errors/ServiceError.js';
 import emailService from './emailService.js';
 
 async function getByUser(userId) {
+  const today = new Date().toISOString().slice(0, 10);
   return MedicalCertificate.findOne({
     where: {
       user_id: userId,
-      valid_until: { [Op.gte]: new Date() },
+      valid_until: { [Op.gte]: today },
+      issue_date: { [Op.lte]: today },
     },
     order: [['valid_until', 'DESC']],
   });
 }
 
 async function listByUser(userId) {
+  const today = new Date().toISOString().slice(0, 10);
   return MedicalCertificate.findAll({
-    where: { user_id: userId },
+    where: {
+      user_id: userId,
+      valid_until: { [Op.lt]: today },
+    },
     order: [['issue_date', 'DESC']],
   });
 }

--- a/tests/medicalCertificateService.test.js
+++ b/tests/medicalCertificateService.test.js
@@ -1,12 +1,13 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findOneMock = jest.fn();
+const findAllMock = jest.fn();
 const createMock = jest.fn();
 const sendEmailMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
-  MedicalCertificate: { findOne: findOneMock, create: createMock },
+  MedicalCertificate: { findOne: findOneMock, findAll: findAllMock, create: createMock },
   User: { findByPk: jest.fn().mockResolvedValue({ id: 'u1', email: 'e' }) },
 }));
 
@@ -21,6 +22,7 @@ beforeEach(() => {
   sendEmailMock.mockClear();
   createMock.mockClear();
   findOneMock.mockClear();
+  findAllMock.mockClear();
 });
 
 test('getByUser selects latest valid certificate', async () => {
@@ -33,7 +35,10 @@ test('getByUser selects latest valid certificate', async () => {
   expect(opts.where.user_id).toBe('u1');
   const key = Object.getOwnPropertySymbols(opts.where.valid_until)[0];
   expect(key.toString()).toContain('gte');
-  expect(opts.where.valid_until[key]).toBeInstanceOf(Date);
+  expect(typeof opts.where.valid_until[key]).toBe('string');
+  const key2 = Object.getOwnPropertySymbols(opts.where.issue_date)[0];
+  expect(key2.toString()).toContain('lte');
+  expect(typeof opts.where.issue_date[key2]).toBe('string');
 });
 
 test('createForUser creates certificate for existing user', async () => {
@@ -60,4 +65,15 @@ test('createForUser skips email when actor is user', async () => {
   createMock.mockResolvedValue({});
   await service.createForUser('u1', {}, 'u1');
   expect(sendEmailMock).not.toHaveBeenCalled();
+});
+
+test('listByUser selects only expired certificates', async () => {
+  findAllMock.mockResolvedValue([]);
+  await service.listByUser('u1');
+  const opts = findAllMock.mock.calls[0][0];
+  expect(opts.order).toEqual([["issue_date", "DESC"]]);
+  expect(opts.where.user_id).toBe('u1');
+  const key = Object.getOwnPropertySymbols(opts.where.valid_until)[0];
+  expect(key.toString()).toContain('lt');
+  expect(typeof opts.where.valid_until[key]).toBe('string');
 });


### PR DESCRIPTION
## Summary
- show only expired certificates in user's history
- update medical certificate service filters
- simplify medical page history loading
- document behavior in README
- adjust medical certificate service test
- fix check for missing certificate
- fix certificate date comparisons

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68644d32de98832da89c1c1dc55ef414