### PR TITLE
Disable training type name updates

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -432,7 +432,14 @@ async function removeType(t) {
             <div class="modal-body">
               <div v-if="typeFormError" class="alert alert-danger">{{ typeFormError }}</div>
               <div class="form-floating mb-3">
-                <input id="ttName" v-model="typeForm.name" class="form-control" placeholder="Название" required />
+                <input
+                  id="ttName"
+                  v-model="typeForm.name"
+                  class="form-control"
+                  placeholder="Название"
+                  required
+                  :disabled="!!typeEditing"
+                />
                 <label for="ttName">Наименование</label>
               </div>
               <div class="form-floating mb-3">

--- a/src/services/trainingTypeService.js
+++ b/src/services/trainingTypeService.js
@@ -34,7 +34,7 @@ async function update(id, data, actorId) {
   if (!type) throw new ServiceError('training_type_not_found', 404);
   await type.update(
     {
-      name: data.name ?? type.name,
+      // name cannot be changed after creation
       alias: data.alias ?? type.alias,
       default_capacity: data.default_capacity ?? type.default_capacity,
       updated_by: actorId,

--- a/src/validators/trainingTypeValidators.js
+++ b/src/validators/trainingTypeValidators.js
@@ -7,7 +7,6 @@ export const trainingTypeCreateRules = [
 ];
 
 export const trainingTypeUpdateRules = [
-  body('name').optional().isString().notEmpty(),
   body('alias').optional().isString().notEmpty(),
   body('default_capacity').optional().isInt({ min: 0 }),
 ];

--- a/tests/trainingTypeService.test.js
+++ b/tests/trainingTypeService.test.js
@@ -1,0 +1,42 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const findAndCountAllMock = jest.fn();
+const findByPkMock = jest.fn();
+const createMock = jest.fn();
+const updateMock = jest.fn();
+const destroyMock = jest.fn();
+
+const instance = { update: updateMock, destroy: destroyMock };
+
+beforeEach(() => {
+  findAndCountAllMock.mockReset();
+  findByPkMock.mockReset();
+  createMock.mockReset();
+  updateMock.mockReset();
+  destroyMock.mockReset();
+});
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  TrainingType: {
+    findAndCountAll: findAndCountAllMock,
+    findByPk: findByPkMock,
+    create: createMock,
+  },
+}));
+
+const { default: service } = await import('../src/services/trainingTypeService.js');
+
+test('update ignores name changes', async () => {
+  findByPkMock.mockResolvedValue({ ...instance, name: 'Old', alias: 'old' });
+  const data = { name: 'New', alias: 'old2', default_capacity: 10 };
+  await service.update('t1', data, 'admin');
+  expect(updateMock).toHaveBeenCalledWith(
+    {
+      alias: 'old2',
+      default_capacity: 10,
+      updated_by: 'admin',
+    },
+    { returning: false }
+  );
+});


### PR DESCRIPTION
## Summary
- restrict editing of training type names
- update validator accordingly
- disable name field on edit
- add service test for name immutability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686456e4c2e8832d8f60365c142f3c67