### PR TITLE
Implement training creation feature

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -13,6 +13,7 @@ import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
 import AdminMedicalCertificates from './views/AdminMedicalCertificates.vue'
 import AdminCampStadiums from './views/AdminCampStadiums.vue'
+import AdminCampTrainings from './views/AdminCampTrainings.vue'
 import PasswordReset from './views/PasswordReset.vue'
 import NotFound from './views/NotFound.vue'
 import Forbidden from './views/Forbidden.vue'
@@ -28,6 +29,7 @@ const routes = [
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/medical-certificates', component: AdminMedicalCertificates, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/camp-stadiums', component: AdminCampStadiums, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/camp-trainings', component: AdminCampTrainings, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },
   { path: '/register', component: Register, meta: { hideLayout: true } },

--- a/client/src/views/AdminCampTrainings.vue
+++ b/client/src/views/AdminCampTrainings.vue
@@ -1,0 +1,250 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue';
+import { RouterLink } from 'vue-router';
+import { Modal } from 'bootstrap';
+import { apiFetch } from '../api.js';
+
+const trainings = ref([]);
+const total = ref(0);
+const currentPage = ref(1);
+const pageSize = 8;
+const isLoading = ref(false);
+const error = ref('');
+
+const trainingTypes = ref([]);
+const statuses = ref([]);
+
+const form = ref({
+  type_id: '',
+  status: '',
+  start_at: '',
+  end_at: '',
+  capacity: '',
+});
+const editing = ref(null);
+const modalRef = ref(null);
+let modal;
+const formError = ref('');
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)));
+
+function toInputValue(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  d.setMinutes(d.getMinutes() - d.getTimezoneOffset());
+  return d.toISOString().slice(0, 16);
+}
+
+function formatDateTime(str) {
+  if (!str) return '';
+  const d = new Date(str);
+  const pad = (n) => (n < 10 ? '0' + n : '' + n);
+  const date = `${pad(d.getDate())}.${pad(d.getMonth() + 1)}.${d.getFullYear()}`;
+  const time = `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  return `${date} ${time}`;
+}
+
+onMounted(() => {
+  modal = new Modal(modalRef.value);
+  loadTrainings();
+  loadTypes();
+  loadStatuses();
+});
+
+watch(currentPage, loadTrainings);
+
+async function loadTrainings() {
+  try {
+    isLoading.value = true;
+    const params = new URLSearchParams({ page: currentPage.value, limit: pageSize });
+    const data = await apiFetch(`/camp-trainings?${params}`);
+    trainings.value = data.trainings;
+    total.value = data.total;
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    isLoading.value = false;
+  }
+}
+
+async function loadTypes() {
+  try {
+    const params = new URLSearchParams({ page: 1, limit: 100 });
+    const data = await apiFetch(`/camp-training-types?${params}`);
+    trainingTypes.value = data.types;
+  } catch (_) {
+    trainingTypes.value = [];
+  }
+}
+
+async function loadStatuses() {
+  try {
+    const data = await apiFetch('/camp-trainings/statuses');
+    statuses.value = data.statuses;
+  } catch (_) {
+    statuses.value = [];
+  }
+}
+
+function openCreate() {
+  editing.value = null;
+  form.value = { type_id: '', status: statuses.value[0]?.alias || '', start_at: '', end_at: '', capacity: '' };
+  formError.value = '';
+  modal.show();
+}
+
+function openEdit(t) {
+  editing.value = t;
+  form.value = {
+    type_id: t.type?.id || '',
+    status: t.status?.alias || '',
+    start_at: toInputValue(t.start_at),
+    end_at: toInputValue(t.end_at),
+    capacity: t.capacity || '',
+  };
+  formError.value = '';
+  modal.show();
+}
+
+async function save() {
+  const payload = {
+    type_id: form.value.type_id,
+    start_at: new Date(form.value.start_at).toISOString(),
+    end_at: new Date(form.value.end_at).toISOString(),
+    capacity: form.value.capacity || undefined,
+  };
+  if (editing.value) {
+    payload.status = form.value.status;
+  }
+  try {
+    if (editing.value) {
+      await apiFetch(`/camp-trainings/${editing.value.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(payload),
+      });
+    } else {
+      await apiFetch('/camp-trainings', {
+        method: 'POST',
+        body: JSON.stringify(payload),
+      });
+    }
+    modal.hide();
+    await loadTrainings();
+  } catch (e) {
+    formError.value = e.message;
+  }
+}
+
+async function removeTraining(t) {
+  if (!confirm('Удалить запись?')) return;
+  await apiFetch(`/camp-trainings/${t.id}`, { method: 'DELETE' });
+  await loadTrainings();
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Тренировки</li>
+      </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Тренировки</h1>
+      <button class="btn btn-brand" @click="openCreate">
+        <i class="bi bi-plus-lg me-1"></i>Добавить
+      </button>
+    </div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="isLoading" class="text-center my-3">
+      <div class="spinner-border" role="status"></div>
+    </div>
+    <div v-if="trainings.length" class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead>
+        <tr>
+          <th>Тип</th>
+          <th>Начало</th>
+          <th>Окончание</th>
+          <th class="text-center">Вместимость</th>
+          <th>Статус</th>
+          <th></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr v-for="t in trainings" :key="t.id">
+          <td>{{ t.type?.name }}</td>
+          <td>{{ formatDateTime(t.start_at) }}</td>
+          <td>{{ formatDateTime(t.end_at) }}</td>
+          <td class="text-center">{{ t.capacity }}</td>
+          <td>{{ t.status?.name }}</td>
+          <td class="text-end">
+            <button class="btn btn-sm btn-secondary me-2" @click="openEdit(t)">Изменить</button>
+            <button class="btn btn-sm btn-danger" @click="removeTraining(t)">Удалить</button>
+          </td>
+        </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-else-if="!isLoading" class="text-muted">Записей нет.</p>
+    <nav class="mt-3" v-if="totalPages > 1">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: currentPage === 1 }">
+          <button class="page-link" @click="currentPage--" :disabled="currentPage === 1">Пред</button>
+        </li>
+        <li class="page-item" v-for="p in totalPages" :key="p" :class="{ active: currentPage === p }">
+          <button class="page-link" @click="currentPage = p">{{ p }}</button>
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+          <button class="page-link" @click="currentPage++" :disabled="currentPage === totalPages">След</button>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div ref="modalRef" class="modal fade" tabindex="-1">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form @submit.prevent="save">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ editing ? 'Изменить тренировку' : 'Добавить тренировку' }}</h5>
+            <button type="button" class="btn-close" @click="modal.hide()"></button>
+          </div>
+          <div class="modal-body">
+            <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
+            <div class="mb-3">
+              <label class="form-label">Тип</label>
+              <select v-model="form.type_id" class="form-select" required>
+                <option value="" disabled>Выберите тип</option>
+                <option v-for="tt in trainingTypes" :key="tt.id" :value="tt.id">{{ tt.name }}</option>
+              </select>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Статус</label>
+              <select v-model="form.status" class="form-select" :disabled="!editing">
+                <option v-for="s in statuses" :key="s.alias" :value="s.alias">{{ s.name }}</option>
+              </select>
+            </div>
+            <div class="form-floating mb-3">
+              <input id="trStart" v-model="form.start_at" type="datetime-local" class="form-control" required />
+              <label for="trStart">Начало</label>
+            </div>
+            <div class="form-floating mb-3">
+              <input id="trEnd" v-model="form.end_at" type="datetime-local" class="form-control" required />
+              <label for="trEnd">Окончание</label>
+            </div>
+            <div class="form-floating mb-3">
+              <input id="trCap" v-model="form.capacity" type="number" min="0" class="form-control" />
+              <label for="trCap">Вместимость</label>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+            <button type="submit" class="btn btn-primary">Сохранить</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -12,6 +12,11 @@ const tiles = [
     title: 'Управление сборами',
     icon: 'bi-building',
     to: '/camp-stadiums'
+  },
+  {
+    title: 'Тренировки',
+    icon: 'bi-calendar-event',
+    to: '/camp-trainings'
   }
 ]
 </script>

--- a/src/controllers/trainingAdminController.js
+++ b/src/controllers/trainingAdminController.js
@@ -1,0 +1,71 @@
+import { validationResult } from 'express-validator';
+
+import trainingService from '../services/trainingService.js';
+import mapper from '../mappers/trainingMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await trainingService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({ trainings: rows.map(mapper.toPublic), total: count });
+  },
+
+  async get(req, res) {
+    try {
+      const training = await trainingService.getById(req.params.id);
+      return res.json({ training: mapper.toPublic(training) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const training = await trainingService.create(req.body, req.user.id);
+      return res.status(201).json({ training: mapper.toPublic(training) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const training = await trainingService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ training: mapper.toPublic(training) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await trainingService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async statuses(_req, res) {
+    const statuses = await trainingService.listStatuses();
+    return res.json({
+      statuses: statuses.map((s) => ({ id: s.id, name: s.name, alias: s.alias })),
+    });
+  },
+};

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -1,0 +1,27 @@
+function sanitize(obj) {
+  const { id, start_at, end_at, capacity, TrainingType, TrainingStatus } = obj;
+  const res = { id, start_at, end_at, capacity };
+  if (TrainingType) {
+    res.type = {
+      id: TrainingType.id,
+      name: TrainingType.name,
+      alias: TrainingType.alias,
+    };
+  }
+  if (TrainingStatus) {
+    res.status = {
+      id: TrainingStatus.id,
+      name: TrainingStatus.name,
+      alias: TrainingStatus.alias,
+    };
+  }
+  return res;
+}
+
+function toPublic(training) {
+  if (!training) return null;
+  const plain = typeof training.get === 'function' ? training.get({ plain: true }) : training;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/migrations/20250705004000-create-training-statuses.js
+++ b/src/migrations/20250705004000-create-training-statuses.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_statuses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('training_statuses');
+  },
+};

--- a/src/migrations/20250705005000-create-trainings.js
+++ b/src/migrations/20250705005000-create-trainings.js
@@ -1,0 +1,55 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('trainings', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      type_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'training_types', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      status_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'training_statuses', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+      },
+      start_at: { type: Sequelize.DATE, allowNull: false },
+      end_at: { type: Sequelize.DATE, allowNull: false },
+      capacity: { type: Sequelize.INTEGER },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('trainings');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -25,6 +25,8 @@ import ParkingType from './parkingType.js';
 import CampStadium from './campStadium.js';
 import CampStadiumParkingType from './campStadiumParkingType.js';
 import TrainingType from './trainingType.js';
+import TrainingStatus from './trainingStatus.js';
+import Training from './training.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -96,6 +98,12 @@ CampStadiumParkingType.belongsTo(ParkingType, {
   foreignKey: 'parking_type_id',
 });
 
+/* trainings */
+TrainingStatus.hasMany(Training, { foreignKey: 'status_id' });
+Training.belongsTo(TrainingStatus, { foreignKey: 'status_id' });
+TrainingType.hasMany(Training, { foreignKey: 'type_id' });
+Training.belongsTo(TrainingType, { foreignKey: 'type_id' });
+
 /* external systems */
 User.hasMany(UserExternalId, { foreignKey: 'user_id' });
 UserExternalId.belongsTo(User, { foreignKey: 'user_id' });
@@ -138,6 +146,8 @@ export {
   CampStadium,
   CampStadiumParkingType,
   TrainingType,
+  TrainingStatus,
+  Training,
   File,
   MedicalCertificateType,
   MedicalCertificateFile,

--- a/src/models/training.js
+++ b/src/models/training.js
@@ -1,0 +1,29 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class Training extends Model {}
+
+Training.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    type_id: { type: DataTypes.UUID, allowNull: false },
+    status_id: { type: DataTypes.UUID, allowNull: false },
+    start_at: { type: DataTypes.DATE, allowNull: false },
+    end_at: { type: DataTypes.DATE, allowNull: false },
+    capacity: { type: DataTypes.INTEGER },
+  },
+  {
+    sequelize,
+    modelName: 'Training',
+    tableName: 'trainings',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default Training;

--- a/src/models/trainingStatus.js
+++ b/src/models/trainingStatus.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TrainingStatus extends Model {}
+
+TrainingStatus.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'TrainingStatus',
+    tableName: 'training_statuses',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default TrainingStatus;

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -1,0 +1,20 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/trainingAdminController.js';
+import {
+  trainingCreateRules,
+  trainingUpdateRules,
+} from '../validators/trainingValidators.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+router.get('/statuses', auth, authorize('ADMIN'), controller.statuses);
+router.post('/', auth, authorize('ADMIN'), trainingCreateRules, controller.create);
+router.get('/:id', auth, authorize('ADMIN'), controller.get);
+router.put('/:id', auth, authorize('ADMIN'), trainingUpdateRules, controller.update);
+router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -21,6 +21,7 @@ import profileRouter from './profile.js';
 import passwordResetRouter from './passwordReset.js';
 import campStadiumsRouter from './campStadiums.js';
 import campTrainingTypesRouter from './campTrainingTypes.js';
+import campTrainingsRouter from './campTrainings.js';
 
 const router = express.Router();
 
@@ -41,6 +42,7 @@ router.use('/profile', profileRouter);
 router.use('/password-reset', passwordResetRouter);
 router.use('/camp-stadiums', campStadiumsRouter);
 router.use('/camp-training-types', campTrainingTypesRouter);
+router.use('/camp-trainings', campTrainingsRouter);
 
 /**
  * @swagger

--- a/src/seeders/20250802001000-create-training-statuses.js
+++ b/src/seeders/20250802001000-create-training-statuses.js
@@ -1,0 +1,31 @@
+'use strict';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM training_statuses WHERE alias IN (\'SCHEDULED\',\'REGISTRATION_OPEN\',\'FINAL_CALL\',\'REGISTRATION_CLOSED\',\'COMPLETED\');'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'training_statuses',
+      [
+        { id: uuidv4(), name: 'Назначена', alias: 'SCHEDULED', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Идет регистрация', alias: 'REGISTRATION_OPEN', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Final call', alias: 'FINAL_CALL', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Регистрация закрыта', alias: 'REGISTRATION_CLOSED', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Тренировка завершена', alias: 'COMPLETED', created_at: now, updated_at: now },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('training_statuses', {
+      alias: ['SCHEDULED','REGISTRATION_OPEN','FINAL_CALL','REGISTRATION_CLOSED','COMPLETED'],
+    });
+  },
+};

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -1,0 +1,77 @@
+import { Training, TrainingStatus, TrainingType } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  return Training.findAndCountAll({
+    include: [TrainingType, TrainingStatus],
+    order: [['start_at', 'DESC']],
+    limit,
+    offset,
+  });
+}
+
+async function getById(id) {
+  const training = await Training.findByPk(id, { include: [TrainingType, TrainingStatus] });
+  if (!training) throw new ServiceError('training_not_found', 404);
+  return training;
+}
+
+async function create(data, actorId) {
+  const status = await TrainingStatus.findOne({ where: { alias: 'SCHEDULED' } });
+  if (!status) throw new ServiceError('training_status_not_found');
+  const training = await Training.create({
+    type_id: data.type_id,
+    status_id: status.id,
+    start_at: data.start_at,
+    end_at: data.end_at,
+    capacity: data.capacity,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return getById(training.id);
+}
+
+async function update(id, data, actorId) {
+  const training = await Training.findByPk(id);
+  if (!training) throw new ServiceError('training_not_found', 404);
+  let statusId = training.status_id;
+  if (data.status) {
+    const st = await TrainingStatus.findOne({ where: { alias: data.status } });
+    if (!st) throw new ServiceError('training_status_not_found');
+    statusId = st.id;
+  }
+  await training.update(
+    {
+      type_id: data.type_id ?? training.type_id,
+      status_id: statusId,
+      start_at: data.start_at ?? training.start_at,
+      end_at: data.end_at ?? training.end_at,
+      capacity: data.capacity ?? training.capacity,
+      updated_by: actorId,
+    },
+    { returning: false }
+  );
+  return getById(id);
+}
+
+async function remove(id) {
+  const training = await Training.findByPk(id);
+  if (!training) throw new ServiceError('training_not_found', 404);
+  await training.destroy();
+}
+
+async function listStatuses() {
+  return TrainingStatus.findAll({ order: [['id', 'ASC']] });
+}
+
+export default {
+  listAll,
+  getById,
+  create,
+  update,
+  remove,
+  listStatuses,
+};

--- a/src/validators/trainingValidators.js
+++ b/src/validators/trainingValidators.js
@@ -1,0 +1,28 @@
+import { body } from 'express-validator';
+
+export const trainingCreateRules = [
+  body('type_id').isUUID(),
+  body('start_at').isISO8601(),
+  body('end_at')
+    .isISO8601()
+    .custom((val, { req }) => new Date(val) > new Date(req.body.start_at)),
+  body('capacity').optional().isInt({ min: 0 }),
+];
+
+export const trainingUpdateRules = [
+  body('type_id').optional().isUUID(),
+  body('start_at')
+    .optional()
+    .isISO8601(),
+  body('end_at')
+    .optional()
+    .isISO8601()
+    .custom((val, { req }) => {
+      if (req.body.start_at) {
+        return new Date(val) > new Date(req.body.start_at);
+      }
+      return true;
+    }),
+  body('capacity').optional().isInt({ min: 0 }),
+  body('status').optional().isString(),
+];


### PR DESCRIPTION
## Summary
- add TrainingStatus and Training models with migrations and seed data
- provide admin CRUD for trainings
- expose training statuses via API

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68650201a6b4832db786f12f01b5dfda