### PR TITLE
Improve accessibility and responsive meta

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2,12 +2,17 @@
 <html lang="ru">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/fhm-logo.svg" />
+    <meta name="theme-color" content="#113867" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" integrity="sha384-XGjxtQfXaH2tnPFa9x+ruJTuLE3Aa6LhHSWRr1XeTyhezb4abCG4ccI5AkVDxqC+" crossorigin="anonymous"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <title>АСОУ ПД «Поток»</title>
   </head>
   <body>
+    <a href="#main" class="skip-link visually-hidden-focusable">Перейти к содержимому</a>
     <div id="app"></div>
     <script type="module" src="/src/main.js"></script>
   </body>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -14,7 +14,7 @@ const mainClass = computed(() =>
 <template>
   <div class="d-flex flex-column min-vh-100">
     <NavBar v-if="showLayout" />
-    <main :class="mainClass">
+    <main id="main" :class="mainClass">
       <router-view />
     </main>
     <FooterBar v-if="showLayout" />

--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -44,3 +44,17 @@
   box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.1);
 }
 
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--brand-color);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  z-index: 100;
+  transition: top 0.3s ease-in-out;
+}
+.skip-link:focus {
+  top: 0;
+}
+


### PR DESCRIPTION
## Summary
- tweak root meta tags for better PWA experience
- add skip link for keyboard navigation
- style skip link in brand CSS
- mark main element with an id for skip link targeting

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650ac350c0832da753121c32a1db92