### PR TITLE
Restrict training type deletion

### DIFF
--- a/src/controllers/trainingTypeAdminController.js
+++ b/src/controllers/trainingTypeAdminController.js
@@ -52,13 +52,4 @@ export default {
       return sendError(res, err, 404);
     }
   },
-
-  async remove(req, res) {
-    try {
-      await trainingTypeService.remove(req.params.id);
-      return res.status(204).end();
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
 };

--- a/src/routes/campTrainingTypes.js
+++ b/src/routes/campTrainingTypes.js
@@ -26,6 +26,6 @@ router.put(
   trainingTypeUpdateRules,
   controller.update
 );
-router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
 
 export default router;

--- a/src/services/trainingTypeService.js
+++ b/src/services/trainingTypeService.js
@@ -79,7 +79,8 @@ async function update(id, data, actorId) {
   if (!type) throw new ServiceError('training_type_not_found', 404);
   await type.update(
     {
-      // name cannot be changed after creation
+      name: data.name ?? type.name,
+      alias: data.name ? generateAlias(data.name) : type.alias,
       default_capacity: data.default_capacity ?? type.default_capacity,
       updated_by: actorId,
     },
@@ -88,10 +89,4 @@ async function update(id, data, actorId) {
   return type;
 }
 
-async function remove(id) {
-  const type = await TrainingType.findByPk(id);
-  if (!type) throw new ServiceError('training_type_not_found', 404);
-  await type.destroy();
-}
-
-export default { listAll, getById, create, update, remove };
+export default { listAll, getById, create, update };

--- a/src/validators/trainingTypeValidators.js
+++ b/src/validators/trainingTypeValidators.js
@@ -6,5 +6,6 @@ export const trainingTypeCreateRules = [
 ];
 
 export const trainingTypeUpdateRules = [
+  body('name').optional().isString().notEmpty(),
   body('default_capacity').optional().isInt({ min: 0 }),
 ];

--- a/tests/trainingTypeService.test.js
+++ b/tests/trainingTypeService.test.js
@@ -27,12 +27,14 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
 
 const { default: service } = await import('../src/services/trainingTypeService.js');
 
-test('update ignores name changes', async () => {
+test('update modifies name and capacity', async () => {
   findByPkMock.mockResolvedValue({ ...instance, name: 'Old', alias: 'old' });
   const data = { name: 'New', alias: 'old2', default_capacity: 10 };
   await service.update('t1', data, 'admin');
   expect(updateMock).toHaveBeenCalledWith(
     {
+      name: 'New',
+      alias: 'NEW',
       default_capacity: 10,
       updated_by: 'admin',
     },


### PR DESCRIPTION
## Summary
- update training type service to allow renaming and prevent deletion
- drop DELETE route and controller action for training types
- validate name on update
- adjust tests for new behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68650aeb5510832daf708c30ff84bd87