### PR TITLE
Fix training time validation

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -150,6 +150,17 @@ watch(
   }
 );
 
+watch(
+  [() => trainingForm.value.start_at, () => trainingForm.value.end_at],
+  ([start, end]) => {
+    if (start && end && new Date(end) <= new Date(start)) {
+      trainingFormError.value = 'Время окончания должно быть позже начала';
+    } else {
+      trainingFormError.value = '';
+    }
+  }
+);
+
 async function loadParkingTypes() {
   try {
     const data = await apiFetch('/camp-stadiums/parking-types');
@@ -412,6 +423,12 @@ function openEditTraining(t) {
 }
 
 async function saveTraining() {
+  if (
+    new Date(trainingForm.value.end_at) <= new Date(trainingForm.value.start_at)
+  ) {
+    trainingFormError.value = 'Время окончания должно быть позже начала';
+    return;
+  }
   const payload = {
     type_id: trainingForm.value.type_id,
     camp_stadium_id: trainingForm.value.camp_stadium_id,

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -53,6 +53,11 @@ async function update(id, data, actorId) {
     if (!st) throw new ServiceError('training_status_not_found');
     statusId = st.id;
   }
+  const newStart = data.start_at ? new Date(data.start_at) : training.start_at;
+  const newEnd = data.end_at ? new Date(data.end_at) : training.end_at;
+  if (newEnd <= newStart) {
+    throw new ServiceError('invalid_time_range');
+  }
   await training.update(
     {
       type_id: data.type_id ?? training.type_id,

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -1,0 +1,40 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const findByPkMock = jest.fn();
+const updateMock = jest.fn();
+const statusFindMock = jest.fn();
+
+const trainingInstance = {
+  start_at: new Date('2024-01-01T10:00:00Z'),
+  end_at: new Date('2024-01-01T12:00:00Z'),
+  update: updateMock,
+  status_id: 's1',
+};
+
+beforeEach(() => {
+  findByPkMock.mockReset();
+  updateMock.mockReset();
+  statusFindMock.mockReset();
+});
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  Training: { findByPk: findByPkMock },
+  TrainingStatus: { findOne: statusFindMock },
+  TrainingType: {},
+  CampStadium: {},
+}));
+
+const { default: service } = await import('../src/services/trainingService.js');
+
+test('update throws on invalid time range', async () => {
+  findByPkMock.mockResolvedValue({ ...trainingInstance });
+  await expect(
+    service.update(
+      't1',
+      { end_at: '2024-01-01T09:00:00Z' },
+      'admin'
+    )
+  ).rejects.toThrow('invalid_time_range');
+});
+


### PR DESCRIPTION
## Summary
- validate end time after start time when updating trainings
- add unit test for invalid training time range

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68650f71c5e0832da744ba5bcd334758