### PR TITLE
Add medical examination schedules

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -13,6 +13,8 @@ import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
 import AdminMedicalCertificates from './views/AdminMedicalCertificates.vue'
 import AdminCampStadiums from './views/AdminCampStadiums.vue'
+import AdminMedicalCenters from './views/AdminMedicalCenters.vue'
+import AdminMedicalExams from './views/AdminMedicalExams.vue'
 import PasswordReset from './views/PasswordReset.vue'
 import NotFound from './views/NotFound.vue'
 import Forbidden from './views/Forbidden.vue'
@@ -27,6 +29,8 @@ const routes = [
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/medical-certificates', component: AdminMedicalCertificates, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/medical-centers', component: AdminMedicalCenters, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/medical-exams', component: AdminMedicalExams, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/camp-stadiums', component: AdminCampStadiums, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -9,6 +9,16 @@ const tiles = [
     to: '/medical-certificates'
   },
   {
+    title: 'Медицинские центры',
+    icon: 'bi-hospital',
+    to: '/medical-centers'
+  },
+  {
+    title: 'Расписание медосмотров',
+    icon: 'bi-calendar-check',
+    to: '/medical-exams'
+  },
+  {
     title: 'Управление сборами',
     icon: 'bi-building',
     to: '/camp-stadiums'

--- a/client/src/views/AdminMedicalCenters.vue
+++ b/client/src/views/AdminMedicalCenters.vue
@@ -1,0 +1,286 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import Modal from 'bootstrap/js/dist/modal'
+import { apiFetch } from '../api.js'
+import { suggestAddress, cleanAddress } from '../dadata.js'
+
+const centers = ref([])
+const total = ref(0)
+const currentPage = ref(1)
+const pageSize = 8
+const isLoading = ref(false)
+const error = ref('')
+
+const form = ref({
+  name: '',
+  inn: '',
+  address: { result: '' },
+  phone: '',
+  email: '',
+  website: ''
+})
+const phoneInput = ref('')
+const editing = ref(null)
+const modalRef = ref(null)
+let modal
+const formError = ref('')
+const addrSuggestions = ref([])
+let addrTimeout
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+
+onMounted(() => {
+  modal = new Modal(modalRef.value)
+  load()
+})
+
+watch(currentPage, load)
+
+watch(
+  () => form.value.address.result,
+  (val) => {
+    clearTimeout(addrTimeout)
+    if (!val || val.length < 3) {
+      addrSuggestions.value = []
+      return
+    }
+    const query = val.trim()
+    addrTimeout = setTimeout(async () => {
+      addrSuggestions.value = await suggestAddress(query)
+    }, 300)
+  }
+)
+
+function formatPhone(digits) {
+  if (!digits) return ''
+  let out = '+7'
+  if (digits.length > 1) out += ' (' + digits.slice(1, 4)
+  if (digits.length >= 4) out += ') '
+  if (digits.length >= 4) out += digits.slice(4, 7)
+  if (digits.length >= 7) out += '-' + digits.slice(7, 9)
+  if (digits.length >= 9) out += '-' + digits.slice(9, 11)
+  return out
+}
+
+function onPhoneInput(e) {
+  let digits = e.target.value.replace(/\D/g, '')
+  if (!digits.startsWith('7')) digits = '7' + digits.replace(/^7*/, '')
+  digits = digits.slice(0, 11)
+  form.value.phone = digits
+  phoneInput.value = formatPhone(digits)
+}
+
+function onPhoneKeydown(e) {
+  if (e.key === 'Backspace' || e.key === 'Delete') {
+    e.preventDefault()
+    form.value.phone = form.value.phone.slice(0, -1)
+    phoneInput.value = formatPhone(form.value.phone)
+  }
+}
+
+function applyAddrSuggestion(s) {
+  form.value.address.result = s.value
+  addrSuggestions.value = []
+}
+
+async function onAddrBlur() {
+  const cleaned = await cleanAddress(form.value.address.result)
+  if (cleaned && cleaned.result) {
+    form.value.address.result = cleaned.result
+  }
+  addrSuggestions.value = []
+}
+
+async function load() {
+  try {
+    isLoading.value = true
+    const params = new URLSearchParams({ page: currentPage.value, limit: pageSize })
+    const data = await apiFetch(`/medical-centers?${params}`)
+    centers.value = data.centers
+    total.value = data.total
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function openCreate() {
+  editing.value = null
+  Object.assign(form.value, { name: '', inn: '', address: { result: '' }, phone: '', email: '', website: '' })
+  phoneInput.value = ''
+  formError.value = ''
+  addrSuggestions.value = []
+  modal.show()
+}
+
+function openEdit(center) {
+  editing.value = center
+  form.value.name = center.name
+  form.value.inn = center.inn
+  form.value.address.result = center.address ? center.address.result : ''
+  form.value.phone = center.phone || ''
+  phoneInput.value = formatPhone(center.phone || '')
+  form.value.email = center.email || ''
+  form.value.website = center.website || ''
+  formError.value = ''
+  addrSuggestions.value = []
+  modal.show()
+}
+
+async function save() {
+  try {
+    formError.value = ''
+    const body = {
+      name: form.value.name,
+      inn: form.value.inn,
+      phone: form.value.phone,
+      email: form.value.email,
+      website: form.value.website
+    }
+    if (form.value.address.result) {
+      body.address = { result: form.value.address.result }
+    }
+    let path = '/medical-centers'
+    let method = 'POST'
+    if (editing.value) {
+      path += `/${editing.value.id}`
+      method = 'PUT'
+    }
+    await apiFetch(path, { method, body: JSON.stringify(body) })
+    modal.hide()
+    await load()
+  } catch (e) {
+    formError.value = e.message
+  }
+}
+
+async function removeCenter(center) {
+  if (!confirm('Удалить запись?')) return
+  try {
+    await apiFetch(`/medical-centers/${center.id}`, { method: 'DELETE' })
+    await load()
+  } catch (e) {
+    alert(e.message)
+  }
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Медицинские центры</li>
+      </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Медицинские центры</h1>
+      <button class="btn btn-brand" @click="openCreate">
+        <i class="bi bi-plus-lg me-1"></i>Добавить
+      </button>
+    </div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="isLoading" class="text-center my-3"><div class="spinner-border" role="status"></div></div>
+    <div v-if="centers.length" class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Название</th>
+            <th>ИНН</th>
+            <th>Адрес</th>
+            <th>Телефон</th>
+            <th>Email</th>
+            <th>Сайт</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="c in centers" :key="c.id">
+            <td>{{ c.name }}</td>
+            <td>{{ c.inn }}</td>
+            <td>{{ c.address?.result || '' }}</td>
+            <td>{{ formatPhone(c.phone) }}</td>
+            <td>{{ c.email }}</td>
+            <td>{{ c.website }}</td>
+            <td class="text-end">
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(c)">Изменить</button>
+              <button class="btn btn-sm btn-danger" @click="removeCenter(c)">Удалить</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-else-if="!isLoading" class="text-muted">Записей нет.</p>
+    <nav class="mt-3" v-if="totalPages > 1">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: currentPage === 1 }">
+          <button class="page-link" @click="currentPage--" :disabled="currentPage === 1">Пред</button>
+        </li>
+        <li class="page-item" v-for="p in totalPages" :key="p" :class="{ active: currentPage === p }">
+          <button class="page-link" @click="currentPage = p">{{ p }}</button>
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+          <button class="page-link" @click="currentPage++" :disabled="currentPage === totalPages">След</button>
+        </li>
+      </ul>
+    </nav>
+
+    <div ref="modalRef" class="modal fade" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form @submit.prevent="save">
+            <div class="modal-header">
+              <h5 class="modal-title">{{ editing ? 'Изменить центр' : 'Добавить центр' }}</h5>
+              <button type="button" class="btn-close" @click="modal.hide()"></button>
+            </div>
+            <div class="modal-body">
+              <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
+              <div class="form-floating mb-3">
+                <input id="mcName" v-model="form.name" class="form-control" placeholder="Название" required />
+                <label for="mcName">Наименование</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="mcInn" v-model="form.inn" class="form-control" placeholder="ИНН" required />
+                <label for="mcInn">ИНН</label>
+              </div>
+              <div class="form-floating mb-3 position-relative">
+                <textarea id="mcAddr" v-model="form.address.result" @blur="onAddrBlur" class="form-control" rows="2" placeholder="Адрес"></textarea>
+                <label for="mcAddr">Адрес</label>
+                <ul v-if="addrSuggestions.length" class="list-group position-absolute w-100" style="z-index:1050">
+                  <li v-for="s in addrSuggestions" :key="s.value" class="list-group-item list-group-item-action" @mousedown.prevent="applyAddrSuggestion(s)">
+                    {{ s.value }}
+                  </li>
+                </ul>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="mcPhone" type="tel" v-model="phoneInput" @input="onPhoneInput" @keydown="onPhoneKeydown" class="form-control" placeholder="Телефон" />
+                <label for="mcPhone">Телефон</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="mcEmail" v-model="form.email" type="email" class="form-control" placeholder="Email" />
+                <label for="mcEmail">Email</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="mcWeb" v-model="form.website" class="form-control" placeholder="Сайт" />
+                <label for="mcWeb">Сайт</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+              <button type="submit" class="btn btn-primary">Сохранить</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.list-group {
+  max-height: 200px;
+  overflow-y: auto;
+}
+</style>

--- a/client/src/views/AdminMedicalExams.vue
+++ b/client/src/views/AdminMedicalExams.vue
@@ -1,0 +1,225 @@
+<script setup>
+import { ref, onMounted, watch, computed } from 'vue'
+import { RouterLink } from 'vue-router'
+import Modal from 'bootstrap/js/dist/modal'
+import { apiFetch } from '../api.js'
+
+const exams = ref([])
+const total = ref(0)
+const currentPage = ref(1)
+const pageSize = 8
+const isLoading = ref(false)
+const error = ref('')
+
+const centers = ref([])
+const statuses = ref([])
+
+const form = ref({
+  medical_center_id: '',
+  start_at: '',
+  end_at: '',
+  capacity: '',
+  status: ''
+})
+const editing = ref(null)
+const modalRef = ref(null)
+let modal
+const formError = ref('')
+
+const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)))
+
+onMounted(() => {
+  modal = new Modal(modalRef.value)
+  load()
+  loadCenters()
+  loadStatuses()
+})
+
+watch(currentPage, load)
+
+async function loadCenters() {
+  try {
+    const data = await apiFetch('/medical-centers?page=1&limit=100')
+    centers.value = data.centers
+  } catch (_e) {
+    centers.value = []
+  }
+}
+
+async function loadStatuses() {
+  try {
+    const data = await apiFetch('/medical-exams/statuses')
+    statuses.value = data.statuses
+  } catch (_e) {
+    statuses.value = []
+  }
+}
+
+async function load() {
+  try {
+    isLoading.value = true
+    const params = new URLSearchParams({ page: currentPage.value, limit: pageSize })
+    const data = await apiFetch(`/medical-exams?${params}`)
+    exams.value = data.exams
+    total.value = data.total
+  } catch (e) {
+    error.value = e.message
+  } finally {
+    isLoading.value = false
+  }
+}
+
+function openCreate() {
+  editing.value = null
+  Object.assign(form.value, { medical_center_id: '', start_at: '', end_at: '', capacity: '', status: '' })
+  formError.value = ''
+  modal.show()
+}
+
+function openEdit(exam) {
+  editing.value = exam
+  form.value.medical_center_id = exam.center?.id || ''
+  form.value.start_at = exam.start_at
+  form.value.end_at = exam.end_at
+  form.value.capacity = exam.capacity || ''
+  form.value.status = exam.status?.alias || ''
+  formError.value = ''
+  modal.show()
+}
+
+async function save() {
+  try {
+    formError.value = ''
+    const body = {
+      medical_center_id: form.value.medical_center_id,
+      start_at: form.value.start_at,
+      end_at: form.value.end_at,
+      capacity: form.value.capacity
+    }
+    if (editing.value) {
+      if (form.value.status) body.status = form.value.status
+      await apiFetch(`/medical-exams/${editing.value.id}`, { method: 'PUT', body: JSON.stringify(body) })
+    } else {
+      await apiFetch('/medical-exams', { method: 'POST', body: JSON.stringify(body) })
+    }
+    modal.hide()
+    await load()
+  } catch (e) {
+    formError.value = e.message
+  }
+}
+
+async function removeExam(exam) {
+  if (!confirm('Удалить запись?')) return
+  try {
+    await apiFetch(`/medical-exams/${exam.id}`, { method: 'DELETE' })
+    await load()
+  } catch (e) {
+    alert(e.message)
+  }
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Медицинские обследования</li>
+      </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+      <h1 class="mb-0">Расписание медосмотров</h1>
+      <button class="btn btn-brand" @click="openCreate">
+        <i class="bi bi-plus-lg me-1"></i>Добавить
+      </button>
+    </div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="isLoading" class="text-center my-3"><div class="spinner-border" role="status"></div></div>
+    <div v-if="exams.length" class="table-responsive">
+      <table class="table table-striped align-middle">
+        <thead>
+          <tr>
+            <th>Центр</th>
+            <th>Период</th>
+            <th>Места</th>
+            <th>Статус</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="ex in exams" :key="ex.id">
+            <td>{{ ex.center?.name }}</td>
+            <td>{{ ex.start_at }} - {{ ex.end_at }}</td>
+            <td>{{ ex.capacity }}</td>
+            <td>{{ ex.status?.name }}</td>
+            <td class="text-end">
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(ex)">Изменить</button>
+              <button class="btn btn-sm btn-danger" @click="removeExam(ex)">Удалить</button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <p v-else-if="!isLoading" class="text-muted">Записей нет.</p>
+    <nav class="mt-3" v-if="totalPages > 1">
+      <ul class="pagination justify-content-center">
+        <li class="page-item" :class="{ disabled: currentPage === 1 }">
+          <button class="page-link" @click="currentPage--" :disabled="currentPage === 1">Пред</button>
+        </li>
+        <li class="page-item" v-for="p in totalPages" :key="p" :class="{ active: currentPage === p }">
+          <button class="page-link" @click="currentPage = p">{{ p }}</button>
+        </li>
+        <li class="page-item" :class="{ disabled: currentPage === totalPages }">
+          <button class="page-link" @click="currentPage++" :disabled="currentPage === totalPages">След</button>
+        </li>
+      </ul>
+    </nav>
+
+    <div ref="modalRef" class="modal fade" tabindex="-1">
+      <div class="modal-dialog">
+        <div class="modal-content">
+          <form @submit.prevent="save">
+            <div class="modal-header">
+              <h5 class="modal-title">{{ editing ? 'Изменить запись' : 'Добавить запись' }}</h5>
+              <button type="button" class="btn-close" @click="modal.hide()"></button>
+            </div>
+            <div class="modal-body">
+              <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
+              <div class="mb-3">
+                <label class="form-label">Медицинский центр</label>
+                <select v-model="form.medical_center_id" class="form-select" required>
+                  <option value="" disabled>Выберите центр</option>
+                  <option v-for="c in centers" :key="c.id" :value="c.id">{{ c.name }}</option>
+                </select>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="exStart" type="date" v-model="form.start_at" class="form-control" required />
+                <label for="exStart">Начало</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="exEnd" type="date" v-model="form.end_at" class="form-control" required />
+                <label for="exEnd">Окончание</label>
+              </div>
+              <div class="form-floating mb-3">
+                <input id="exCap" type="number" min="0" v-model="form.capacity" class="form-control" />
+                <label for="exCap">Количество мест</label>
+              </div>
+              <div class="mb-3" v-if="editing">
+                <label class="form-label">Статус</label>
+                <select v-model="form.status" class="form-select">
+                  <option value="" disabled>Выберите статус</option>
+                  <option v-for="s in statuses" :key="s.alias" :value="s.alias">{{ s.name }}</option>
+                </select>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+              <button type="submit" class="btn btn-primary">Сохранить</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/controllers/medicalCenterAdminController.js
+++ b/src/controllers/medicalCenterAdminController.js
@@ -1,0 +1,63 @@
+import { validationResult } from 'express-validator';
+import medicalCenterService from '../services/medicalCenterService.js';
+import mapper from '../mappers/medicalCenterMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await medicalCenterService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({ centers: rows.map(mapper.toPublic), total: count });
+  },
+
+  async get(req, res) {
+    try {
+      const center = await medicalCenterService.getById(req.params.id);
+      return res.json({ center: mapper.toPublic(center) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const center = await medicalCenterService.create(req.body, req.user.id);
+      return res.status(201).json({ center: mapper.toPublic(center) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const center = await medicalCenterService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ center: mapper.toPublic(center) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await medicalCenterService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/controllers/medicalExamAdminController.js
+++ b/src/controllers/medicalExamAdminController.js
@@ -1,0 +1,70 @@
+import { validationResult } from 'express-validator';
+import medicalExamService from '../services/medicalExamService.js';
+import mapper from '../mappers/medicalExamMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    const { rows, count } = await medicalExamService.listAll({
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    return res.json({ exams: rows.map(mapper.toPublic), total: count });
+  },
+
+  async get(req, res) {
+    try {
+      const exam = await medicalExamService.getById(req.params.id);
+      return res.json({ exam: mapper.toPublic(exam) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const exam = await medicalExamService.create(req.body, req.user.id);
+      return res.status(201).json({ exam: mapper.toPublic(exam) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const exam = await medicalExamService.update(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.json({ exam: mapper.toPublic(exam) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await medicalExamService.remove(req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async statuses(_req, res) {
+    const statuses = await medicalExamService.listStatuses();
+    return res.json({
+      statuses: statuses.map((s) => ({ id: s.id, name: s.name, alias: s.alias })),
+    });
+  },
+};

--- a/src/mappers/medicalCenterMapper.js
+++ b/src/mappers/medicalCenterMapper.js
@@ -1,0 +1,19 @@
+function sanitize(obj) {
+  const { id, name, inn, is_legal_entity, phone, email, website, Address } = obj;
+  const out = { id, name, inn, is_legal_entity, phone, email, website };
+  if (Address) {
+    out.address = {
+      id: Address.id,
+      result: Address.result,
+    };
+  }
+  return out;
+}
+
+function toPublic(center) {
+  if (!center) return null;
+  const plain = typeof center.get === 'function' ? center.get({ plain: true }) : center;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/mappers/medicalExamMapper.js
+++ b/src/mappers/medicalExamMapper.js
@@ -1,0 +1,19 @@
+function sanitize(obj) {
+  const { id, start_at, end_at, capacity, MedicalCenter, MedicalExamStatus } = obj;
+  const out = { id, start_at, end_at, capacity };
+  if (MedicalCenter) {
+    out.center = { id: MedicalCenter.id, name: MedicalCenter.name };
+  }
+  if (MedicalExamStatus) {
+    out.status = { id: MedicalExamStatus.id, name: MedicalExamStatus.name, alias: MedicalExamStatus.alias };
+  }
+  return out;
+}
+
+function toPublic(exam) {
+  if (!exam) return null;
+  const plain = typeof exam.get === 'function' ? exam.get({ plain: true }) : exam;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/migrations/20250901000000-create-medical-centers.js
+++ b/src/migrations/20250901000000-create-medical-centers.js
@@ -1,0 +1,50 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('medical_centers', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(255), allowNull: false },
+      inn: { type: Sequelize.STRING(12), allowNull: false, unique: true },
+      is_legal_entity: { type: Sequelize.BOOLEAN, allowNull: false },
+      address_id: {
+        type: Sequelize.UUID,
+        references: { model: 'addresses', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      phone: { type: Sequelize.STRING(15) },
+      email: { type: Sequelize.STRING(255) },
+      website: { type: Sequelize.STRING(255) },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('medical_centers');
+  },
+};

--- a/src/migrations/20250901001000-create-medical-exam-statuses.js
+++ b/src/migrations/20250901001000-create-medical-exam-statuses.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('medical_exam_statuses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_at: { type: Sequelize.DATE, defaultValue: Sequelize.literal('NOW()') },
+      updated_at: { type: Sequelize.DATE, defaultValue: Sequelize.literal('NOW()') },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('medical_exam_statuses');
+  },
+};

--- a/src/migrations/20250901002000-create-medical-exams.js
+++ b/src/migrations/20250901002000-create-medical-exams.js
@@ -1,0 +1,49 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('medical_exams', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      medical_center_id: {
+        type: Sequelize.UUID,
+        references: { model: 'medical_centers', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+        allowNull: false,
+      },
+      status_id: {
+        type: Sequelize.UUID,
+        references: { model: 'medical_exam_statuses', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+        allowNull: false,
+      },
+      start_at: { type: Sequelize.DATEONLY, allowNull: false },
+      end_at: { type: Sequelize.DATEONLY, allowNull: false },
+      capacity: { type: Sequelize.INTEGER },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: { type: Sequelize.DATE, defaultValue: Sequelize.literal('NOW()') },
+      updated_at: { type: Sequelize.DATE, defaultValue: Sequelize.literal('NOW()') },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('medical_exams');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -27,6 +27,9 @@ import CampStadiumParkingType from './campStadiumParkingType.js';
 import TrainingType from './trainingType.js';
 import TrainingStatus from './trainingStatus.js';
 import Training from './training.js';
+import MedicalCenter from './medicalCenter.js';
+import MedicalExamStatus from './medicalExamStatus.js';
+import MedicalExam from './medicalExam.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -106,6 +109,14 @@ Training.belongsTo(TrainingType, { foreignKey: 'type_id' });
 CampStadium.hasMany(Training, { foreignKey: 'camp_stadium_id' });
 Training.belongsTo(CampStadium, { foreignKey: 'camp_stadium_id' });
 
+/* medical centers */
+MedicalCenter.belongsTo(Address, { foreignKey: 'address_id' });
+Address.hasMany(MedicalCenter, { foreignKey: 'address_id' });
+MedicalCenter.hasMany(MedicalExam, { foreignKey: 'medical_center_id' });
+MedicalExam.belongsTo(MedicalCenter, { foreignKey: 'medical_center_id' });
+MedicalExamStatus.hasMany(MedicalExam, { foreignKey: 'status_id' });
+MedicalExam.belongsTo(MedicalExamStatus, { foreignKey: 'status_id' });
+
 /* external systems */
 User.hasMany(UserExternalId, { foreignKey: 'user_id' });
 UserExternalId.belongsTo(User, { foreignKey: 'user_id' });
@@ -153,4 +164,7 @@ export {
   File,
   MedicalCertificateType,
   MedicalCertificateFile,
+  MedicalCenter,
+  MedicalExamStatus,
+  MedicalExam,
 };

--- a/src/models/medicalCenter.js
+++ b/src/models/medicalCenter.js
@@ -1,0 +1,30 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class MedicalCenter extends Model {}
+
+MedicalCenter.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(255), allowNull: false },
+    inn: { type: DataTypes.STRING(12), allowNull: false, unique: true },
+    is_legal_entity: { type: DataTypes.BOOLEAN, allowNull: false },
+    address_id: { type: DataTypes.UUID },
+    phone: { type: DataTypes.STRING(15) },
+    email: { type: DataTypes.STRING(255) },
+    website: { type: DataTypes.STRING(255) },
+  },
+  {
+    sequelize,
+    modelName: 'MedicalCenter',
+    tableName: 'medical_centers',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default MedicalCenter;

--- a/src/models/medicalExam.js
+++ b/src/models/medicalExam.js
@@ -1,0 +1,28 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class MedicalExam extends Model {}
+
+MedicalExam.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    medical_center_id: { type: DataTypes.UUID, allowNull: false },
+    status_id: { type: DataTypes.UUID, allowNull: false },
+    start_at: { type: DataTypes.DATEONLY, allowNull: false },
+    end_at: { type: DataTypes.DATEONLY, allowNull: false },
+    capacity: { type: DataTypes.INTEGER },
+  },
+  {
+    sequelize,
+    modelName: 'MedicalExam',
+    tableName: 'medical_exams',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default MedicalExam;

--- a/src/models/medicalExamStatus.js
+++ b/src/models/medicalExamStatus.js
@@ -1,0 +1,25 @@
+import { DataTypes, Model } from 'sequelize';
+import sequelize from '../config/database.js';
+
+class MedicalExamStatus extends Model {}
+
+MedicalExamStatus.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'MedicalExamStatus',
+    tableName: 'medical_exam_statuses',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default MedicalExamStatus;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -22,6 +22,8 @@ import passwordResetRouter from './passwordReset.js';
 import campStadiumsRouter from './campStadiums.js';
 import campTrainingTypesRouter from './campTrainingTypes.js';
 import campTrainingsRouter from './campTrainings.js';
+import medicalCentersRouter from './medicalCenters.js';
+import medicalExamsRouter from './medicalExams.js';
 
 const router = express.Router();
 
@@ -43,6 +45,8 @@ router.use('/password-reset', passwordResetRouter);
 router.use('/camp-stadiums', campStadiumsRouter);
 router.use('/camp-training-types', campTrainingTypesRouter);
 router.use('/camp-trainings', campTrainingsRouter);
+router.use('/medical-centers', medicalCentersRouter);
+router.use('/medical-exams', medicalExamsRouter);
 
 /**
  * @swagger

--- a/src/routes/medicalCenters.js
+++ b/src/routes/medicalCenters.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/medicalCenterAdminController.js';
+import {
+  medicalCenterCreateRules,
+  medicalCenterUpdateRules,
+} from '../validators/medicalCenterValidators.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+router.post('/', auth, authorize('ADMIN'), medicalCenterCreateRules, controller.create);
+router.get('/:id', auth, authorize('ADMIN'), controller.get);
+router.put('/:id', auth, authorize('ADMIN'), medicalCenterUpdateRules, controller.update);
+router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+export default router;

--- a/src/routes/medicalExams.js
+++ b/src/routes/medicalExams.js
@@ -1,0 +1,16 @@
+import express from 'express';
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/medicalExamAdminController.js';
+import { medicalExamCreateRules, medicalExamUpdateRules } from '../validators/medicalExamValidators.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+router.get('/statuses', auth, authorize('ADMIN'), controller.statuses);
+router.post('/', auth, authorize('ADMIN'), medicalExamCreateRules, controller.create);
+router.get('/:id', auth, authorize('ADMIN'), controller.get);
+router.put('/:id', auth, authorize('ADMIN'), medicalExamUpdateRules, controller.update);
+router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+export default router;

--- a/src/seeders/20250901003000-create-medical-exam-statuses.js
+++ b/src/seeders/20250901003000-create-medical-exam-statuses.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      "SELECT COUNT(*) AS cnt FROM medical_exam_statuses WHERE alias IN ('OPEN','FINAL_CALL','CLOSED');"
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'medical_exam_statuses',
+      [
+        { id: uuidv4(), name: 'Регистрация открыта', alias: 'OPEN', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Регистрация завершается', alias: 'FINAL_CALL', created_at: now, updated_at: now },
+        { id: uuidv4(), name: 'Регистрация закрыта', alias: 'CLOSED', created_at: now, updated_at: now },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('medical_exam_statuses', {
+      alias: ['OPEN', 'FINAL_CALL', 'CLOSED'],
+    });
+  },
+};

--- a/src/services/medicalCenterService.js
+++ b/src/services/medicalCenterService.js
@@ -1,0 +1,81 @@
+import { MedicalCenter, Address } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+import * as dadataService from './dadataService.js';
+
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  return MedicalCenter.findAndCountAll({
+    include: [Address],
+    limit,
+    offset,
+    order: [['name', 'ASC']],
+  });
+}
+
+async function getById(id) {
+  const center = await MedicalCenter.findByPk(id, { include: [Address] });
+  if (!center) throw new ServiceError('center_not_found', 404);
+  return center;
+}
+
+function detectLegalEntity(inn) {
+  return String(inn).length === 10;
+}
+
+async function create(data, actorId) {
+  const cleaned = await dadataService.cleanAddress(data.address.result);
+  const addrData = cleaned || { result: data.address.result };
+  const address = await Address.create({ ...addrData, created_by: actorId, updated_by: actorId });
+  const center = await MedicalCenter.create({
+    name: data.name,
+    inn: data.inn,
+    is_legal_entity: detectLegalEntity(data.inn),
+    address_id: address.id,
+    phone: data.phone ? data.phone.replace(/\D/g, '') : null,
+    email: data.email,
+    website: data.website,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return getById(center.id);
+}
+
+async function update(id, data, actorId) {
+  const center = await MedicalCenter.findByPk(id, { include: [Address] });
+  if (!center) throw new ServiceError('center_not_found', 404);
+  if (data.address) {
+    const cleaned = await dadataService.cleanAddress(data.address.result);
+    const addrData = cleaned || { result: data.address.result };
+    if (center.Address) {
+      await center.Address.update({ ...addrData, updated_by: actorId });
+    } else {
+      const addr = await Address.create({ ...addrData, created_by: actorId, updated_by: actorId });
+      data.address_id = addr.id;
+    }
+  }
+  await center.update(
+    {
+      name: data.name ?? center.name,
+      inn: data.inn ?? center.inn,
+      is_legal_entity: data.inn ? detectLegalEntity(data.inn) : center.is_legal_entity,
+      address_id: data.address_id ?? center.address_id,
+      phone: data.phone !== undefined ? data.phone.replace(/\D/g, '') : center.phone,
+      email: data.email ?? center.email,
+      website: data.website ?? center.website,
+      updated_by: actorId,
+    },
+    { returning: false }
+  );
+  return getById(id);
+}
+
+async function remove(id) {
+  const center = await MedicalCenter.findByPk(id, { include: [Address] });
+  if (!center) throw new ServiceError('center_not_found', 404);
+  if (center.Address) await center.Address.destroy();
+  await center.destroy();
+}
+
+export default { listAll, getById, create, update, remove };

--- a/src/services/medicalExamService.js
+++ b/src/services/medicalExamService.js
@@ -1,0 +1,68 @@
+import { MedicalExam, MedicalExamStatus, MedicalCenter } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+async function listAll(options = {}) {
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  return MedicalExam.findAndCountAll({
+    include: [MedicalExamStatus, MedicalCenter],
+    order: [['start_at', 'DESC']],
+    limit,
+    offset,
+  });
+}
+
+async function getById(id) {
+  const exam = await MedicalExam.findByPk(id, { include: [MedicalExamStatus, MedicalCenter] });
+  if (!exam) throw new ServiceError('exam_not_found', 404);
+  return exam;
+}
+
+async function create(data, actorId) {
+  const status = await MedicalExamStatus.findOne({ where: { alias: 'OPEN' } });
+  const exam = await MedicalExam.create({
+    medical_center_id: data.medical_center_id,
+    status_id: status ? status.id : data.status_id,
+    start_at: data.start_at,
+    end_at: data.end_at,
+    capacity: data.capacity,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return getById(exam.id);
+}
+
+async function update(id, data, actorId) {
+  const exam = await MedicalExam.findByPk(id);
+  if (!exam) throw new ServiceError('exam_not_found', 404);
+  let statusId = exam.status_id;
+  if (data.status) {
+    const st = await MedicalExamStatus.findOne({ where: { alias: data.status } });
+    if (st) statusId = st.id;
+  }
+  await exam.update(
+    {
+      medical_center_id: data.medical_center_id ?? exam.medical_center_id,
+      status_id: statusId,
+      start_at: data.start_at ?? exam.start_at,
+      end_at: data.end_at ?? exam.end_at,
+      capacity: data.capacity ?? exam.capacity,
+      updated_by: actorId,
+    },
+    { returning: false }
+  );
+  return getById(id);
+}
+
+async function remove(id) {
+  const exam = await MedicalExam.findByPk(id);
+  if (!exam) throw new ServiceError('exam_not_found', 404);
+  await exam.destroy();
+}
+
+async function listStatuses() {
+  return MedicalExamStatus.findAll({ order: [['id', 'ASC']] });
+}
+
+export default { listAll, getById, create, update, remove, listStatuses };

--- a/src/validators/medicalCenterValidators.js
+++ b/src/validators/medicalCenterValidators.js
@@ -1,0 +1,41 @@
+import { body } from 'express-validator';
+
+export const medicalCenterCreateRules = [
+  body('name').isString().notEmpty(),
+  body('inn').isLength({ min: 10, max: 12 }).matches(/^\d+$/),
+  body('address.result').notEmpty().withMessage('invalid_address'),
+  body('phone')
+    .optional()
+    .customSanitizer((v) => v.replace(/\D/g, ''))
+    .isMobilePhone('ru-RU'),
+  body('email').optional().isEmail(),
+  body('website')
+    .optional()
+    .isURL({ require_protocol: false })
+    .customSanitizer((v) => {
+      if (v && !/^https?:\/\//i.test(v)) {
+        return `http://${v}`;
+      }
+      return v;
+    }),
+];
+
+export const medicalCenterUpdateRules = [
+  body('name').optional().isString().notEmpty(),
+  body('inn').optional().isLength({ min: 10, max: 12 }).matches(/^\d+$/),
+  body('address.result').optional().notEmpty(),
+  body('phone')
+    .optional()
+    .customSanitizer((v) => v.replace(/\D/g, ''))
+    .isMobilePhone('ru-RU'),
+  body('email').optional().isEmail(),
+  body('website')
+    .optional()
+    .isURL({ require_protocol: false })
+    .customSanitizer((v) => {
+      if (v && !/^https?:\/\//i.test(v)) {
+        return `http://${v}`;
+      }
+      return v;
+    }),
+];

--- a/src/validators/medicalExamValidators.js
+++ b/src/validators/medicalExamValidators.js
@@ -1,0 +1,26 @@
+import { body } from 'express-validator';
+
+export const medicalExamCreateRules = [
+  body('medical_center_id').isUUID(),
+  body('start_at').isISO8601(),
+  body('end_at')
+    .isISO8601()
+    .custom((val, { req }) => new Date(val) >= new Date(req.body.start_at)),
+  body('capacity').optional().isInt({ min: 0 }),
+];
+
+export const medicalExamUpdateRules = [
+  body('medical_center_id').optional().isUUID(),
+  body('start_at').optional().isISO8601(),
+  body('end_at')
+    .optional()
+    .isISO8601()
+    .custom((val, { req }) => {
+      if (req.body.start_at) {
+        return new Date(val) >= new Date(req.body.start_at);
+      }
+      return true;
+    }),
+  body('capacity').optional().isInt({ min: 0 }),
+  body('status').optional().isString(),
+];


### PR DESCRIPTION
## Summary
- add models for medical centers and medical exams
- create migrations and seeders
- expose services and controllers
- wire up admin routes
- **add admin UI for medical centers and exams**

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686523a4bc3c832d804cfe435fc547d9