### PR TITLE
Add judges medical certificates list

### DIFF
--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -303,36 +303,37 @@ async function loadJudges() {
     <div v-if="judgesLoading" class="text-center my-3">
       <div class="spinner-border" role="status"></div>
     </div>
-    <div
-      v-if="judges.length"
-      class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-3"
-    >
-      <div v-for="j in judges" :key="j.user.id" class="col">
-        <div :class="['card tile h-100', hasActive(j) ? '' : 'border-danger']">
-          <div class="card-body p-3">
-            <h5 class="card-title">
-              {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic }}
-            </h5>
-            <p class="small text-muted mb-2">{{ formatDate(j.user.birth_date) }}</p>
-            <div class="table-responsive">
-              <table class="table table-sm mb-0">
-                <thead>
-                  <tr>
-                    <th>Номер</th>
-                    <th>Учреждение</th>
-                    <th>Срок</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr v-for="c in j.certificates" :key="c.id">
-                    <td>{{ c.certificate_number }}</td>
-                    <td>{{ c.organization }}</td>
-                    <td>{{ formatDate(c.issue_date) }} - {{ formatDate(c.valid_until) }}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-          </div>
+    <div v-if="judges.length" class="card tile">
+      <div class="card-body p-3">
+        <div class="table-responsive">
+          <table class="table table-hover align-middle mb-0">
+            <thead>
+              <tr>
+                <th>ФИО</th>
+                <th class="d-none d-md-table-cell">Дата рождения</th>
+                <th>Номер заключения</th>
+                <th class="d-none d-lg-table-cell">Учреждение</th>
+                <th class="d-none d-xl-table-cell">Период действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="j in judges" :key="j.user.id" :class="{ 'table-danger': !hasActive(j) }">
+                <td>{{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic }}</td>
+                <td class="d-none d-md-table-cell">{{ formatDate(j.user.birth_date) }}</td>
+                <td>
+                  <div v-for="c in j.certificates" :key="c.id">{{ c.certificate_number }}</div>
+                </td>
+                <td class="d-none d-lg-table-cell">
+                  <div v-for="c in j.certificates" :key="c.id">{{ c.organization }}</div>
+                </td>
+                <td class="d-none d-xl-table-cell">
+                  <div v-for="c in j.certificates" :key="c.id" class="text-nowrap">
+                    {{ formatDate(c.issue_date) }} - {{ formatDate(c.valid_until) }}
+                  </div>
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -98,9 +98,7 @@ function openEdit(cert) {
   editing.value = cert
   Object.assign(form.value, cert)
   skipUserWatch = true
-  userQuery.value = cert.user
-    ? `${cert.user.last_name} ${cert.user.first_name}`
-    : ''
+  userQuery.value = ''
   userSuggestions.value = []
   formError.value = ''
   loadFiles()
@@ -178,6 +176,18 @@ async function removeFile(file) {
   }
 }
 
+async function removeCert() {
+  if (!editing.value) return
+  if (!confirm('Удалить справку?')) return
+  try {
+    await apiFetch(`/medical-certificates/${editing.value.id}`, { method: 'DELETE' })
+    modal.hide()
+    await loadJudges()
+  } catch (e) {
+    formError.value = e.message
+  }
+}
+
 function formatDate(str) {
   if (!str) return ''
   const [y, m, d] = str.split('-')
@@ -221,13 +231,11 @@ async function loadJudges() {
       </button>
     </div>
 
-
-    <h2 class="mt-5 mb-3">Судьи</h2>
     <div v-if="judgesError" class="alert alert-danger">{{ judgesError }}</div>
     <div v-if="judgesLoading" class="text-center my-3">
       <div class="spinner-border" role="status"></div>
     </div>
-    <div v-if="judges.length" class="card tile">
+    <div v-if="judges.length" class="card tile fade-in shadow-sm mt-4">
       <div class="card-body p-3">
         <div class="table-responsive">
           <table class="table table-hover align-middle mb-0">
@@ -295,14 +303,13 @@ async function loadJudges() {
             </div>
             <div class="modal-body">
               <div v-if="formError" class="alert alert-danger">{{ formError }}</div>
-              <div class="mb-3 position-relative">
+              <div class="mb-3 position-relative" v-if="!editing">
                 <div class="form-floating">
                   <input
                     id="userId"
                     v-model="userQuery"
                     class="form-control"
                     placeholder="Пользователь"
-                    :disabled="editing"
                   />
                   <label for="userId">Пользователь</label>
                 </div>
@@ -396,7 +403,17 @@ async function loadJudges() {
               </div>
             </div>
             <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
+              <button
+                v-if="editing"
+                type="button"
+                class="btn btn-danger me-auto"
+                @click="removeCert"
+              >
+                Удалить
+              </button>
+              <button type="button" class="btn btn-secondary" @click="modal.hide()">
+                Отмена
+              </button>
               <button type="submit" class="btn btn-primary" :disabled="editing">
                 Сохранить
               </button>

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -94,6 +94,19 @@ function openCreate() {
   modal.show()
 }
 
+function openEdit(cert) {
+  editing.value = cert
+  Object.assign(form.value, cert)
+  skipUserWatch = true
+  userQuery.value = cert.user
+    ? `${cert.user.last_name} ${cert.user.first_name}`
+    : ''
+  userSuggestions.value = []
+  formError.value = ''
+  loadFiles()
+  modal.show()
+}
+
 function selectUser(u) {
   form.value.user_id = u.id
   skipUserWatch = true
@@ -232,14 +245,36 @@ async function loadJudges() {
                 <td>{{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic }}</td>
                 <td class="d-none d-md-table-cell">{{ formatDate(j.user.birth_date) }}</td>
                 <td>
-                  <div v-for="c in j.certificates" :key="c.id">{{ c.certificate_number }}</div>
+                  <div v-for="c in j.certificates" :key="c.id">
+                    <button
+                      type="button"
+                      class="btn btn-link p-0"
+                      @click="openEdit(c)"
+                    >
+                      {{ c.certificate_number }}
+                    </button>
+                  </div>
                 </td>
                 <td class="d-none d-lg-table-cell">
-                  <div v-for="c in j.certificates" :key="c.id">{{ c.organization }}</div>
+                  <div v-for="c in j.certificates" :key="c.id">
+                    <button
+                      type="button"
+                      class="btn btn-link p-0"
+                      @click="openEdit(c)"
+                    >
+                      {{ c.organization }}
+                    </button>
+                  </div>
                 </td>
                 <td class="d-none d-xl-table-cell">
                   <div v-for="c in j.certificates" :key="c.id" class="text-nowrap">
-                    {{ formatDate(c.issue_date) }} - {{ formatDate(c.valid_until) }}
+                    <button
+                      type="button"
+                      class="btn btn-link p-0"
+                      @click="openEdit(c)"
+                    >
+                      {{ formatDate(c.issue_date) }} - {{ formatDate(c.valid_until) }}
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/src/controllers/medicalCertificateAdminController.js
+++ b/src/controllers/medicalCertificateAdminController.js
@@ -20,25 +20,18 @@ export default {
 
   async listByRole(req, res) {
     try {
-      const certs = await medicalCertificateService.listByRole(req.params.alias);
-      const grouped = {};
-      for (const c of certs) {
-        const user = c.User;
-        if (!grouped[user.id]) {
-          grouped[user.id] = {
-            user: {
-              id: user.id,
-              last_name: user.last_name,
-              first_name: user.first_name,
-              patronymic: user.patronymic,
-              birth_date: user.birth_date,
-            },
-            certificates: [],
-          };
-        }
-        grouped[user.id].certificates.push(medicalCertificateMapper.toPublic(c));
-      }
-      return res.json({ judges: Object.values(grouped) });
+      const data = await medicalCertificateService.listByRole(req.params.alias);
+      const judges = data.map((j) => ({
+        user: {
+          id: j.user.id,
+          last_name: j.user.last_name,
+          first_name: j.user.first_name,
+          patronymic: j.user.patronymic,
+          birth_date: j.user.birth_date,
+        },
+        certificates: j.certificates.map((c) => medicalCertificateMapper.toPublic(c)),
+      }));
+      return res.json({ judges });
     } catch (err) {
       return sendError(res, err);
     }

--- a/src/mappers/medicalCertificateMapper.js
+++ b/src/mappers/medicalCertificateMapper.js
@@ -23,6 +23,7 @@ function toPublic(cert) {
       last_name: plain.User.last_name,
       first_name: plain.User.first_name,
       patronymic: plain.User.patronymic,
+      birth_date: plain.User.birth_date,
     };
   }
   return result;

--- a/src/routes/medicalCertificates.js
+++ b/src/routes/medicalCertificates.js
@@ -19,6 +19,8 @@ router.post('/', auth, medicalCertificateRules, selfController.create);
 router.delete('/', auth, selfController.remove);
 router.get('/me/files', auth, fileController.listMe);
 
+router.get('/role/:alias', auth, authorize('ADMIN'), adminController.listByRole);
+
 router.get('/', auth, authorize('ADMIN'), adminController.list);
 router.get('/:id', auth, authorize('ADMIN'), adminController.get);
 router.put(

--- a/src/services/medicalCertificateService.js
+++ b/src/services/medicalCertificateService.js
@@ -1,6 +1,6 @@
 import { Op } from 'sequelize';
 
-import { MedicalCertificate, User, Role } from '../models/index.js';
+import { MedicalCertificate, User } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 
 import emailService from './emailService.js';
@@ -64,11 +64,20 @@ async function listAll(options = {}) {
   const include = [
     {
       model: User,
-      include: options.role
-        ? [{ model: Role, where: { alias: options.role }, through: { attributes: [] }, required: true }]
-        : [],
     },
   ];
+
+  if (options.role) {
+    const { Role } = await import('../models/index.js');
+    include[0].include = [
+      {
+        model: Role,
+        where: { alias: options.role },
+        through: { attributes: [] },
+        required: true,
+      },
+    ];
+  }
 
   return MedicalCertificate.findAndCountAll({
     include,
@@ -79,6 +88,7 @@ async function listAll(options = {}) {
 }
 
 async function listByRole(alias) {
+  const { Role } = await import('../models/index.js');
   const users = await User.findAll({
     include: [
       {


### PR DESCRIPTION
## Summary
- filter certificates by role on backend
- expose `/medical-certificates/role/:alias` route
- include user's birth date in certificate mapper
- show judges list with grouped certificates in admin UI

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865284831b8832da33838f241821c83