### PR TITLE
Fix camp admin tab data loading

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -115,8 +115,6 @@ function handleAddClick() {
 
 onMounted(() => {
   modal = new Modal(modalRef.value);
-  typeModal = new Modal(typeModalRef.value);
-  trainingModal = new Modal(trainingModalRef.value);
   load();
   loadParkingTypes();
   loadTypes();
@@ -328,6 +326,9 @@ async function loadTypes() {
 }
 
 function openCreateType() {
+  if (!typeModal) {
+    typeModal = new Modal(typeModalRef.value)
+  }
   typeEditing.value = null;
   typeForm.value = { name: '', default_capacity: '' };
   typeFormError.value = '';
@@ -335,6 +336,9 @@ function openCreateType() {
 }
 
 function openEditType(t) {
+  if (!typeModal) {
+    typeModal = new Modal(typeModalRef.value)
+  }
   typeEditing.value = t;
   typeForm.value = {
     name: t.name,
@@ -406,6 +410,9 @@ async function loadStadiumOptions() {
 }
 
 function openCreateTraining() {
+  if (!trainingModal) {
+    trainingModal = new Modal(trainingModalRef.value)
+  }
   trainingEditing.value = null;
   if (!statuses.value.length) loadStatuses();
   if (!stadiumOptions.value.length) loadStadiumOptions();
@@ -438,6 +445,9 @@ function formatDateTime(str) {
 }
 
 function openEditTraining(t) {
+  if (!trainingModal) {
+    trainingModal = new Modal(trainingModalRef.value)
+  }
   trainingEditing.value = t;
   trainingForm.value = {
     type_id: t.type?.id || '',

--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -97,12 +97,32 @@ let addrTimeout;
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)));
 const typesTotalPages = computed(() => Math.max(1, Math.ceil(typesTotal.value / pageSize)));
 
+const addButtonText = computed(() => {
+  if (activeTab.value === 'types') return 'Добавить тип';
+  if (activeTab.value === 'trainings') return 'Добавить тренировку';
+  return 'Добавить стадион';
+});
+
+function handleAddClick() {
+  if (activeTab.value === 'stadiums') {
+    openCreate();
+  } else if (activeTab.value === 'types') {
+    openCreateType();
+  } else {
+    openCreateTraining();
+  }
+}
+
 onMounted(() => {
   modal = new Modal(modalRef.value);
   typeModal = new Modal(typeModalRef.value);
   trainingModal = new Modal(trainingModalRef.value);
   load();
   loadParkingTypes();
+  loadTypes();
+  loadTrainings();
+  loadStatuses();
+  loadStadiumOptions();
   });
 
 watch(currentPage, () => {
@@ -494,24 +514,8 @@ async function removeTraining(t) {
               : 'Тренировки'
         }}
       </h1>
-      <button
-          class="btn btn-brand"
-          @click="
-            activeTab === 'stadiums'
-              ? openCreate()
-              : activeTab === 'types'
-                ? openCreateType()
-                : openCreateTraining()
-          "
-      >
-        <i class="bi bi-plus-lg me-1"></i>
-        {{
-          activeTab === 'types'
-            ? 'Добавить тип'
-            : activeTab === 'trainings'
-              ? 'Добавить тренировку'
-              : 'Добавить стадион'
-        }}
+      <button class="btn btn-brand" @click="handleAddClick">
+        <i class="bi bi-plus-lg me-1"></i>{{ addButtonText }}
       </button>
     </div>
     <ul class="nav nav-tabs mb-3">


### PR DESCRIPTION
## Summary
- preload all camp management data on mount
- simplify add-button logic with computed label and handler

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686527142398832d8bef522c0964db7b