### PR TITLE
Add placeholder for upcoming events on Home page

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -9,7 +9,9 @@ const showLayout = computed(() => !route.matched.some((r) => r.meta.hideLayout))
 const mainClass = computed(() => {
   if (!showLayout.value) return 'flex-grow-1'
   const base = 'flex-grow-1 py-3'
-  return route.meta.fluid ? `${base} container-fluid` : `${base} container`
+  return route.meta.fluid
+    ? `${base} container-fluid px-0`
+    : `${base} container`
 })
 </script>
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -8,10 +8,10 @@ const route = useRoute()
 const showLayout = computed(() => !route.matched.some((r) => r.meta.hideLayout))
 const mainClass = computed(() => {
   if (!showLayout.value) return 'flex-grow-1'
-  const base = 'flex-grow-1 py-3'
+  const base = 'flex-grow-1'
   return route.meta.fluid
     ? `${base} container-fluid px-0`
-    : `${base} container`
+    : `${base} container py-3`
 })
 </script>
 

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -6,9 +6,11 @@ import FooterBar from './components/FooterBar.vue'
 
 const route = useRoute()
 const showLayout = computed(() => !route.matched.some((r) => r.meta.hideLayout))
-const mainClass = computed(() =>
-  showLayout.value ? 'flex-grow-1 container py-3' : 'flex-grow-1'
-)
+const mainClass = computed(() => {
+  if (!showLayout.value) return 'flex-grow-1'
+  const base = 'flex-grow-1 py-3'
+  return route.meta.fluid ? `${base} container-fluid` : `${base} container`
+})
 </script>
 
 <template>

--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -58,3 +58,7 @@
   top: 0;
 }
 
+body {
+  background-color: #f0f1f3;
+}
+

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -21,7 +21,7 @@ import Forbidden from './views/Forbidden.vue'
 import ServerError from './views/ServerError.vue'
 
 const routes = [
-  { path: '/', component: Home, meta: { requiresAuth: true } },
+  { path: '/', component: Home, meta: { requiresAuth: true, fluid: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
   { path: '/medical', component: Medical, meta: { requiresAuth: true } },
   { path: '/admin', component: AdminHome, meta: { requiresAuth: true, requiresAdmin: true } },

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -32,7 +32,7 @@ const greeting = computed(() => {
 </script>
 
 <template>
-  <div class="home-page py-4">
+  <div class="py-4">
     <div class="container">
       <h1 class="mb-4 text-start">
         {{ greeting }}, {{ shortName || auth.user?.phone }}!
@@ -82,9 +82,6 @@ const greeting = computed(() => {
 </template>
 
 <style scoped>
-.home-page {
-  background-color: #f0f1f3;
-}
 
 .main-tile {
   border-radius: 1rem;

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -36,6 +36,12 @@ const greeting = computed(() => {
     <h1 class="mb-4 text-start">
       {{ greeting }}, {{ shortName || auth.user?.phone }}!
     </h1>
+    <div class="card mb-4 text-center">
+      <div class="card-body">
+        <h5 class="card-title mb-2">Ближайшие события</h5>
+        <p class="card-text text-muted mb-0">Информация скоро будет доступна</p>
+      </div>
+    </div>
     <div class="row g-4">
       <div class="col-6 col-md-4 col-lg-3" v-for="section in sections" :key="section.title">
         <component

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -32,23 +32,25 @@ const greeting = computed(() => {
 </script>
 
 <template>
-  <div class="container mt-4">
-    <h1 class="mb-4 text-start">
-      {{ greeting }}, {{ shortName || auth.user?.phone }}!
-    </h1>
-    <div class="card mb-4 text-center">
-      <div class="card-body">
-        <h5 class="card-title mb-2">Ближайшие события</h5>
-        <p class="card-text text-muted mb-0">Информация скоро будет доступна</p>
+  <div class="home-page py-4">
+    <div class="container">
+      <h1 class="mb-4 text-start">
+        {{ greeting }}, {{ shortName || auth.user?.phone }}!
+      </h1>
+      <div class="card mb-4 text-center">
+        <div class="card-body">
+          <h5 class="card-title mb-2">Ближайшие события</h5>
+          <p class="card-text text-muted mb-0">Информация скоро будет доступна</p>
+        </div>
       </div>
-    </div>
-    <div class="row g-4">
-      <div class="col-6 col-md-4 col-lg-3" v-for="section in sections" :key="section.title">
-        <component
-          :is="section.to ? RouterLink : 'div'"
-          :to="section.to"
-          class="card h-100 text-center tile fade-in text-decoration-none text-body"
-          :class="{ 'placeholder-card': !section.to }"
+      <div class="card main-tile p-4">
+        <div class="row g-4">
+          <div class="col-6 col-md-4 col-lg-3" v-for="section in sections" :key="section.title">
+          <component
+            :is="section.to ? RouterLink : 'div'"
+            :to="section.to"
+            class="card h-100 text-center tile fade-in text-decoration-none text-body"
+            :class="{ 'placeholder-card': !section.to }"
         >
           <div class="card-body d-flex flex-column justify-content-center align-items-center">
             <i
@@ -59,25 +61,37 @@ const greeting = computed(() => {
             <h5 class="card-title">{{ section.title }}</h5>
             <p v-if="!section.to" class="text-muted small mb-0">Раздел в разработке</p>
           </div>
-        </component>
-      </div>
-      <div v-if="isAdmin" class="col-6 col-md-4 col-lg-3">
-        <RouterLink to="/admin" class="card h-100 text-center tile fade-in text-decoration-none text-body">
-          <div class="card-body d-flex flex-column justify-content-center align-items-center">
-            <i
-              class="bi bi-shield-lock fs-1 mb-3 icon-brand"
-              role="img"
-              aria-label="Администрирование"
-            ></i>
-            <h5 class="card-title">Администрирование</h5>
-          </div>
-        </RouterLink>
+          </component>
+        </div>
+        <div v-if="isAdmin" class="col-6 col-md-4 col-lg-3">
+          <RouterLink to="/admin" class="card h-100 text-center tile fade-in text-decoration-none text-body">
+            <div class="card-body d-flex flex-column justify-content-center align-items-center">
+              <i
+                class="bi bi-shield-lock fs-1 mb-3 icon-brand"
+                role="img"
+                aria-label="Администрирование"
+              ></i>
+              <h5 class="card-title">Администрирование</h5>
+            </div>
+          </RouterLink>
+        </div>
       </div>
     </div>
   </div>
+</div>
 </template>
 
 <style scoped>
+.home-page {
+  background-color: #f0f1f3;
+}
+
+.main-tile {
+  border-radius: 1rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.05);
+  background-color: #fff;
+}
+
 .placeholder-card {
   background-color: #f8f9fa;
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- add a placeholder card for upcoming events below the greeting on the home page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686637e72870832db637dcfa82c47c59