### PR TITLE
Unify medical admin sections

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -11,10 +11,8 @@ import AdminUsers from './views/AdminUsers.vue'
 import AdminHome from './views/AdminHome.vue'
 import AdminUserEdit from './views/AdminUserEdit.vue'
 import AdminUserCreate from './views/AdminUserCreate.vue'
-import AdminMedicalCertificates from './views/AdminMedicalCertificates.vue'
 import AdminCampStadiums from './views/AdminCampStadiums.vue'
-import AdminMedicalCenters from './views/AdminMedicalCenters.vue'
-import AdminMedicalExams from './views/AdminMedicalExams.vue'
+import AdminMedicalManagement from './views/AdminMedicalManagement.vue'
 import PasswordReset from './views/PasswordReset.vue'
 import NotFound from './views/NotFound.vue'
 import Forbidden from './views/Forbidden.vue'
@@ -28,9 +26,7 @@ const routes = [
   { path: '/users', component: AdminUsers, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/new', component: AdminUserCreate, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/users/:id', component: AdminUserEdit, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/medical-certificates', component: AdminMedicalCertificates, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/medical-centers', component: AdminMedicalCenters, meta: { requiresAuth: true, requiresAdmin: true } },
-  { path: '/medical-exams', component: AdminMedicalExams, meta: { requiresAuth: true, requiresAdmin: true } },
+  { path: '/medical-admin', component: AdminMedicalManagement, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/camp-stadiums', component: AdminCampStadiums, meta: { requiresAuth: true, requiresAdmin: true } },
   { path: '/password-reset', component: PasswordReset, meta: { hideLayout: true } },
   { path: '/login', component: Login, meta: { hideLayout: true } },

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -4,19 +4,9 @@ import { RouterLink } from 'vue-router'
 const tiles = [
   { title: 'Управление пользователями', icon: 'bi-people', to: '/users' },
   {
-    title: 'Медицинские справки',
+    title: 'Медицина',
     icon: 'bi-file-earmark-medical',
-    to: '/medical-certificates'
-  },
-  {
-    title: 'Медицинские центры',
-    icon: 'bi-hospital',
-    to: '/medical-centers'
-  },
-  {
-    title: 'Расписание медосмотров',
-    icon: 'bi-calendar-check',
-    to: '/medical-exams'
+    to: '/medical-admin'
   },
   {
     title: 'Управление сборами',

--- a/client/src/views/AdminMedicalCenters.vue
+++ b/client/src/views/AdminMedicalCenters.vue
@@ -168,13 +168,7 @@ async function removeCenter(center) {
 </script>
 
 <template>
-  <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
-      <ol class="breadcrumb mb-0">
-        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
-        <li class="breadcrumb-item active" aria-current="page">Медицинские центры</li>
-      </ol>
-    </nav>
+  <div>
     <div class="d-flex justify-content-between align-items-center mb-4">
       <h1 class="mb-0">Медицинские центры</h1>
       <button class="btn btn-brand" @click="openCreate">

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -217,13 +217,7 @@ async function loadJudges() {
 </script>
 
 <template>
-  <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
-      <ol class="breadcrumb mb-0">
-        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
-        <li class="breadcrumb-item active" aria-current="page">Медицинские справки</li>
-      </ol>
-    </nav>
+  <div>
     <div class="d-flex justify-content-between align-items-center mb-4">
       <h1 class="mb-0">Медицинские заключения</h1>
       <button class="btn btn-brand" @click="openCreate">

--- a/client/src/views/AdminMedicalExams.vue
+++ b/client/src/views/AdminMedicalExams.vue
@@ -121,13 +121,7 @@ async function removeExam(exam) {
 </script>
 
 <template>
-  <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
-      <ol class="breadcrumb mb-0">
-        <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
-        <li class="breadcrumb-item active" aria-current="page">Медицинские обследования</li>
-      </ol>
-    </nav>
+  <div>
     <div class="d-flex justify-content-between align-items-center mb-4">
       <h1 class="mb-0">Расписание медосмотров</h1>
       <button class="btn btn-brand" @click="openCreate">

--- a/client/src/views/AdminMedicalManagement.vue
+++ b/client/src/views/AdminMedicalManagement.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { ref } from 'vue';
+import { RouterLink } from 'vue-router';
+import AdminMedicalCertificates from './AdminMedicalCertificates.vue';
+import AdminMedicalCenters from './AdminMedicalCenters.vue';
+import AdminMedicalExams from './AdminMedicalExams.vue';
+
+const activeTab = ref('certificates');
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item">
+          <RouterLink to="/admin">Администрирование</RouterLink>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">Медицина</li>
+      </ol>
+    </nav>
+    <ul class="nav nav-tabs mb-3">
+      <li class="nav-item">
+        <button
+          class="nav-link"
+          :class="{ active: activeTab === 'certificates' }"
+          @click="activeTab = 'certificates'"
+        >
+          Медицинские справки
+        </button>
+      </li>
+      <li class="nav-item">
+        <button
+          class="nav-link"
+          :class="{ active: activeTab === 'centers' }"
+          @click="activeTab = 'centers'"
+        >
+          Медицинские центры
+        </button>
+      </li>
+      <li class="nav-item">
+        <button
+          class="nav-link"
+          :class="{ active: activeTab === 'exams' }"
+          @click="activeTab = 'exams'"
+        >
+          Расписание медосмотров
+        </button>
+      </li>
+    </ul>
+    <div v-if="activeTab === 'certificates'">
+      <AdminMedicalCertificates />
+    </div>
+    <div v-else-if="activeTab === 'centers'">
+      <AdminMedicalCenters />
+    </div>
+    <div v-else>
+      <AdminMedicalExams />
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
## Summary
- add AdminMedicalManagement page with tabs for certificates, centers and exams
- add single "Медицина" tile in admin home
- route consolidated sections under `/medical-admin`
- drop obsolete individual medical routes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866379208d0832d91fde130ce1d2bda