### PR TITLE
Implement nav-fill on admin medical tabs

### DIFF
--- a/client/src/views/AdminMedicalCenters.vue
+++ b/client/src/views/AdminMedicalCenters.vue
@@ -169,15 +169,15 @@ async function removeCenter(center) {
 
 <template>
   <div>
-    <div class="card tile fade-in mb-4">
+    <div class="card tile fade-in shadow-sm mb-4">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h1 class="mb-0">Медицинские центры</h1>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>
       </div>
-      <div class="card-body p-0">
-        <div v-if="error" class="alert alert-danger m-3">{{ error }}</div>
+      <div class="card-body p-3">
+        <div v-if="error" class="alert alert-danger mb-3">{{ error }}</div>
         <div v-if="isLoading" class="text-center my-3"><div class="spinner-border" role="status"></div></div>
         <div v-if="centers.length" class="table-responsive">
           <table class="table table-striped align-middle mb-0">

--- a/client/src/views/AdminMedicalExams.vue
+++ b/client/src/views/AdminMedicalExams.vue
@@ -122,15 +122,15 @@ async function removeExam(exam) {
 
 <template>
   <div>
-    <div class="card tile fade-in mb-4">
+    <div class="card tile fade-in shadow-sm mb-4">
       <div class="card-header d-flex justify-content-between align-items-center">
         <h1 class="mb-0">Расписание медосмотров</h1>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>
       </div>
-      <div class="card-body p-0">
-        <div v-if="error" class="alert alert-danger m-3">{{ error }}</div>
+      <div class="card-body p-3">
+        <div v-if="error" class="alert alert-danger mb-3">{{ error }}</div>
         <div v-if="isLoading" class="text-center my-3"><div class="spinner-border" role="status"></div></div>
         <div v-if="exams.length" class="table-responsive">
           <table class="table table-striped align-middle mb-0">

--- a/client/src/views/AdminMedicalManagement.vue
+++ b/client/src/views/AdminMedicalManagement.vue
@@ -20,7 +20,7 @@ const activeTab = ref('certificates');
     </nav>
     <div class="card tile mb-4">
       <div class="card-body p-2">
-        <ul class="nav nav-tabs mb-0">
+        <ul class="nav nav-tabs nav-fill justify-content-between mb-0">
           <li class="nav-item">
             <button
               class="nav-link"


### PR DESCRIPTION
## Summary
- adjust admin medical nav tabs to fill available space
- align admin medical center and exam pages with the certificates tab style

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68665394e554832daf76a674b0dfa7ba