### PR TITLE
Auto-fill training capacity and end time

### DIFF
--- a/client/src/views/AdminTrainings.vue
+++ b/client/src/views/AdminTrainings.vue
@@ -40,6 +40,27 @@ onMounted(() => {
 
 watch(currentPage, loadTrainings);
 
+watch(
+  () => form.value.type_id,
+  (newId) => {
+    if (editing.value) return;
+    const type = trainingTypes.value.find((tt) => tt.id === newId);
+    if (type && type.default_capacity !== undefined) {
+      form.value.capacity = type.default_capacity;
+    }
+  }
+);
+
+watch(
+  () => form.value.start_at,
+  (newStart) => {
+    if (editing.value || !newStart) return;
+    const end = new Date(newStart);
+    end.setMinutes(end.getMinutes() + 90);
+    form.value.end_at = toInputValue(end);
+  }
+);
+
 async function loadTrainings() {
   isLoading.value = true;
   error.value = '';


### PR DESCRIPTION
## Summary
- prefill training capacity from the selected type's default
- auto-fill end time 90 minutes after start time

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686656eb21b4832d9925565b80f148cf