### PR TITLE
Add admin management of referee groups

### DIFF
--- a/client/src/components/RefereeGroupAssignments.vue
+++ b/client/src/components/RefereeGroupAssignments.vue
@@ -1,0 +1,109 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { apiFetch } from '../api.js';
+
+const judges = ref([]);
+const groups = ref([]);
+const loading = ref(false);
+const error = ref('');
+
+async function loadJudges() {
+  loading.value = true;
+  error.value = '';
+  try {
+    const data = await apiFetch('/referee-group-users');
+    judges.value = data.judges.map((j) => ({
+      ...j,
+      group_id: j.group ? j.group.id : ''
+    }));
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function loadGroups() {
+  try {
+    const params = new URLSearchParams({ page: 1, limit: 100 });
+    const data = await apiFetch(`/referee-groups?${params}`);
+    groups.value = data.groups;
+  } catch (_) {
+    groups.value = [];
+  }
+}
+
+async function setGroup(judge) {
+  if (!judge.group_id) return;
+  try {
+    await apiFetch(`/referee-group-users/${judge.user.id}`, {
+      method: 'POST',
+      body: JSON.stringify({ group_id: judge.group_id })
+    });
+  } catch (e) {
+    alert(e.message);
+  }
+}
+
+function formatName(u) {
+  return `${u.last_name} ${u.first_name} ${u.patronymic || ''}`.trim();
+}
+
+function formatDate(d) {
+  if (!d) return '';
+  const [y, m, day] = d.split('-');
+  return `${day}.${m}.${y}`;
+}
+
+onMounted(() => {
+  loadJudges();
+  loadGroups();
+});
+
+const refresh = () => {
+  loadJudges();
+  loadGroups();
+};
+
+defineExpose({ refresh });
+</script>
+
+<template>
+  <div>
+    <div v-if="error" class="alert alert-danger">{{ error }}</div>
+    <div v-if="loading" class="text-center my-3">
+      <div class="spinner-border" role="status"></div>
+    </div>
+    <div v-if="judges.length" class="card tile fade-in">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <h2 class="h5 mb-0">Назначение судей</h2>
+      </div>
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped align-middle mb-0">
+            <thead>
+              <tr>
+                <th>ФИО</th>
+                <th>Дата рождения</th>
+                <th>Группа</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="j in judges" :key="j.user.id">
+                <td>{{ formatName(j.user) }}</td>
+                <td>{{ formatDate(j.user.birth_date) }}</td>
+                <td>
+                  <select v-model="j.group_id" class="form-select" @change="setGroup(j)">
+                    <option value="" disabled>Выберите группу</option>
+                    <option v-for="g in groups" :key="g.id" :value="g.id">{{ g.name }}</option>
+                  </select>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+    <p v-else-if="!loading" class="text-muted">Судьи не найдены.</p>
+  </div>
+</template>

--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -4,6 +4,7 @@ import { RouterLink } from 'vue-router';
 import Modal from 'bootstrap/js/dist/modal';
 import { apiFetch } from '../api.js';
 import { suggestAddress, cleanAddress } from '../dadata.js';
+import RefereeGroupAssignments from '../components/RefereeGroupAssignments.vue';
 
 const activeTab = ref('stadiums');
 
@@ -75,6 +76,7 @@ const trainingEditing = ref(null);
 const trainingModalRef = ref(null);
 let trainingModal;
 const trainingFormError = ref('');
+const assignmentsRef = ref(null);
 
 const form = ref({
   name: '',
@@ -121,6 +123,8 @@ watch(activeTab, (val) => {
   } else if (val === 'trainings' && !trainings.value.length) {
     loadTrainings();
     if (!stadiumOptions.value.length) loadStadiumOptions();
+  } else if (val === 'judges') {
+    assignmentsRef.value?.refresh();
   }
 });
 
@@ -499,6 +503,11 @@ async function removeTraining(t) {
               Тренировки
             </button>
           </li>
+          <li class="nav-item">
+            <button class="nav-link" :class="{ active: activeTab === 'judges' }" @click="activeTab = 'judges'">
+              Судьи
+            </button>
+          </li>
         </ul>
       </div>
     </div>
@@ -758,6 +767,10 @@ async function removeTraining(t) {
         </div>
       </div>
     </div>
+  </div>
+
+  <div v-if="activeTab === 'judges'" class="mb-4">
+    <RefereeGroupAssignments ref="assignmentsRef" />
   </div>
 
   <div ref="modalRef" class="modal fade" tabindex="-1">

--- a/src/controllers/refereeGroupUserAdminController.js
+++ b/src/controllers/refereeGroupUserAdminController.js
@@ -1,0 +1,44 @@
+import { validationResult } from 'express-validator';
+
+import refereeGroupService from '../services/refereeGroupService.js';
+import userMapper from '../mappers/userMapper.js';
+import groupMapper from '../mappers/refereeGroupMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const judges = await refereeGroupService.listReferees();
+    const data = judges.map((u) => ({
+      user: userMapper.toPublic(u),
+      group: u.RefereeGroupUser
+        ? groupMapper.toPublic(u.RefereeGroupUser.RefereeGroup)
+        : null,
+    }));
+    return res.json({ judges: data });
+  },
+
+  async setGroup(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      await refereeGroupService.setUserGroup(
+        req.params.id,
+        req.body.group_id,
+        req.user.id
+      );
+      const user = await refereeGroupService.getReferee(req.params.id);
+      return res.json({
+        judge: {
+          user: userMapper.toPublic(user),
+          group: user.RefereeGroupUser
+            ? groupMapper.toPublic(user.RefereeGroupUser.RefereeGroup)
+            : null,
+        },
+      });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -24,6 +24,7 @@ import campTrainingTypesRouter from './campTrainingTypes.js';
 import campTrainingsRouter from './campTrainings.js';
 import campSeasonsRouter from './campSeasons.js';
 import refereeGroupsRouter from './refereeGroups.js';
+import refereeGroupUsersRouter from './refereeGroupUsers.js';
 import medicalCentersRouter from './medicalCenters.js';
 import medicalExamsRouter from './medicalExams.js';
 
@@ -49,6 +50,7 @@ router.use('/camp-training-types', campTrainingTypesRouter);
 router.use('/camp-trainings', campTrainingsRouter);
 router.use('/camp-seasons', campSeasonsRouter);
 router.use('/referee-groups', refereeGroupsRouter);
+router.use('/referee-group-users', refereeGroupUsersRouter);
 router.use('/medical-centers', medicalCentersRouter);
 router.use('/medical-exams', medicalExamsRouter);
 

--- a/src/routes/refereeGroupUsers.js
+++ b/src/routes/refereeGroupUsers.js
@@ -37,6 +37,12 @@ router.get('/', auth, authorize('ADMIN'), controller.list);
  *       200:
  *         description: Updated referee
  */
-router.post('/:id', auth, authorize('ADMIN'), setGroupRules, controller.setGroup);
+router.post(
+  '/:id',
+  auth,
+  authorize('ADMIN'),
+  setGroupRules,
+  controller.setGroup
+);
 
 export default router;

--- a/src/routes/refereeGroupUsers.js
+++ b/src/routes/refereeGroupUsers.js
@@ -1,0 +1,42 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/refereeGroupUserAdminController.js';
+import { setGroupRules } from '../validators/refereeGroupUserValidators.js';
+
+const router = express.Router();
+
+/**
+ * @swagger
+ * /referee-group-users:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: List all referees with their group
+ *     responses:
+ *       200:
+ *         description: Array of referees
+ */
+router.get('/', auth, authorize('ADMIN'), controller.list);
+
+/**
+ * @swagger
+ * /referee-group-users/{id}:
+ *   post:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Set referee group for user
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated referee
+ */
+router.post('/:id', auth, authorize('ADMIN'), setGroupRules, controller.setGroup);
+
+export default router;

--- a/src/validators/refereeGroupUserValidators.js
+++ b/src/validators/refereeGroupUserValidators.js
@@ -1,0 +1,3 @@
+import { body } from 'express-validator';
+
+export const setGroupRules = [body('group_id').isUUID()];


### PR DESCRIPTION
## Summary
- enable admin to list and assign referees to camp groups
- expose new `/referee-group-users` routes
- add validator and controller logic
- extend referee group service with helper functions

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686657226a60832d9d88998435e1b7df