### PR TITLE
Add link between trainings and referee groups

### DIFF
--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -9,6 +9,7 @@ function sanitize(obj) {
     TrainingType,
     CampStadium,
     Season,
+    RefereeGroups,
   } = obj;
   const res = {
     id,
@@ -38,6 +39,9 @@ function sanitize(obj) {
       name: Season.name,
       alias: Season.alias,
     };
+  }
+  if (RefereeGroups) {
+    res.groups = RefereeGroups.map((g) => ({ id: g.id, name: g.name }));
   }
   return res;
 }

--- a/src/migrations/20250705050000-create-training-referee-groups.js
+++ b/src/migrations/20250705050000-create-training-referee-groups.js
@@ -1,0 +1,57 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_referee_groups', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      training_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'trainings', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      group_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'referee_groups', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+    await queryInterface.addConstraint('training_referee_groups', {
+      fields: ['training_id', 'group_id'],
+      type: 'unique',
+      name: 'uq_training_referee_group_training_group',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('training_referee_groups');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -29,6 +29,7 @@ import Training from './training.js';
 import Season from './season.js';
 import RefereeGroup from './refereeGroup.js';
 import RefereeGroupUser from './refereeGroupUser.js';
+import TrainingRefereeGroup from './trainingRefereeGroup.js';
 import MedicalCenter from './medicalCenter.js';
 import MedicalExamStatus from './medicalExamStatus.js';
 import MedicalExam from './medicalExam.js';
@@ -110,6 +111,18 @@ CampStadium.hasMany(Training, { foreignKey: 'camp_stadium_id' });
 Training.belongsTo(CampStadium, { foreignKey: 'camp_stadium_id' });
 Season.hasMany(Training, { foreignKey: 'season_id' });
 Training.belongsTo(Season, { foreignKey: 'season_id' });
+Training.belongsToMany(RefereeGroup, {
+  through: TrainingRefereeGroup,
+  foreignKey: 'training_id',
+});
+RefereeGroup.belongsToMany(Training, {
+  through: TrainingRefereeGroup,
+  foreignKey: 'group_id',
+});
+Training.hasMany(TrainingRefereeGroup, { foreignKey: 'training_id' });
+TrainingRefereeGroup.belongsTo(Training, { foreignKey: 'training_id' });
+RefereeGroup.hasMany(TrainingRefereeGroup, { foreignKey: 'group_id' });
+TrainingRefereeGroup.belongsTo(RefereeGroup, { foreignKey: 'group_id' });
 Season.hasMany(RefereeGroup, { foreignKey: 'season_id' });
 RefereeGroup.belongsTo(Season, { foreignKey: 'season_id' });
 User.belongsToMany(RefereeGroup, {
@@ -179,6 +192,7 @@ export {
   Season,
   RefereeGroup,
   RefereeGroupUser,
+  TrainingRefereeGroup,
   File,
   MedicalCertificateType,
   MedicalCertificateFile,

--- a/src/models/trainingRefereeGroup.js
+++ b/src/models/trainingRefereeGroup.js
@@ -1,0 +1,25 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TrainingRefereeGroup extends Model {}
+
+TrainingRefereeGroup.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'TrainingRefereeGroup',
+    tableName: 'training_referee_groups',
+    paranoid: true,
+    underscored: true,
+    indexes: [{ unique: true, fields: ['training_id', 'group_id'] }],
+  }
+);
+
+export default TrainingRefereeGroup;

--- a/src/validators/trainingValidators.js
+++ b/src/validators/trainingValidators.js
@@ -9,6 +9,8 @@ export const trainingCreateRules = [
     .isISO8601()
     .custom((val, { req }) => new Date(val) > new Date(req.body.start_at)),
   body('capacity').optional().isInt({ min: 0 }),
+  body('groups').optional().isArray(),
+  body('groups.*').isUUID(),
 ];
 
 export const trainingUpdateRules = [
@@ -26,4 +28,6 @@ export const trainingUpdateRules = [
       return true;
     }),
   body('capacity').optional().isInt({ min: 0 }),
+  body('groups').optional().isArray(),
+  body('groups.*').isUUID(),
 ];

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -2,6 +2,9 @@ import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findByPkMock = jest.fn();
 const updateMock = jest.fn();
+const destroyMock = jest.fn();
+const bulkCreateMock = jest.fn();
+const findAllGroupsMock = jest.fn();
 
 const trainingInstance = {
   start_at: new Date('2024-01-01T10:00:00Z'),
@@ -12,6 +15,9 @@ const trainingInstance = {
 beforeEach(() => {
   findByPkMock.mockReset();
   updateMock.mockReset();
+  destroyMock.mockReset();
+  bulkCreateMock.mockReset();
+  findAllGroupsMock.mockReset();
 });
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -20,6 +26,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   TrainingType: {},
   CampStadium: {},
   Season: {},
+  TrainingRefereeGroup: { destroy: destroyMock, bulkCreate: bulkCreateMock },
+  RefereeGroup: { findAll: findAllGroupsMock },
 }));
 
 const { default: service } = await import('../src/services/trainingService.js');


### PR DESCRIPTION
## Summary
- create `training_referee_groups` table
- add `TrainingRefereeGroup` model and wire up associations
- allow specifying referee groups when creating or updating a training
- expose training groups in API mapper
- validate groups in training validators
- update training service tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68666a7162fc832da7a29eb9d927f699