### PR TITLE
Add judge training sign-up

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -1,0 +1,52 @@
+<script setup>
+import { RouterLink } from 'vue-router';
+
+const props = defineProps({
+  training: { type: Object, required: true }
+});
+const emit = defineEmits(['register', 'unregister']);
+
+function formatDateTimeRange(start, end) {
+  const s = new Date(start);
+  const e = new Date(end);
+  return (
+    s.toLocaleDateString() +
+    ' ' +
+    s.toLocaleTimeString().slice(0, 5) +
+    ' - ' +
+    e.toLocaleDateString() +
+    ' ' +
+    e.toLocaleTimeString().slice(0, 5)
+  );
+}
+</script>
+
+<template>
+  <div class="card h-100 training-card">
+    <div class="card-body d-flex flex-column">
+      <h5 class="card-title mb-1">{{ training.stadium?.name }}</h5>
+      <p class="text-muted mb-1">{{ training.type?.name }}</p>
+      <p class="mb-1"><i class="bi bi-clock me-1"></i>{{ formatDateTimeRange(training.start_at, training.end_at) }}</p>
+      <p class="mb-3">Вместимость: {{ training.capacity || '—' }}</p>
+      <button
+        v-if="training.registered"
+        class="btn btn-sm btn-secondary mt-auto"
+        @click="emit('unregister', training.id)"
+      >Отменить</button>
+      <button
+        v-else
+        class="btn btn-sm btn-brand mt-auto"
+        :disabled="!training.registration_open"
+        @click="emit('register', training.id)"
+      >Записаться</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.training-card {
+  width: 18rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+</style>

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -7,6 +7,7 @@ import { auth, fetchCurrentUser, clearAuth } from './auth.js';
 import Home from './views/Home.vue';
 import Profile from './views/Profile.vue';
 import Medical from './views/Medical.vue';
+import Camps from './views/Camps.vue';
 import AdminUsers from './views/AdminUsers.vue';
 import AdminHome from './views/AdminHome.vue';
 import AdminUserEdit from './views/AdminUserEdit.vue';
@@ -23,6 +24,7 @@ const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true, fluid: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
   { path: '/medical', component: Medical, meta: { requiresAuth: true } },
+  { path: '/camps', component: Camps, meta: { requiresAuth: true } },
   {
     path: '/admin',
     component: AdminHome,

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -1,0 +1,151 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { RouterLink } from 'vue-router';
+import { apiFetch } from '../api.js';
+
+const trainings = ref([]);
+const total = ref(0);
+const page = ref(1);
+const pageSize = 10;
+const loading = ref(true);
+const error = ref('');
+
+function formatDateTimeRange(start, end) {
+  const s = new Date(start);
+  const e = new Date(end);
+  return (
+    s.toLocaleDateString() +
+    ' ' +
+    s.toLocaleTimeString().slice(0, 5) +
+    ' - ' +
+    e.toLocaleDateString() +
+    ' ' +
+    e.toLocaleTimeString().slice(0, 5)
+  );
+}
+
+async function load() {
+  loading.value = true;
+  try {
+    const data = await apiFetch(
+      `/camp-trainings/available?page=${page.value}&limit=${pageSize}`
+    );
+    trainings.value = data.trainings || [];
+    total.value = data.total || 0;
+    error.value = '';
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function register(id) {
+  try {
+    await apiFetch(`/camp-trainings/${id}/register`, { method: 'POST' });
+    await load();
+  } catch (e) {
+    error.value = e.message;
+  }
+}
+
+async function unregister(id) {
+  try {
+    await apiFetch(`/camp-trainings/${id}/register`, { method: 'DELETE' });
+    await load();
+  } catch (e) {
+    error.value = e.message;
+  }
+}
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="container my-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item"><RouterLink to="/">Главная</RouterLink></li>
+        <li class="breadcrumb-item active" aria-current="page">Сборы</li>
+      </ol>
+    </nav>
+    <h1 class="mb-4">Запись на сборы</h1>
+    <div v-if="loading" class="text-center my-5">
+      <div class="spinner-border" role="status" aria-label="Загрузка">
+        <span class="visually-hidden">Загрузка…</span>
+      </div>
+    </div>
+    <div v-else>
+      <div v-if="error" class="alert alert-danger">{{ error }}</div>
+      <div v-if="trainings.length" class="table-responsive">
+        <table class="table table-striped align-middle mb-0">
+          <thead>
+            <tr>
+              <th>Тип</th>
+              <th>Стадион</th>
+              <th>Дата и время</th>
+              <th class="text-center">Вместимость</th>
+              <th class="text-center">Действие</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="t in trainings" :key="t.id">
+              <td>{{ t.type?.name }}</td>
+              <td>{{ t.stadium?.name }}</td>
+              <td>{{ formatDateTimeRange(t.start_at, t.end_at) }}</td>
+              <td class="text-center">{{ t.capacity || '—' }}</td>
+              <td class="text-center">
+                <button
+                  v-if="t.registered"
+                  class="btn btn-sm btn-secondary"
+                  @click="unregister(t.id)"
+                >
+                  Отменить
+                </button>
+                <button
+                  v-else
+                  class="btn btn-sm btn-brand"
+                  :disabled="!t.registration_open"
+                  @click="register(t.id)"
+                >
+                  Записаться
+                </button>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p v-else class="text-muted">Нет доступных тренировок</p>
+      <nav class="mt-3" v-if="Math.ceil(total / pageSize) > 1">
+        <ul class="pagination justify-content-center">
+          <li class="page-item" :class="{ disabled: page === 1 }">
+            <button class="page-link" @click="page--; load()" :disabled="page === 1">Пред</button>
+          </li>
+          <li
+            class="page-item"
+            v-for="p in Math.max(1, Math.ceil(total / pageSize))"
+            :key="p"
+            :class="{ active: page === p }"
+          >
+            <button class="page-link" @click="page = p; load()">{{ p }}</button>
+          </li>
+          <li
+            class="page-item"
+            :class="{ disabled: page === Math.max(1, Math.ceil(total / pageSize)) }"
+          >
+            <button
+              class="page-link"
+              @click="page++; load()"
+              :disabled="page === Math.max(1, Math.ceil(total / pageSize))"
+            >
+              След
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+</style>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -8,7 +8,7 @@ const sections = [
   { title: 'Прошедшие матчи', icon: 'bi-clock-history' },
   { title: 'Рапорты', icon: 'bi-file-earmark-text' },
   { title: 'Доходы', icon: 'bi-currency-dollar' },
-  { title: 'Сборы', icon: 'bi-people-fill' },
+  { title: 'Сборы', icon: 'bi-people-fill', to: '/camps' },
   { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical' },
   { title: 'Результаты тестов', icon: 'bi-graph-up' },
   { title: 'Документы', icon: 'bi-folder2-open' },

--- a/src/controllers/trainingSelfController.js
+++ b/src/controllers/trainingSelfController.js
@@ -1,0 +1,40 @@
+import trainingRegistrationService from '../services/trainingRegistrationService.js';
+import mapper from '../mappers/trainingMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async available(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    try {
+      const { rows, count } = await trainingRegistrationService.listAvailable(
+        req.user.id,
+        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
+      );
+      return res.json({ trainings: rows.map(mapper.toPublic), total: count });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async register(req, res) {
+    try {
+      await trainingRegistrationService.register(
+        req.user.id,
+        req.params.id,
+        req.user.id
+      );
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async unregister(req, res) {
+    try {
+      await trainingRegistrationService.unregister(req.user.id, req.params.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -19,6 +19,7 @@ function sanitize(obj) {
     camp_stadium_id,
     season_id,
     registration_open: obj.registration_open,
+    registered: obj.user_registered,
   };
   if (TrainingType) {
     res.type = {

--- a/src/migrations/20250705060000-create-training-registrations.js
+++ b/src/migrations/20250705060000-create-training-registrations.js
@@ -1,0 +1,58 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_registrations', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      training_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'trainings', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+    await queryInterface.addConstraint('training_registrations', {
+      fields: ['training_id', 'user_id'],
+      type: 'unique',
+      name: 'uq_training_registrations_training_user',
+      where: { deleted_at: null },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('training_registrations');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -33,6 +33,7 @@ import TrainingRefereeGroup from './trainingRefereeGroup.js';
 import MedicalCenter from './medicalCenter.js';
 import MedicalExamStatus from './medicalExamStatus.js';
 import MedicalExam from './medicalExam.js';
+import TrainingRegistration from './trainingRegistration.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -125,6 +126,10 @@ RefereeGroup.hasMany(TrainingRefereeGroup, { foreignKey: 'group_id' });
 TrainingRefereeGroup.belongsTo(RefereeGroup, { foreignKey: 'group_id' });
 Season.hasMany(RefereeGroup, { foreignKey: 'season_id' });
 RefereeGroup.belongsTo(Season, { foreignKey: 'season_id' });
+Training.hasMany(TrainingRegistration, { foreignKey: 'training_id' });
+TrainingRegistration.belongsTo(Training, { foreignKey: 'training_id' });
+User.hasMany(TrainingRegistration, { foreignKey: 'user_id' });
+TrainingRegistration.belongsTo(User, { foreignKey: 'user_id' });
 User.belongsToMany(RefereeGroup, {
   through: RefereeGroupUser,
   foreignKey: 'user_id',
@@ -199,4 +204,5 @@ export {
   MedicalCenter,
   MedicalExamStatus,
   MedicalExam,
+  TrainingRegistration,
 };

--- a/src/models/trainingRegistration.js
+++ b/src/models/trainingRegistration.js
@@ -1,0 +1,25 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TrainingRegistration extends Model {}
+
+TrainingRegistration.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+  },
+  {
+    sequelize,
+    modelName: 'TrainingRegistration',
+    tableName: 'training_registrations',
+    paranoid: true,
+    underscored: true,
+    indexes: [{ unique: true, fields: ['training_id', 'user_id'] }],
+  }
+);
+
+export default TrainingRegistration;

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -3,6 +3,7 @@ import express from 'express';
 import auth from '../middlewares/auth.js';
 import authorize from '../middlewares/authorize.js';
 import controller from '../controllers/trainingAdminController.js';
+import selfController from '../controllers/trainingSelfController.js';
 import {
   trainingCreateRules,
   trainingUpdateRules,
@@ -18,6 +19,7 @@ router.post(
   trainingCreateRules,
   controller.create
 );
+router.get('/available', auth, selfController.available);
 router.get('/:id', auth, authorize('ADMIN'), controller.get);
 router.put(
   '/:id',
@@ -27,5 +29,8 @@ router.put(
   controller.update
 );
 router.delete('/:id', auth, authorize('ADMIN'), controller.remove);
+
+router.post('/:id/register', auth, selfController.register);
+router.delete('/:id/register', auth, selfController.unregister);
 
 export default router;

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -1,0 +1,94 @@
+import {
+  Training,
+  TrainingType,
+  CampStadium,
+  Season,
+  RefereeGroup,
+  RefereeGroupUser,
+  TrainingRegistration,
+} from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+import trainingService from './trainingService.js';
+
+async function listAvailable(userId, options = {}) {
+  const link = await RefereeGroupUser.findOne({ where: { user_id: userId } });
+  if (!link) return { rows: [], count: 0 };
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  const { rows, count } = await Training.findAndCountAll({
+    include: [
+      TrainingType,
+      CampStadium,
+      Season,
+      {
+        model: RefereeGroup,
+        through: { attributes: [] },
+        where: { id: link.group_id },
+      },
+      { model: TrainingRegistration },
+    ],
+    order: [['start_at', 'DESC']],
+    distinct: true,
+    limit,
+    offset,
+  });
+  return {
+    rows: rows.map((t) => {
+      const registeredCount = t.TrainingRegistrations.length;
+      const userRegistered = t.TrainingRegistrations.some((r) => r.user_id === userId);
+      const plain = t.get();
+      return {
+        ...plain,
+        registration_open: trainingService.isRegistrationOpen(t, registeredCount),
+        user_registered: userRegistered,
+      };
+    }),
+    count,
+  };
+}
+
+async function register(userId, trainingId, actorId) {
+  const [training, link] = await Promise.all([
+    Training.findByPk(trainingId, {
+      include: [
+        { model: RefereeGroup, through: { attributes: [] } },
+        { model: TrainingRegistration },
+      ],
+    }),
+    RefereeGroupUser.findOne({ where: { user_id: userId } }),
+  ]);
+  if (!training) throw new ServiceError('training_not_found', 404);
+  if (!link) throw new ServiceError('referee_group_not_found');
+  if (!training.RefereeGroups.some((g) => g.id === link.group_id)) {
+    throw new ServiceError('access_denied');
+  }
+  const registeredCount = training.TrainingRegistrations.length;
+  if (!trainingService.isRegistrationOpen(training, registeredCount)) {
+    throw new ServiceError('registration_closed');
+  }
+  if (training.TrainingRegistrations.some((r) => r.user_id === userId)) {
+    throw new ServiceError('already_registered');
+  }
+  await TrainingRegistration.create({
+    training_id: trainingId,
+    user_id: userId,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+}
+
+async function unregister(userId, trainingId) {
+  const registration = await TrainingRegistration.findOne({
+    where: { training_id: trainingId, user_id: userId },
+  });
+  if (!registration) throw new ServiceError('registration_not_found', 404);
+  const training = await Training.findByPk(trainingId);
+  const count = await TrainingRegistration.count({ where: { training_id: trainingId } });
+  if (!training || !trainingService.isRegistrationOpen(training, count)) {
+    throw new ServiceError('registration_closed');
+  }
+  await registration.destroy();
+}
+
+export default { listAvailable, register, unregister };

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -53,7 +53,8 @@ async function getById(id) {
     ],
   });
   if (!training) throw new ServiceError('training_not_found', 404);
-  const plain = training.get();
+  const plain =
+    typeof training.get === 'function' ? training.get() : training;
   return { ...plain, registration_open: isRegistrationOpen(training) };
 }
 


### PR DESCRIPTION
## Summary
- create model and migration for training registrations
- allow referees to view available trainings and register
- expose new signup endpoints
- show signup link in UI and add Camps page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866783768f4832da6ce51a5b2c9f0e8