### PR TITLE
Redesign training signup section

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -2,32 +2,51 @@
 import { RouterLink } from 'vue-router';
 
 const props = defineProps({
-  training: { type: Object, required: true }
+  training: { type: Object, required: true },
 });
 const emit = defineEmits(['register', 'unregister']);
 
-function formatDateTimeRange(start, end) {
-  const s = new Date(start);
-  const e = new Date(end);
-  return (
-    s.toLocaleDateString() +
-    ' ' +
-    s.toLocaleTimeString().slice(0, 5) +
-    ' - ' +
-    e.toLocaleDateString() +
-    ' ' +
-    e.toLocaleTimeString().slice(0, 5)
-  );
+function formatStart(date) {
+  const d = new Date(date);
+  return d
+    .toLocaleDateString('ru-RU', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    .replace(',', ' в');
+}
+
+function durationText(start, end) {
+  const diff = (new Date(end) - new Date(start)) / 60000;
+  const h = Math.floor(diff / 60);
+  const m = Math.round(diff % 60);
+  let out = 'Приблизительно ';
+  if (h > 0) out += `${h} час${h > 1 ? 'а' : ''}`;
+  if (h > 0 && m > 0) out += ' ';
+  if (m > 0) out += `${m} минут`;
+  return out;
+}
+
+function seatStatus(t) {
+  if (typeof t.available === 'number') {
+    if (t.available === 0) return 'закончились';
+    if (t.available <= 5) return 'мало';
+    return 'много';
+  }
+  return 'много';
 }
 </script>
 
 <template>
   <div class="card h-100 training-card">
     <div class="card-body d-flex flex-column">
-      <h5 class="card-title mb-1">{{ training.stadium?.name }}</h5>
-      <p class="text-muted mb-1">{{ training.type?.name }}</p>
-      <p class="mb-1"><i class="bi bi-clock me-1"></i>{{ formatDateTimeRange(training.start_at, training.end_at) }}</p>
-      <p class="mb-3">Вместимость: {{ training.capacity || '—' }}</p>
+      <h5 class="card-title mb-2">{{ formatStart(training.start_at) }}</h5>
+      <p class="text-muted mb-2">{{ durationText(training.start_at, training.end_at) }}</p>
+      <span class="badge bg-brand align-self-start mb-2">{{ training.type?.name }}</span>
+      <p class="small mb-3">Мест: {{ seatStatus(training) }}</p>
       <button
         v-if="training.registered"
         class="btn btn-sm btn-secondary mt-auto"
@@ -45,8 +64,6 @@ function formatDateTimeRange(start, end) {
 
 <style scoped>
 .training-card {
-  width: 18rem;
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
 }
 </style>

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -18,6 +18,7 @@ function sanitize(obj) {
     capacity,
     camp_stadium_id,
     season_id,
+    available,
     registration_open: obj.registration_open,
     registered: obj.user_registered,
   };

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -41,8 +41,13 @@ async function listAvailable(userId, options = {}) {
         (r) => r.user_id === userId
       );
       const plain = t.get();
+      const available =
+        typeof plain.capacity === 'number'
+          ? Math.max(0, plain.capacity - registeredCount)
+          : null;
       return {
         ...plain,
+        available,
         registration_open: trainingService.isRegistrationOpen(
           t,
           registeredCount


### PR DESCRIPTION
## Summary
- add available spots to training registration service
- expose spots via training mapper
- update TrainingCard with new layout
- overhaul Camps view with My Camps and registration tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686683eb3de4832da11753807ab14a59