### PR TITLE
Replace buttons with icons

### DIFF
--- a/client/src/components/BankAccountForm.vue
+++ b/client/src/components/BankAccountForm.vue
@@ -236,7 +236,9 @@ async function removeAccount() {
             </div>
           </div>
           <div class="modal-footer">
-            <button v-if="account" type="button" class="btn btn-danger me-auto" @click="removeAccount">Удалить</button>
+            <button v-if="account" type="button" class="btn btn-danger me-auto" @click="removeAccount">
+              <i class="bi bi-trash"></i>
+            </button>
             <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
             <button type="submit" class="btn btn-brand">Сохранить</button>
           </div>

--- a/client/src/components/InnSnilsForm.vue
+++ b/client/src/components/InnSnilsForm.vue
@@ -211,7 +211,7 @@ async function removeItem() {
               class="btn btn-danger me-auto"
               @click="removeItem"
             >
-              Удалить
+              <i class="bi bi-trash"></i>
             </button>
             <button type="button" class="btn btn-secondary" @click="modal.hide()">Отмена</button>
             <button type="submit" class="btn btn-brand">Сохранить</button>

--- a/client/src/components/UserAddressForm.vue
+++ b/client/src/components/UserAddressForm.vue
@@ -276,7 +276,7 @@ function applySuggestion(sug) {
                 class="btn btn-danger me-auto"
                 @click="removeAddress"
               >
-                Удалить
+                <i class="bi bi-trash"></i>
               </button>
               <button
                 type="button"

--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -578,8 +578,12 @@ async function removeTraining(t) {
               <span v-else class="text-muted">Нет</span>
             </td>
             <td class="text-end">
-              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(st)">Изменить</button>
-              <button class="btn btn-sm btn-danger" @click="removeStadium(st)">Удалить</button>
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(st)">
+                <i class="bi bi-pencil"></i>
+              </button>
+              <button class="btn btn-sm btn-danger" @click="removeStadium(st)">
+                <i class="bi bi-trash"></i>
+              </button>
             </td>
           </tr>
           </tbody>
@@ -631,7 +635,9 @@ async function removeTraining(t) {
           <td>{{ t.name }}</td>
           <td class="text-center">{{ t.default_capacity }}</td>
           <td class="text-end">
-            <button class="btn btn-sm btn-secondary" @click="openEditType(t)">Изменить</button>
+            <button class="btn btn-sm btn-secondary" @click="openEditType(t)">
+              <i class="bi bi-pencil"></i>
+            </button>
           </td>
         </tr>
         </tbody>
@@ -733,8 +739,12 @@ async function removeTraining(t) {
             ></i>
           </td>
           <td class="text-end">
-            <button class="btn btn-sm btn-secondary me-2" @click="openEditTraining(t)">Изменить</button>
-            <button class="btn btn-sm btn-danger" @click="removeTraining(t)">Удалить</button>
+            <button class="btn btn-sm btn-secondary me-2" @click="openEditTraining(t)">
+              <i class="bi bi-pencil"></i>
+            </button>
+            <button class="btn btn-sm btn-danger" @click="removeTraining(t)">
+              <i class="bi bi-trash"></i>
+            </button>
           </td>
         </tr>
         </tbody>

--- a/client/src/views/AdminMedicalCenters.vue
+++ b/client/src/views/AdminMedicalCenters.vue
@@ -200,8 +200,12 @@ async function removeCenter(center) {
             <td>{{ c.email }}</td>
             <td>{{ c.website }}</td>
             <td class="text-end">
-              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(c)">Изменить</button>
-              <button class="btn btn-sm btn-danger" @click="removeCenter(c)">Удалить</button>
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(c)">
+                <i class="bi bi-pencil"></i>
+              </button>
+              <button class="btn btn-sm btn-danger" @click="removeCenter(c)">
+                <i class="bi bi-trash"></i>
+              </button>
             </td>
           </tr>
         </tbody>

--- a/client/src/views/AdminMedicalCertificates.vue
+++ b/client/src/views/AdminMedicalCertificates.vue
@@ -417,7 +417,7 @@ async function loadJudges() {
                 :disabled="deleting"
               >
                 <span v-if="deleting" class="spinner-border spinner-border-sm me-2"></span>
-                Удалить
+                <i class="bi bi-trash"></i>
               </button>
               <button type="button" class="btn btn-secondary" @click="modal.hide()">
                 Отмена

--- a/client/src/views/AdminMedicalExams.vue
+++ b/client/src/views/AdminMedicalExams.vue
@@ -149,8 +149,12 @@ async function removeExam(exam) {
             <td>{{ ex.capacity }}</td>
             <td>{{ ex.status?.name }}</td>
             <td class="text-end">
-              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(ex)">Изменить</button>
-              <button class="btn btn-sm btn-danger" @click="removeExam(ex)">Удалить</button>
+              <button class="btn btn-sm btn-secondary me-2" @click="openEdit(ex)">
+                <i class="bi bi-pencil"></i>
+              </button>
+              <button class="btn btn-sm btn-danger" @click="removeExam(ex)">
+                <i class="bi bi-trash"></i>
+              </button>
             </td>
           </tr>
         </tbody>

--- a/client/src/views/AdminRefereeGroups.vue
+++ b/client/src/views/AdminRefereeGroups.vue
@@ -145,10 +145,10 @@ async function removeGroup(group) {
                     class="btn btn-sm btn-secondary me-2"
                     @click="openEdit(g)"
                   >
-                    Изменить
+                    <i class="bi bi-pencil"></i>
                   </button>
                   <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
-                    Удалить
+                    <i class="bi bi-trash"></i>
                   </button>
                 </td>
               </tr>

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -278,7 +278,7 @@ async function copy(text) {
             <td><span class="badge" :class="statusClass(u.status)">{{ u.status_name }}</span></td>
             <td class="text-end">
               <button class="btn btn-sm btn-secondary me-2" @click="openEdit(u)">
-                Редактировать
+                <i class="bi bi-pencil"></i>
               </button>
               <button
                 v-if="u.status === 'ACTIVE'"


### PR DESCRIPTION
## Summary
- use bootstrap icons for Edit and Delete actions across UI

## Testing
- `NODE_OPTIONS=--experimental-vm-modules npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6866849dcd3c832db73578471280d187