### PR TITLE
Add upcoming events

### DIFF
--- a/src/controllers/trainingSelfController.js
+++ b/src/controllers/trainingSelfController.js
@@ -16,6 +16,19 @@ export default {
     }
   },
 
+  async upcoming(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    try {
+      const { rows, count } = await trainingRegistrationService.listUpcomingByUser(
+        req.user.id,
+        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
+      );
+      return res.json({ trainings: rows.map(mapper.toPublic), total: count });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
   async register(req, res) {
     try {
       await trainingRegistrationService.register(

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -1,3 +1,5 @@
+import campStadiumMapper from './campStadiumMapper.js';
+
 function sanitize(obj) {
   const {
     id,
@@ -30,10 +32,7 @@ function sanitize(obj) {
     };
   }
   if (CampStadium) {
-    res.stadium = {
-      id: CampStadium.id,
-      name: CampStadium.name,
-    };
+    res.stadium = campStadiumMapper.toPublic(CampStadium);
   }
   if (Season) {
     res.season = {

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -21,6 +21,7 @@ router.post(
   controller.create
 );
 router.get('/available', auth, selfController.available);
+router.get('/me/upcoming', auth, selfController.upcoming);
 router.get('/:id', auth, authorize('ADMIN'), controller.get);
 router.put(
   '/:id',

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -7,6 +7,7 @@ import {
   RefereeGroupUser,
   TrainingRegistration,
   User,
+  Address,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 
@@ -21,7 +22,7 @@ async function listAvailable(userId, options = {}) {
   const { rows, count } = await Training.findAndCountAll({
     include: [
       TrainingType,
-      CampStadium,
+      { model: CampStadium, include: [Address] },
       Season,
       {
         model: RefereeGroup,
@@ -105,6 +106,44 @@ async function unregister(userId, trainingId) {
   await registration.destroy();
 }
 
+async function listUpcomingByUser(userId, options = {}) {
+  const { Op } = await import('sequelize');
+  const page = Math.max(1, parseInt(options.page || 1, 10));
+  const limit = Math.max(1, parseInt(options.limit || 20, 10));
+  const offset = (page - 1) * limit;
+  const now = new Date();
+  const { rows, count } = await Training.findAndCountAll({
+    include: [
+      TrainingType,
+      { model: CampStadium, include: [Address] },
+      Season,
+      { model: TrainingRegistration, where: { user_id: userId } },
+    ],
+    where: { start_at: { [Op.gte]: now } },
+    order: [['start_at', 'ASC']],
+    limit,
+    offset,
+    distinct: true,
+  });
+  return {
+    rows: rows.map((t) => {
+      const registeredCount = t.TrainingRegistrations.length;
+      const plain = t.get();
+      const available =
+        typeof plain.capacity === 'number'
+          ? Math.max(0, plain.capacity - registeredCount)
+          : null;
+      return {
+        ...plain,
+        available,
+        registration_open: trainingService.isRegistrationOpen(t, registeredCount),
+        user_registered: true,
+      };
+    }),
+    count,
+  };
+}
+
 async function listByTraining(trainingId, options = {}) {
   const page = Math.max(1, parseInt(options.page || 1, 10));
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
@@ -133,6 +172,7 @@ export default {
   listAvailable,
   register,
   unregister,
+  listUpcomingByUser,
   listByTraining,
   remove,
 };

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -5,6 +5,7 @@ import {
   Season,
   RefereeGroup,
   TrainingRefereeGroup,
+  Address,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 
@@ -26,7 +27,7 @@ async function listAll(options = {}) {
   const { rows, count } = await Training.findAndCountAll({
     include: [
       TrainingType,
-      CampStadium,
+      { model: CampStadium, include: [Address] },
       Season,
       { model: RefereeGroup, through: { attributes: [] } },
     ],
@@ -47,7 +48,7 @@ async function getById(id) {
   const training = await Training.findByPk(id, {
     include: [
       TrainingType,
-      CampStadium,
+      { model: CampStadium, include: [Address] },
       Season,
       { model: RefereeGroup, through: { attributes: [] } },
     ],


### PR DESCRIPTION
## Summary
- implement upcoming events fetch API for registered trainings
- expose route `/camp-trainings/me/upcoming`
- extend training mapper to include stadium info
- show upcoming trainings on home page with address and Yandex link

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68668a139768832da81a625dc46f1c8d