### PR TITLE
Add training roles

### DIFF
--- a/src/migrations/20250705061000-create-training-roles.js
+++ b/src/migrations/20250705061000-create-training-roles.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_roles', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('training_roles');
+  },
+};

--- a/src/migrations/20250705062000-add-training-role-to-training-registrations.js
+++ b/src/migrations/20250705062000-add-training-role-to-training-registrations.js
@@ -1,0 +1,17 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('training_registrations', 'training_role_id', {
+      type: Sequelize.UUID,
+      allowNull: false,
+      references: { model: 'training_roles', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'RESTRICT',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('training_registrations', 'training_role_id');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -34,6 +34,7 @@ import MedicalCenter from './medicalCenter.js';
 import MedicalExamStatus from './medicalExamStatus.js';
 import MedicalExam from './medicalExam.js';
 import TrainingRegistration from './trainingRegistration.js';
+import TrainingRole from './trainingRole.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -130,6 +131,8 @@ Training.hasMany(TrainingRegistration, { foreignKey: 'training_id' });
 TrainingRegistration.belongsTo(Training, { foreignKey: 'training_id' });
 User.hasMany(TrainingRegistration, { foreignKey: 'user_id' });
 TrainingRegistration.belongsTo(User, { foreignKey: 'user_id' });
+TrainingRole.hasMany(TrainingRegistration, { foreignKey: 'training_role_id' });
+TrainingRegistration.belongsTo(TrainingRole, { foreignKey: 'training_role_id' });
 User.belongsToMany(RefereeGroup, {
   through: RefereeGroupUser,
   foreignKey: 'user_id',
@@ -204,5 +207,6 @@ export {
   MedicalCenter,
   MedicalExamStatus,
   MedicalExam,
+  TrainingRole,
   TrainingRegistration,
 };

--- a/src/models/trainingRole.js
+++ b/src/models/trainingRole.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TrainingRole extends Model {}
+
+TrainingRole.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'TrainingRole',
+    tableName: 'training_roles',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default TrainingRole;

--- a/src/seeders/20250802001000-create-training-roles.js
+++ b/src/seeders/20250802001000-create-training-roles.js
@@ -1,0 +1,46 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM training_roles WHERE alias IN (\'PARTICIPANT\',\'COACH\',\'EQUIPMENT_MANAGER\');'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'training_roles',
+      [
+        {
+          id: uuidv4(),
+          name: 'Участник',
+          alias: 'PARTICIPANT',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Тренер',
+          alias: 'COACH',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Ответственный за инвентарь',
+          alias: 'EQUIPMENT_MANAGER',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('training_roles', {
+      alias: ['PARTICIPANT', 'COACH', 'EQUIPMENT_MANAGER'],
+    });
+  },
+};

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -6,6 +6,7 @@ import {
   RefereeGroup,
   RefereeGroupUser,
   TrainingRegistration,
+  TrainingRole,
   User,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
@@ -82,9 +83,12 @@ async function register(userId, trainingId, actorId) {
   if (training.TrainingRegistrations.some((r) => r.user_id === userId)) {
     throw new ServiceError('already_registered');
   }
+  const role = await TrainingRole.findOne({ where: { alias: 'PARTICIPANT' } });
+  if (!role) throw new ServiceError('training_role_not_found');
   await TrainingRegistration.create({
     training_id: trainingId,
     user_id: userId,
+    training_role_id: role.id,
     created_by: actorId,
     updated_by: actorId,
   });


### PR DESCRIPTION
## Summary
- add a table of training roles
- link registrations to training roles
- seed default roles and set default on registration

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68668be2bcb0832da47d2baa47af599e