### PR TITLE
Replace participants button with icon

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -800,7 +800,9 @@ async function removeRegistration(userId) {
             ></i>
           </td>
           <td class="text-end">
-            <button class="btn btn-sm btn-primary me-2" @click="openRegistrations(t)">Участники</button>
+            <button class="btn btn-sm btn-primary me-2" @click="openRegistrations(t)">
+              <i class="bi bi-people"></i>
+            </button>
             <button class="btn btn-sm btn-secondary me-2" @click="openEditTraining(t)">
               <i class="bi bi-pencil"></i>
             </button>


### PR DESCRIPTION
## Summary
- replace the Participants button in training list with an icon to save space

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68669754f4fc832dab5265f7e914ba3f