### PR TITLE
feat: weekly training calendar

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -3,6 +3,7 @@
 const props = defineProps({
   training: { type: Object, required: true },
   loading: { type: Boolean, default: false },
+  showCancel: { type: Boolean, default: true },
 });
 const emit = defineEmits(['register', 'unregister']);
 
@@ -64,7 +65,7 @@ function seatStatus(t) {
       >
       <p class="small mb-2">Мест: {{ seatStatus(training) }}</p>
       <button
-        v-if="training.registered"
+        v-if="training.registered && showCancel"
         class="btn btn-sm btn-secondary mt-auto"
         @click="emit('unregister', training.id)"
       >Отменить</button>


### PR DESCRIPTION
## Summary
- add optional `showCancel` prop for training card
- fetch upcoming trainings separately
- display user's upcoming week in calendar layout

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686696f10350832d808acd037bad303d