### PR TITLE
Fix training creation season detection

### DIFF
--- a/src/validators/trainingValidators.js
+++ b/src/validators/trainingValidators.js
@@ -2,7 +2,7 @@ import { body } from 'express-validator';
 
 export const trainingCreateRules = [
   body('type_id').isUUID(),
-  body('season_id').isUUID(),
+  body('season_id').optional().isUUID(),
   body('camp_stadium_id').isUUID(),
   body('start_at').isISO8601(),
   body('end_at')


### PR DESCRIPTION
## Summary
- allow season id to be optional when creating a training
- infer season automatically in service based on provided groups or start date
- extend tests for training service

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68669ca8008c832d834c80a4abe286ee