### PR TITLE
Improve mobile layout for camps

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -84,8 +84,10 @@ function seatStatus(t) {
 
 <style scoped>
 .training-card {
-  max-width: 20rem;
+  width: clamp(16rem, 75vw, 20rem);
   margin: 0;
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
 }
 
 .training-card .card-title {

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -220,7 +220,7 @@ function formatTime(date) {
                   :key="t.id"
                   class="list-group-item"
                 >
-                  <div class="d-flex justify-content-between">
+                  <div class="d-flex flex-column flex-sm-row justify-content-between">
                     <div>
                       <i class="bi bi-clock me-1" aria-hidden="true"></i>
                       {{ formatTime(t.start_at) }}
@@ -256,6 +256,8 @@ function formatTime(date) {
                     v-if="g.stadium.yandex_url"
                     :href="g.stadium.yandex_url"
                     target="_blank"
+                    rel="noopener"
+                    aria-label="Открыть в Яндекс.Картах"
                     class="ms-2"
                   >
                     <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
@@ -292,6 +294,8 @@ function formatTime(date) {
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x mandatory;
   gap: 0.75rem;
   padding-bottom: 0.25rem;
   justify-content: flex-start;


### PR DESCRIPTION
## Summary
- tune `TrainingCard` size and snapping
- adjust camps view for better mobile usability

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68669d099544832d860fb66191aec704