### PR TITLE
Add location info to signup email

### DIFF
--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -57,8 +57,8 @@ export async function sendAccountActivatedEmail(user) {
   await sendMail(user.email, subject, text, html);
 }
 
-export async function sendTrainingRegistrationEmail(user, training) {
-  const { subject, text, html } = renderTrainingRegistrationEmail(training);
+export async function sendTrainingRegistrationEmail(user, training, role) {
+  const { subject, text, html } = renderTrainingRegistrationEmail(training, role);
   await sendMail(user.email, subject, text, html);
 }
 

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -70,6 +70,7 @@ async function register(userId, trainingId, actorId) {
       include: [
         { model: RefereeGroup, through: { attributes: [] } },
         { model: TrainingRegistration },
+        { model: CampStadium, include: [Address] },
       ],
     }),
     RefereeGroupUser.findOne({ where: { user_id: userId } }),
@@ -97,7 +98,7 @@ async function register(userId, trainingId, actorId) {
   });
   const user = await User.findByPk(userId);
   if (user) {
-    await emailService.sendTrainingRegistrationEmail(user, training);
+    await emailService.sendTrainingRegistrationEmail(user, training, role);
   }
 }
 
@@ -119,7 +120,10 @@ async function unregister(userId, trainingId) {
 async function add(trainingId, userId, roleId, actorId) {
   const [training, user, role] = await Promise.all([
     Training.findByPk(trainingId, {
-      include: [{ model: TrainingRegistration }],
+      include: [
+        { model: TrainingRegistration },
+        { model: CampStadium, include: [Address] },
+      ],
     }),
     User.findByPk(userId, { include: [Role] }),
     TrainingRole.findByPk(roleId),
@@ -140,7 +144,7 @@ async function add(trainingId, userId, roleId, actorId) {
     created_by: actorId,
     updated_by: actorId,
   });
-  await emailService.sendTrainingRegistrationEmail(user, training);
+  await emailService.sendTrainingRegistrationEmail(user, training, role);
 }
 
 async function listUpcomingByUser(userId, options = {}) {

--- a/src/templates/trainingRegistrationEmail.js
+++ b/src/templates/trainingRegistrationEmail.js
@@ -1,4 +1,4 @@
-export function renderTrainingRegistrationEmail(training) {
+export function renderTrainingRegistrationEmail(training, role) {
   const date = new Date(training.start_at)
     .toLocaleString('ru-RU', {
       timeZone: 'Europe/Moscow',
@@ -9,16 +9,40 @@ export function renderTrainingRegistrationEmail(training) {
       minute: '2-digit',
     })
     .replace(',', '');
+  const stadium = training.CampStadium || training.stadium || {};
+  const address = stadium.Address?.result || stadium.address?.result;
+  const yandexUrl = stadium.yandex_url;
+  const roleName = role?.name || role?.alias;
   const subject = 'Запись на тренировку подтверждена';
-  const text =
-    `Вы успешно записались на тренировку ${date}.\n\n` +
-    'Если вы не записывались на тренировку, просто проигнорируйте письмо.';
+
+  let text = `Вы успешно записались на тренировку ${date}.`;
+  if (roleName) text += `\nРоль: ${roleName}.`;
+  if (address) {
+    text += `\nМесто проведения: ${address}`;
+    if (yandexUrl) text += ` (${yandexUrl})`;
+    text += '.';
+  }
+  text +=
+    '\n\nЕсли вы не записывались на тренировку, просто проигнорируйте письмо.';
+
+  const htmlRole = roleName
+    ? `<p style="font-size:16px;margin:0 0 16px;">Ваша роль: ${roleName}.</p>`
+    : '';
+  const htmlAddress = address
+    ? `<p style="font-size:16px;margin:0 0 16px;">Место проведения: ${address}${
+        yandexUrl
+          ? ` (<a href="${yandexUrl}" target="_blank">Яндекс.Карты</a>)`
+          : ''
+      }.</p>`
+    : '';
   const html = `
     <div style="font-family: Arial, sans-serif; color: #333;">
       <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
       <p style="font-size:16px;margin:0 0 16px;">
         Вы успешно записались на тренировку ${date} (МСК).
       </p>
+      ${htmlRole}
+      ${htmlAddress}
       <p style="font-size:12px;color:#777;margin:0;">
         Если вы не записывались на тренировку, просто проигнорируйте письмо.
       </p>

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -76,7 +76,11 @@ test('register sends confirmation email', async () => {
   findUserMock.mockResolvedValue({ id: 'u1', email: 'e' });
   await service.register('u1', 't1', 'u1');
   expect(createRegMock).toHaveBeenCalled();
-  expect(sendRegEmailMock).toHaveBeenCalledWith({ id: 'u1', email: 'e' }, training);
+  expect(sendRegEmailMock).toHaveBeenCalledWith(
+    { id: 'u1', email: 'e' },
+    training,
+    { id: 'role1' }
+  );
 });
 
 test('remove sends cancellation email', async () => {
@@ -89,7 +93,8 @@ test('remove sends cancellation email', async () => {
 });
 
 test('add creates registration for referee', async () => {
-  findTrainingMock.mockResolvedValue({ ...training, TrainingRegistrations: [] });
+  const tr = { ...training, TrainingRegistrations: [] };
+  findTrainingMock.mockResolvedValue(tr);
   findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] });
   await service.add('t1', 'u2', 'role2', 'admin');
   expect(createRegMock).toHaveBeenCalledWith({
@@ -99,5 +104,9 @@ test('add creates registration for referee', async () => {
     created_by: 'admin',
     updated_by: 'admin',
   });
-  expect(sendRegEmailMock).toHaveBeenCalled();
+  expect(sendRegEmailMock).toHaveBeenCalledWith(
+    { id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] },
+    tr,
+    { id: 'role1' }
+  );
 });


### PR DESCRIPTION
## Summary
- include stadium address, Yandex link and role in training confirmation emails
- propagate role and stadium data to email service
- adjust service logic and tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68669dc48ca0832dab77a5b2f0cbbce3