### PR TITLE
Fix training pagination

### DIFF
--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -31,6 +31,8 @@ async function listAll(options = {}) {
       Season,
       { model: RefereeGroup, through: { attributes: [] } },
     ],
+    distinct: true,
+    subQuery: false,
     order: [['start_at', 'DESC']],
     limit,
     offset,


### PR DESCRIPTION
## Summary
- fix duplication in admin training list by querying using `distinct`
- ensure proper pagination when trainings have referee groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a092ea98832db916e358fde06357