### PR TITLE
Adjust camp metro display

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -98,9 +98,8 @@ function metroNames(address) {
     return '';
   }
   return address.metro
-    .map((m) =>
-      m.distance ? `${m.name} (${m.distance} км)` : m.name
-    )
+    .slice(0, 2)
+    .map((m) => m.name)
     .join(', ');
 }
 


### PR DESCRIPTION
## Summary
- show only the first two metro stations for a camp's stadium and omit distances

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a00acf8c832daf9fca4b147c22e1