### PR TITLE
Show participant counts in admin training list

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -823,7 +823,7 @@ async function removeRegistration(userId) {
           <th>Тип</th>
           <th>Стадион</th>
           <th>Дата и время</th>
-          <th class="text-center">Вместимость</th>
+          <th class="text-center">Участников</th>
           <th v-for="g in refereeGroups" :key="g.id" class="text-center">{{ g.name }}</th>
           <th></th>
         </tr>
@@ -833,7 +833,7 @@ async function removeRegistration(userId) {
           <td>{{ t.type?.name }}</td>
           <td>{{ t.stadium?.name }}</td>
           <td>{{ formatDateTimeRange(t.start_at, t.end_at) }}</td>
-          <td class="text-center">{{ t.capacity }}</td>
+          <td class="text-center">{{ t.registered_count }} / {{ t.capacity ?? '—' }}</td>
           <td v-for="g in refereeGroups" :key="g.id" class="text-center">
             <i
               v-if="t.groups?.some(gr => gr.id === g.id)"

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -12,6 +12,7 @@ function sanitize(obj) {
     CampStadium,
     Season,
     RefereeGroups,
+    registered_count,
   } = obj;
   const res = {
     id,
@@ -23,6 +24,7 @@ function sanitize(obj) {
     available: obj.available,
     registration_open: obj.registration_open,
     registered: obj.user_registered,
+    registered_count,
   };
   if (TrainingType) {
     res.type = {

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -30,16 +30,22 @@ async function listAll(options = {}) {
       { model: CampStadium, include: [Address] },
       Season,
       { model: RefereeGroup, through: { attributes: [] } },
+      { model: TrainingRegistration },
     ],
     order: [['start_at', 'DESC']],
+    distinct: true,
     limit,
     offset,
   });
   return {
-    rows: rows.map((t) => ({
-      ...t.get(),
-      registration_open: isRegistrationOpen(t),
-    })),
+    rows: rows.map((t) => {
+      const registeredCount = t.TrainingRegistrations?.length || 0;
+      return {
+        ...t.get(),
+        registration_open: isRegistrationOpen(t, registeredCount),
+        registered_count: registeredCount,
+      };
+    }),
     count,
   };
 }


### PR DESCRIPTION
## Summary
- include registration counts when listing trainings
- expose `registered_count` via training mapper
- show current registrations over capacity in admin training table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a10adb6c832da9bb9e5171aaf006