### PR TITLE
Fix overflow on training registration cards

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -306,6 +306,7 @@ function formatTime(date) {
 
 .stadium-body {
   min-width: 0;
+  overflow-x: hidden;
 }
 
 @media (max-width: 575.98px) {

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -248,7 +248,7 @@ function formatTime(date) {
             class="col-12"
           >
             <div class="card tile h-100">
-              <div class="card-body">
+              <div class="card-body stadium-body">
                 <div class="d-flex justify-content-between align-items-start mb-1">
                   <h2 class="h6 mb-1">{{ g.stadium.name }}</h2>
                   <a
@@ -302,6 +302,10 @@ function formatTime(date) {
 
 .training-scroll .training-card {
   margin: 0;
+}
+
+.stadium-body {
+  min-width: 0;
 }
 
 @media (max-width: 575.98px) {

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -306,7 +306,6 @@ function formatTime(date) {
 
 .stadium-body {
   min-width: 0;
-  overflow-x: hidden;
 }
 
 @media (max-width: 575.98px) {


### PR DESCRIPTION
## Summary
- ensure stadium cards shrink within Safari flexboxes by adding `min-width: 0`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_6866a5fa7854832d8c246cf115afa3de