### PR TITLE
Fix training admin list query

### DIFF
--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -34,7 +34,6 @@ async function listAll(options = {}) {
       { model: TrainingRegistration },
     ],
     distinct: true,
-    subQuery: false,
     order: [['start_at', 'ASC']],
     limit,
     offset,


### PR DESCRIPTION
## Summary
- show all trainings in admin area by removing incorrect `subQuery` setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866a70586ac832d99954678b3de5191