### PR TITLE
Fix Safari horizontal scroll for training cards

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -247,7 +247,7 @@ function formatTime(date) {
             :key="g.stadium.id"
             class="col-12"
           >
-            <div class="card tile h-100 w-100">
+            <div class="card tile h-100">
               <div class="card-body stadium-body">
                 <div class="d-flex justify-content-between align-items-start mb-1">
                   <h2 class="h6 mb-1">{{ g.stadium.name }}</h2>
@@ -291,7 +291,6 @@ function formatTime(date) {
 <style scoped>
 .training-scroll {
   display: flex;
-  width: 100%;
   flex-wrap: nowrap;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -307,16 +306,5 @@ function formatTime(date) {
 
 .stadium-body {
   min-width: 0;
-}
-
-@media (max-width: 575.98px) {
-  .training-scroll {
-    flex-wrap: wrap;
-    overflow-x: visible;
-    scroll-snap-type: none;
-  }
-  .training-scroll .training-card {
-    width: 100%;
-  }
 }
 </style>

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -247,7 +247,7 @@ function formatTime(date) {
             :key="g.stadium.id"
             class="col-12"
           >
-            <div class="card tile h-100">
+            <div class="card tile h-100 w-100">
               <div class="card-body stadium-body">
                 <div class="d-flex justify-content-between align-items-start mb-1">
                   <h2 class="h6 mb-1">{{ g.stadium.name }}</h2>
@@ -291,6 +291,7 @@ function formatTime(date) {
 <style scoped>
 .training-scroll {
   display: flex;
+  width: 100%;
   flex-wrap: nowrap;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Summary
- ensure stadium cards stretch to full width so horizontal list doesn't overflow
- constrain training card list width inside stadium card

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ab0e45e4832daf876fdf16aa99d0