### PR TITLE
Improve coverage setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ npm run format      # format with Prettier
 
 ```bash
 npm test
+npm run test:coverage
 ```
 
 ### User management API

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,14 @@
 export default {
   testEnvironment: 'node',
   transform: {},
+  collectCoverage: true,
+  coverageDirectory: 'coverage',
+  coverageThreshold: {
+    global: {
+      statements: 70,
+      branches: 60,
+      functions: 70,
+      lines: 70,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
+    "test:coverage": "npm test -- --coverage --coverageReporters=text-summary",
     "format": "prettier --write \"./{src,routes,controllers,services,models,public,scripts,test}/**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"./{src,routes,controllers,services,models,public,scripts,test}/**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "migrate": "sequelize-cli db:migrate",

--- a/tests/fileService.test.js
+++ b/tests/fileService.test.js
@@ -1,3 +1,4 @@
+/* global process, Buffer */
 import { expect, jest, test, beforeEach } from '@jest/globals';
 
 const sendMock = jest.fn();
@@ -6,17 +7,32 @@ const findOneMock = jest.fn();
 const fileCreateMock = jest.fn();
 const mcCreateMock = jest.fn();
 const mcFindMock = jest.fn();
+const findAllMock = jest.fn();
+const findOneAttMock = jest.fn();
+const destroyAttachmentMock = jest.fn();
+const destroyFileMock = jest.fn();
+const getSignedUrlMock = jest.fn();
 
 jest.unstable_mockModule('../src/utils/s3Client.js', () => ({
   __esModule: true,
   default: { send: sendMock },
 }));
 
+jest.unstable_mockModule('@aws-sdk/s3-request-presigner', () => ({
+  __esModule: true,
+  getSignedUrl: getSignedUrlMock,
+}));
+
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
   File: { create: fileCreateMock, findByPk: jest.fn() },
   MedicalCertificate: { findByPk: findByPkMock },
-  MedicalCertificateFile: { create: mcCreateMock, findByPk: mcFindMock },
+  MedicalCertificateFile: {
+    create: mcCreateMock,
+    findByPk: mcFindMock,
+    findAll: findAllMock,
+    findOne: findOneAttMock,
+  },
   MedicalCertificateType: { findOne: findOneMock },
 }));
 
@@ -27,7 +43,11 @@ beforeEach(() => {
   fileCreateMock.mockClear();
   mcCreateMock.mockClear();
   mcFindMock.mockClear();
-  // eslint-disable-next-line no-undef
+  findAllMock.mockClear();
+  findOneAttMock.mockClear();
+  destroyAttachmentMock.mockClear();
+  destroyFileMock.mockClear();
+  getSignedUrlMock.mockClear();
   delete process.env.S3_BUCKET;
   jest.resetModules();
 });
@@ -37,5 +57,63 @@ test('uploadForCertificate throws when S3 not configured', async () => {
   await expect(
     service.uploadForCertificate('1', {}, 'CONCLUSION', 'u1'),
   ).rejects.toThrow('s3_not_configured');
+});
+
+test('uploadForCertificate uploads and stores file', async () => {
+  process.env.S3_BUCKET = 'b';
+  findByPkMock.mockResolvedValue({
+    getUser: jest.fn().mockResolvedValue({ first_name: 'F', last_name: 'L' }),
+  });
+  findOneMock.mockResolvedValue({ id: 't1', name: 'Type' });
+  fileCreateMock.mockResolvedValue({ id: 'f1' });
+  mcCreateMock.mockResolvedValue({ id: 'mc1' });
+  mcFindMock.mockResolvedValue('result');
+  const { default: service } = await import('../src/services/fileService.js');
+  const file = { originalname: 'a.txt', mimetype: 'text/plain', buffer: Buffer.from('x'), size: 1 };
+  const res = await service.uploadForCertificate('1', file, 'A', 'actor');
+  expect(sendMock).toHaveBeenCalled();
+  expect(fileCreateMock).toHaveBeenCalled();
+  expect(mcCreateMock).toHaveBeenCalled();
+  expect(res).toBe('result');
+});
+
+test('listForCertificate returns attachments sorted', async () => {
+  const list = [];
+  findAllMock.mockResolvedValue(list);
+  const { default: service } = await import('../src/services/fileService.js');
+  const res = await service.listForCertificate('c1');
+  expect(findAllMock).toHaveBeenCalledWith({
+    where: { medical_certificate_id: 'c1' },
+    include: [expect.anything(), expect.anything()],
+    order: [['created_at', 'DESC']],
+  });
+  expect(res).toBe(list);
+});
+
+test('getDownloadUrl returns signed url', async () => {
+  process.env.S3_BUCKET = 'b';
+  getSignedUrlMock.mockResolvedValue('url');
+  const { default: service } = await import('../src/services/fileService.js');
+  const res = await service.getDownloadUrl({ key: 'k' });
+  expect(getSignedUrlMock).toHaveBeenCalled();
+  expect(res).toBe('url');
+});
+
+test('remove destroys attachment and file', async () => {
+  findOneAttMock.mockResolvedValue({
+    destroy: destroyAttachmentMock,
+    File: { destroy: destroyFileMock },
+  });
+  const { default: service } = await import('../src/services/fileService.js');
+  await service.remove('f1');
+  expect(findOneAttMock).toHaveBeenCalled();
+  expect(destroyAttachmentMock).toHaveBeenCalled();
+  expect(destroyFileMock).toHaveBeenCalled();
+});
+
+test('remove throws when not found', async () => {
+  findOneAttMock.mockResolvedValue(null);
+  const { default: service } = await import('../src/services/fileService.js');
+  await expect(service.remove('f1')).rejects.toThrow('file_not_found');
 });
 


### PR DESCRIPTION
## Summary
- enable coverage collection and thresholds for Jest
- add `test:coverage` script and usage docs
- expand tests for `fileService`

## Testing
- `npm run lint`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_6866ab7140fc832d97e81ae0fa9503b9