### PR TITLE
Fix training end time field

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -183,7 +183,7 @@ watch(
     const start = new Date(val);
     const end = new Date(start.getTime() + 90 * 60000);
     if (!trainingEditing.value) {
-      trainingForm.value.end_at = end.toISOString().slice(0, 16);
+      trainingForm.value.end_at = toInputValue(end);
     }
   }
 );


### PR DESCRIPTION
## Summary
- ensure default end time uses local timezone

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866ac8857b4832d8dd60d6d3a43102a