### PR TITLE
Fix regex complexity in alias utils

### DIFF
--- a/src/utils/alias.js
+++ b/src/utils/alias.js
@@ -39,6 +39,7 @@ export default function generateAlias(name) {
   return translit
     .replace(/[^0-9a-zA-Z]+/g, '_')
     .replace(/_+/g, '_')
-    .replace(/^_+|_+$/g, '')
+    .replace(/^_+/, '')
+    .replace(/_+$/, '')
     .toUpperCase();
 }


### PR DESCRIPTION
## Summary
- refactor the trimming regex in `alias` util to avoid ambiguous repetition

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e7485d24832da33c0d46fbe80e96