### PR TITLE
Fix password regex injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "pg": "^8.16.3",
         "pg-hstore": "^2.3.4",
         "redis": "^5.5.6",
+        "safe-regex": "^2.1.1",
         "sequelize": "^6.37.7",
         "sequelize-cli": "^6.6.3",
         "swagger-jsdoc": "^6.2.8",
@@ -10192,6 +10193,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "dev": true,
@@ -10332,6 +10342,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "winston": "^3.17.0",
     "redis": "^5.5.6",
     "lodash": "^4.17.21",
+    "safe-regex": "^2.1.1",
     "lusca": "^1.7.0",
     "express-session": "^1.17.3",
     "connect-redis": "^7.0.0"

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -3,11 +3,19 @@ export const REFRESH_TTL = process.env.JWT_REFRESH_TTL || '30d';
 export const JWT_ALG = process.env.JWT_ALG || 'HS256';
 export const JWT_SECRET = process.env.JWT_SECRET;
 
+import safeRegex from 'safe-regex';
+
 export const PASSWORD_MIN_LENGTH =
   parseInt(process.env.PASSWORD_MIN_LENGTH, 10) || 8;
-export const PASSWORD_PATTERN = new RegExp(
-  process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)'
-);
+
+const rawPasswordPattern =
+  process.env.PASSWORD_PATTERN || '(?=.*[A-Za-z])(?=.*\\d)';
+
+if (!safeRegex(rawPasswordPattern)) {
+  throw new Error('Unsafe PASSWORD_PATTERN');
+}
+
+export const PASSWORD_PATTERN = new RegExp(rawPasswordPattern);
 
 export const COOKIE_NAME = 'refresh_token';
 export const COOKIE_HTTP_ONLY = true;


### PR DESCRIPTION
## Summary
- validate custom password regex with `safe-regex`
- add `safe-regex` dependency

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866e762c1fc832daa24258f521c9caf