### PR TITLE
Fix connect-redis import for Node v24

### DIFF
--- a/src/config/session.js
+++ b/src/config/session.js
@@ -1,9 +1,18 @@
 import session from 'express-session';
-import RedisStore from 'connect-redis';
+import connectRedis from 'connect-redis';
 import dotenv from 'dotenv';
 
 import redisClient from './redis.js';
 dotenv.config();
+function isClass(fn) {
+  return typeof fn === 'function' && /^class\s/.test(Function.prototype.toString.call(fn));
+}
+
+let RedisStore = connectRedis;
+if (!isClass(connectRedis)) {
+  RedisStore = connectRedis(session);
+}
+
 const store = new RedisStore({ client: redisClient });
 export default session({
   store,

--- a/src/config/session.js
+++ b/src/config/session.js
@@ -1,5 +1,5 @@
 import session from 'express-session';
-import connectRedis from 'connect-redis';
+import * as connectRedisPkg from 'connect-redis';
 import dotenv from 'dotenv';
 
 import redisClient from './redis.js';
@@ -7,6 +7,8 @@ dotenv.config();
 function isClass(fn) {
   return typeof fn === 'function' && /^class\s/.test(Function.prototype.toString.call(fn));
 }
+
+const connectRedis = connectRedisPkg.default || connectRedisPkg;
 
 let RedisStore = connectRedis;
 if (!isClass(connectRedis)) {


### PR DESCRIPTION
## Summary
- handle both class and factory forms of `connect-redis`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e8dde268832db43ae2063576d3a7