### PR TITLE
Enable HTTPS configuration for Pulse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,4 +44,11 @@ SESSION_SECRET=supersecret
 # S3_ENDPOINT=https://s3.example.ru
 # S3_ACCESS_KEY=your_key
 # S3_SECRET_KEY=your_secret
+#
+# Production deployment settings
+# BASE_URL=https://pulse.fhmoscow.com
+# COOKIE_DOMAIN=pulse.fhmoscow.com
+# ALLOWED_ORIGINS=https://pulse.fhmoscow.com
+# SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
+# SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ DADATA_SECRET=your_dadata_secret
 # RATE_LIMIT_WINDOW_MS=900000
 # RATE_LIMIT_MAX=100
 # ALLOWED_ORIGINS=http://localhost:5173,http://example.com
+# BASE_URL=https://pulse.fhmoscow.com
+# COOKIE_DOMAIN=pulse.fhmoscow.com
+# SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
+# SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
 ```
 
 Приложение отправляет HTML-письма для подтверждения электронной почты и сброса
@@ -107,6 +111,23 @@ The API will be available at `http://localhost:3000` and Swagger docs at `http:/
 The frontend will be served at `http://localhost:5173`.
 
 On container start, migrations and seeders are run automatically.
+
+### HTTPS deployment
+
+For deployment on `https://pulse.fhmoscow.com` configure the following
+environment variables in `.env`:
+
+```bash
+BASE_URL=https://pulse.fhmoscow.com
+COOKIE_DOMAIN=pulse.fhmoscow.com
+ALLOWED_ORIGINS=https://pulse.fhmoscow.com
+SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
+SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
+```
+
+When `SSL_CERT_PATH` and `SSL_KEY_PATH` are provided the server starts in
+HTTPS mode using the specified certificate. The client build should be configured
+with `VITE_API_BASE=https://pulse.fhmoscow.com`.
 
 ## Local development
 

--- a/app.js
+++ b/app.js
@@ -13,6 +13,8 @@ import swaggerSpec from './src/docs/swagger.js';
 import { ALLOWED_ORIGINS } from './src/config/cors.js';
 
 const app = express();
+// Trust reverse proxy to get correct protocol and IP
+app.set('trust proxy', 1);
 
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));

--- a/bin/www
+++ b/bin/www
@@ -4,6 +4,8 @@
  * Module dependencies.
  */
 import http from 'http';
+import https from 'https';
+import fs from 'fs';
 
 import debugLib from 'debug';
 
@@ -24,9 +26,18 @@ const port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
- * Create HTTP server.
+ * Create HTTP or HTTPS server.
  */
-const server = http.createServer(app);
+let server;
+if (process.env.SSL_CERT_PATH && process.env.SSL_KEY_PATH) {
+  const options = {
+    cert: fs.readFileSync(process.env.SSL_CERT_PATH),
+    key: fs.readFileSync(process.env.SSL_KEY_PATH),
+  };
+  server = https.createServer(options, app);
+} else {
+  server = http.createServer(app);
+}
 
 /**
  * Listen on provided port, on all network interfaces.

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,2 @@
+VITE_API_BASE=https://pulse.fhmoscow.com
+VITE_API_PROXY_TARGET=https://pulse.fhmoscow.com

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -21,6 +21,11 @@ const schema = Joi.object({
   S3_ENDPOINT: Joi.string().optional(),
   S3_ACCESS_KEY: Joi.string().optional(),
   S3_SECRET_KEY: Joi.string().optional(),
+  BASE_URL: Joi.string().optional(),
+  SSL_CERT_PATH: Joi.string().optional(),
+  SSL_KEY_PATH: Joi.string().optional(),
+  COOKIE_DOMAIN: Joi.string().optional(),
+  ALLOWED_ORIGINS: Joi.string().optional(),
 }).unknown(true);
 
 export default function validateEnv() {

--- a/src/docs/swagger.js
+++ b/src/docs/swagger.js
@@ -17,8 +17,8 @@ const options = {
     },
     servers: [
       {
-        url: 'http://localhost:3000',
-        description: 'Local server',
+        url: process.env.BASE_URL || 'http://localhost:3000',
+        description: process.env.BASE_URL ? 'Production server' : 'Local server',
       },
     ],
     components: {


### PR DESCRIPTION
## Summary
- add optional HTTPS-related env vars
- support HTTPS in server startup
- trust reverse proxy in Express app
- allow overriding Swagger server URL via BASE_URL
- document HTTPS deployment steps
- add example env file for frontend

## Testing
- `npm ci`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866e9302ab4832d8736dcff3862d907