### PR TITLE
Fix session.js to match connect-redis 9

### DIFF
--- a/src/config/session.js
+++ b/src/config/session.js
@@ -1,19 +1,9 @@
 import session from 'express-session';
-import * as connectRedisPkg from 'connect-redis';
+import { RedisStore } from 'connect-redis';
 import dotenv from 'dotenv';
 
 import redisClient from './redis.js';
 dotenv.config();
-function isClass(fn) {
-  return typeof fn === 'function' && /^class\s/.test(Function.prototype.toString.call(fn));
-}
-
-const connectRedis = connectRedisPkg.default || connectRedisPkg;
-
-let RedisStore = connectRedis;
-if (!isClass(connectRedis)) {
-  RedisStore = connectRedis(session);
-}
 
 const store = new RedisStore({ client: redisClient });
 export default session({

--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -10,7 +10,7 @@ function buildMocks() {
   }));
   jest.unstable_mockModule('connect-redis', () => ({
     __esModule: true,
-    default: jest.fn(() => jest.fn()),
+    RedisStore: jest.fn(() => jest.fn()),
   }));
   jest.unstable_mockModule('../src/config/redis.js', () => ({
     __esModule: true,


### PR DESCRIPTION
## Summary
- update session.js to import `RedisStore` directly
- adjust session tests for updated store import

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866ec1622e8832d824b3fc1f091a4ae