### PR TITLE
Add usage note under registration heading

### DIFF
--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -70,7 +70,8 @@ async function finish() {
 <template>
   <div class="d-flex align-items-center justify-content-center vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
-      <h1 class="mb-4 text-center">Регистрация</h1>
+      <h1 class="mb-1 text-center">Регистрация</h1>
+      <p class="text-center mb-3">с использованием существующей учетной записи в личном кабинете судьи</p>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>
@@ -87,7 +88,6 @@ async function finish() {
           />
           <label for="email">Email</label>
         </div>
-        <p class="form-text mt-1">с использованием существующей учетной записи в личном кабинете судьи</p>
         <button type="submit" class="btn btn-brand w-100" :disabled="loading">
           <span v-if="loading" class="spinner-border spinner-border-sm me-2"></span>
           Отправить код


### PR DESCRIPTION
## Summary
- improve registration page text layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ec4eb5f8832d8856a348443409ec