### PR TITLE
Allow clearing referee group

### DIFF
--- a/client/src/components/RefereeGroupAssignments.vue
+++ b/client/src/components/RefereeGroupAssignments.vue
@@ -34,12 +34,17 @@ async function loadGroups() {
 }
 
 async function setGroup(judge) {
-  if (!judge.group_id) return;
   try {
-    await apiFetch(`/referee-group-users/${judge.user.id}`, {
-      method: 'POST',
-      body: JSON.stringify({ group_id: judge.group_id })
-    });
+    if (!judge.group_id) {
+      await apiFetch(`/referee-group-users/${judge.user.id}`, {
+        method: 'DELETE'
+      });
+    } else {
+      await apiFetch(`/referee-group-users/${judge.user.id}`, {
+        method: 'POST',
+        body: JSON.stringify({ group_id: judge.group_id })
+      });
+    }
   } catch (e) {
     alert(e.message);
   }
@@ -94,7 +99,7 @@ defineExpose({ refresh });
                 <td>{{ formatDate(j.user.birth_date) }}</td>
                 <td>
                   <select v-model="j.group_id" class="form-select" @change="setGroup(j)">
-                    <option value="" disabled>Выберите группу</option>
+                    <option value="">Без группы</option>
                     <option v-for="g in groups" :key="g.id" :value="g.id">{{ g.name }}</option>
                   </select>
                 </td>

--- a/src/controllers/refereeGroupUserAdminController.js
+++ b/src/controllers/refereeGroupUserAdminController.js
@@ -41,4 +41,19 @@ export default {
       return sendError(res, err, 404);
     }
   },
+
+  async clearGroup(req, res) {
+    try {
+      await refereeGroupService.removeUser(req.params.id);
+      const user = await refereeGroupService.getReferee(req.params.id);
+      return res.json({
+        judge: {
+          user: userMapper.toPublic(user),
+          group: null,
+        },
+      });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
 };

--- a/src/models/refereeGroupUser.js
+++ b/src/models/refereeGroupUser.js
@@ -16,7 +16,6 @@ RefereeGroupUser.init(
     sequelize,
     modelName: 'RefereeGroupUser',
     tableName: 'referee_group_users',
-    paranoid: true,
     underscored: true,
     indexes: [{ unique: true, fields: ['user_id'] }],
   }

--- a/src/models/refereeGroupUser.js
+++ b/src/models/refereeGroupUser.js
@@ -16,6 +16,7 @@ RefereeGroupUser.init(
     sequelize,
     modelName: 'RefereeGroupUser',
     tableName: 'referee_group_users',
+    paranoid: true,
     underscored: true,
     indexes: [{ unique: true, fields: ['user_id'] }],
   }

--- a/src/routes/refereeGroupUsers.js
+++ b/src/routes/refereeGroupUsers.js
@@ -45,4 +45,23 @@ router.post(
   controller.setGroup
 );
 
+/**
+ * @swagger
+ * /referee-group-users/{id}:
+ *   delete:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: Remove referee from group
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Updated referee
+ */
+router.delete('/:id', auth, authorize('ADMIN'), controller.clearGroup);
+
 export default router;

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -110,7 +110,7 @@ async function setUserGroup(userId, groupId, actorId) {
     paranoid: false,
   });
   if (link) {
-    if (link.deleted_at) {
+    if (link.deletedAt) {
       await link.restore();
     }
     await link.update({ group_id: groupId, updated_by: actorId });

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -105,8 +105,14 @@ async function setUserGroup(userId, groupId, actorId) {
   ]);
   if (!user) throw new ServiceError('user_not_found', 404);
   if (!group) throw new ServiceError('referee_group_not_found', 404);
-  let link = await RefereeGroupUser.findOne({ where: { user_id: userId } });
+  let link = await RefereeGroupUser.findOne({
+    where: { user_id: userId },
+    paranoid: false,
+  });
   if (link) {
+    if (link.deleted_at) {
+      await link.restore();
+    }
     await link.update({ group_id: groupId, updated_by: actorId });
   } else {
     link = await RefereeGroupUser.create({
@@ -121,7 +127,7 @@ async function setUserGroup(userId, groupId, actorId) {
 
 async function removeUser(userId) {
   const link = await RefereeGroupUser.findOne({ where: { user_id: userId } });
-  if (link) await link.destroy({ force: true });
+  if (link) await link.destroy();
 }
 
 async function remove(id) {

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -121,7 +121,7 @@ async function setUserGroup(userId, groupId, actorId) {
 
 async function removeUser(userId) {
   const link = await RefereeGroupUser.findOne({ where: { user_id: userId } });
-  if (link) await link.destroy();
+  if (link) await link.destroy({ force: true });
 }
 
 async function remove(id) {

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -2,32 +2,51 @@ import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findOneMock = jest.fn();
 const destroyMock = jest.fn();
+const createMock = jest.fn();
+const restoreMock = jest.fn();
+const updateMock = jest.fn();
+const findGroupMock = jest.fn();
+const findUserMock = jest.fn();
 
 beforeEach(() => {
   findOneMock.mockReset();
   destroyMock.mockReset();
+  createMock.mockReset();
+  restoreMock.mockReset();
+  updateMock.mockReset();
+  findGroupMock.mockReset();
+  findUserMock.mockReset();
 });
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
-  RefereeGroup: {},
-  RefereeGroupUser: { findOne: findOneMock },
+  RefereeGroup: { findByPk: findGroupMock },
+  RefereeGroupUser: { findOne: findOneMock, create: createMock },
   Season: {},
-  User: {},
+  User: { findByPk: findUserMock },
   Role: {},
 }));
 
 const { default: service } = await import('../src/services/refereeGroupService.js');
 
-test('removeUser deletes assignment permanently', async () => {
+test('removeUser soft deletes assignment', async () => {
   findOneMock.mockResolvedValue({ destroy: destroyMock });
   await service.removeUser('u1');
-  expect(destroyMock).toHaveBeenCalledWith({ force: true });
+  expect(destroyMock).toHaveBeenCalled();
 });
-
 
 test('removeUser does nothing when link missing', async () => {
   findOneMock.mockResolvedValue(null);
   await service.removeUser('u1');
   expect(destroyMock).not.toHaveBeenCalled();
+});
+
+test('setUserGroup restores deleted record', async () => {
+  findGroupMock.mockResolvedValue({ id: 'g1' });
+  findUserMock.mockResolvedValue({ id: 'u1' });
+  findOneMock.mockResolvedValue({ deleted_at: new Date(), restore: restoreMock, update: updateMock });
+  await service.setUserGroup('u1', 'g1', 'admin');
+  expect(restoreMock).toHaveBeenCalled();
+  expect(updateMock).toHaveBeenCalledWith({ group_id: 'g1', updated_by: 'admin' });
+  expect(createMock).not.toHaveBeenCalled();
 });

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -1,0 +1,33 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const findOneMock = jest.fn();
+const destroyMock = jest.fn();
+
+beforeEach(() => {
+  findOneMock.mockReset();
+  destroyMock.mockReset();
+});
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  RefereeGroup: {},
+  RefereeGroupUser: { findOne: findOneMock },
+  Season: {},
+  User: {},
+  Role: {},
+}));
+
+const { default: service } = await import('../src/services/refereeGroupService.js');
+
+test('removeUser deletes assignment permanently', async () => {
+  findOneMock.mockResolvedValue({ destroy: destroyMock });
+  await service.removeUser('u1');
+  expect(destroyMock).toHaveBeenCalledWith({ force: true });
+});
+
+
+test('removeUser does nothing when link missing', async () => {
+  findOneMock.mockResolvedValue(null);
+  await service.removeUser('u1');
+  expect(destroyMock).not.toHaveBeenCalled();
+});

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -44,7 +44,7 @@ test('removeUser does nothing when link missing', async () => {
 test('setUserGroup restores deleted record', async () => {
   findGroupMock.mockResolvedValue({ id: 'g1' });
   findUserMock.mockResolvedValue({ id: 'u1' });
-  findOneMock.mockResolvedValue({ deleted_at: new Date(), restore: restoreMock, update: updateMock });
+  findOneMock.mockResolvedValue({ deletedAt: new Date(), restore: restoreMock, update: updateMock });
   await service.setUserGroup('u1', 'g1', 'admin');
   expect(restoreMock).toHaveBeenCalled();
   expect(updateMock).toHaveBeenCalledWith({ group_id: 'g1', updated_by: 'admin' });
@@ -60,7 +60,7 @@ test('user can be reassigned after removal', async () => {
   // assign user to a group again
   findGroupMock.mockResolvedValue({ id: 'g2' });
   findUserMock.mockResolvedValue({ id: 'u1' });
-  findOneMock.mockResolvedValueOnce({ deleted_at: new Date(), restore: restoreMock, update: updateMock });
+  findOneMock.mockResolvedValueOnce({ deletedAt: new Date(), restore: restoreMock, update: updateMock });
   await service.setUserGroup('u1', 'g2', 'admin');
   expect(restoreMock).toHaveBeenCalled();
   expect(updateMock).toHaveBeenCalledWith({ group_id: 'g2', updated_by: 'admin' });

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -50,3 +50,19 @@ test('setUserGroup restores deleted record', async () => {
   expect(updateMock).toHaveBeenCalledWith({ group_id: 'g1', updated_by: 'admin' });
   expect(createMock).not.toHaveBeenCalled();
 });
+
+test('user can be reassigned after removal', async () => {
+  // soft delete existing assignment
+  findOneMock.mockResolvedValueOnce({ destroy: destroyMock });
+  await service.removeUser('u1');
+  expect(destroyMock).toHaveBeenCalled();
+
+  // assign user to a group again
+  findGroupMock.mockResolvedValue({ id: 'g2' });
+  findUserMock.mockResolvedValue({ id: 'u1' });
+  findOneMock.mockResolvedValueOnce({ deleted_at: new Date(), restore: restoreMock, update: updateMock });
+  await service.setUserGroup('u1', 'g2', 'admin');
+  expect(restoreMock).toHaveBeenCalled();
+  expect(updateMock).toHaveBeenCalledWith({ group_id: 'g2', updated_by: 'admin' });
+  expect(createMock).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- add controller method to clear referee group from a referee
- expose DELETE `/referee-group-users/:id` API endpoint
- allow admin UI to pick `Без группы` for judges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866ee1d46fc832d9d875d9b28ae7c41