### PR TITLE
Add training type badges on My Trainings

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -1,6 +1,7 @@
 <script setup>
 
 import { computed } from 'vue';
+import { typeBadgeClass as badgeClass } from '../utils/training.js';
 
 const props = defineProps({
   training: { type: Object, required: true },
@@ -19,19 +20,6 @@ function formatStart(date) {
     minute: '2-digit',
   });
   return text.charAt(0).toUpperCase() + text.slice(1);
-}
-
-function badgeClass(alias) {
-  if (!alias) return 'bg-secondary';
-  switch (alias) {
-    case 'ICE':
-      return 'bg-brand';
-    case 'BASIC_FIT':
-      return 'bg-success';
-    case 'THEORY':
-    default:
-      return 'bg-secondary';
-  }
 }
 
 function durationText(start, end) {

--- a/client/src/utils/training.js
+++ b/client/src/utils/training.js
@@ -1,0 +1,12 @@
+export function typeBadgeClass(alias) {
+  if (!alias) return 'bg-secondary';
+  switch (alias) {
+    case 'ICE':
+      return 'bg-brand';
+    case 'BASIC_FIT':
+      return 'bg-success';
+    case 'THEORY':
+    default:
+      return 'bg-secondary';
+  }
+}

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -5,6 +5,7 @@ import { apiFetch } from '../api.js';
 import TrainingCard from '../components/TrainingCard.vue';
 import metroIcon from '../assets/metro.svg';
 import yandexLogo from '../assets/yandex-maps.svg';
+import { typeBadgeClass } from '../utils/training.js';
 
 const trainings = ref([]);
 const mine = ref([]);
@@ -223,7 +224,9 @@ function formatTime(date) {
                     <div>
                       <i class="bi bi-clock me-1" aria-hidden="true"></i>
                       {{ formatTime(t.start_at) }}
-                      <span class="ms-2">{{ t.type?.name }}</span>
+                      <span class="badge ms-2" :class="typeBadgeClass(t.type?.alias)">
+                        {{ t.type?.name }}
+                      </span>
                     </div>
                     <div class="text-end">
                       <div class="fw-semibold">{{ t.stadium?.name }}</div>


### PR DESCRIPTION
## Summary
- show consistent training type badges on My Trainings
- centralize badge color logic in a new utility

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6866f1669544832da1e6179395d275ae