### PR TITLE
Fix training re-registration with soft delete

### DIFF
--- a/src/migrations/20250705063000-update-training-registration-unique-index.js
+++ b/src/migrations/20250705063000-update-training-registration-unique-index.js
@@ -1,0 +1,31 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.removeConstraint(
+      'training_registrations',
+      'uq_training_registrations_training_user'
+    );
+    await queryInterface.addIndex(
+      'training_registrations',
+      ['training_id', 'user_id'],
+      {
+        name: 'uq_training_registrations_training_user',
+        unique: true,
+        where: { deleted_at: null },
+      }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex(
+      'training_registrations',
+      'uq_training_registrations_training_user'
+    );
+    await queryInterface.addConstraint('training_registrations', {
+      fields: ['training_id', 'user_id'],
+      type: 'unique',
+      name: 'uq_training_registrations_training_user',
+    });
+  },
+};

--- a/src/models/trainingRegistration.js
+++ b/src/models/trainingRegistration.js
@@ -18,7 +18,13 @@ TrainingRegistration.init(
     tableName: 'training_registrations',
     paranoid: true,
     underscored: true,
-    indexes: [{ unique: true, fields: ['training_id', 'user_id'] }],
+    indexes: [
+      {
+        unique: true,
+        fields: ['training_id', 'user_id'],
+        where: { deleted_at: null },
+      },
+    ],
   }
 );
 


### PR DESCRIPTION
## Summary
- update unique index definition on training registrations to ignore soft-deleted rows
- add migration dropping the old constraint and creating a partial index

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f513e8c8832da990dd872433eeea