### PR TITLE
Add admin ability to change training registration role

### DIFF
--- a/src/controllers/trainingRegistrationAdminController.js
+++ b/src/controllers/trainingRegistrationAdminController.js
@@ -46,6 +46,24 @@ export default {
     }
   },
 
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      await trainingRegistrationService.updateRole(
+        req.params.id,
+        req.params.userId,
+        req.body.training_role_id,
+        req.user.id
+      );
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
   async remove(req, res) {
     try {
       await trainingRegistrationService.remove(

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -9,7 +9,10 @@ import {
   trainingCreateRules,
   trainingUpdateRules,
 } from '../validators/trainingValidators.js';
-import { createRegistrationRules } from '../validators/trainingRegistrationValidators.js';
+import {
+  createRegistrationRules,
+  updateRegistrationRules,
+} from '../validators/trainingRegistrationValidators.js';
 
 const router = express.Router();
 
@@ -45,6 +48,13 @@ router.post(
   authorize('ADMIN'),
   createRegistrationRules,
   registrationsController.create
+);
+router.put(
+  '/:id/registrations/:userId',
+  auth,
+  authorize('ADMIN'),
+  updateRegistrationRules,
+  registrationsController.update
 );
 router.delete(
   '/:id/registrations/:userId',

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -14,6 +14,7 @@ import { renderMedicalCertificateAddedEmail } from '../templates/medicalCertific
 import { renderAccountActivatedEmail } from '../templates/accountActivatedEmail.js';
 import { renderTrainingRegistrationEmail } from '../templates/trainingRegistrationEmail.js';
 import { renderTrainingRegistrationCancelledEmail } from '../templates/trainingRegistrationCancelledEmail.js';
+import { renderTrainingRoleChangedEmail } from '../templates/trainingRoleChangedEmail.js';
 
 const transporter = nodemailer.createTransport({
   host: SMTP_HOST,
@@ -70,6 +71,11 @@ export async function sendTrainingRegistrationCancelledEmail(user, training) {
     renderTrainingRegistrationCancelledEmail(training);
   await sendMail(user.email, subject, text, html);
 }
+
+export async function sendTrainingRoleChangedEmail(user, training, role) {
+  const { subject, text, html } = renderTrainingRoleChangedEmail(training, role);
+  await sendMail(user.email, subject, text, html);
+}
 export default {
   sendMail,
   sendVerificationEmail,
@@ -78,4 +84,5 @@ export default {
   sendAccountActivatedEmail,
   sendTrainingRegistrationEmail,
   sendTrainingRegistrationCancelledEmail,
+  sendTrainingRoleChangedEmail,
 };

--- a/src/templates/trainingRoleChangedEmail.js
+++ b/src/templates/trainingRoleChangedEmail.js
@@ -1,0 +1,48 @@
+export function renderTrainingRoleChangedEmail(training, role) {
+  const date = new Date(training.start_at)
+    .toLocaleString('ru-RU', {
+      timeZone: 'Europe/Moscow',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    .replace(',', '');
+  const stadium = training.CampStadium || training.stadium || {};
+  const address = stadium.Address?.result || stadium.address?.result;
+  const yandexUrl = stadium.yandex_url;
+  const roleName = role?.name || role?.alias;
+  const subject = 'Изменена роль на тренировке';
+  let text = `Администратор изменил вашу роль на тренировке ${date}.`;
+  if (roleName) text += `\nНовая роль: ${roleName}.`;
+  if (address) {
+    text += `\nМесто проведения: ${address}`;
+    if (yandexUrl) text += ` (${yandexUrl})`;
+    text += '.';
+  }
+  text += '\n\nЕсли вы считаете это ошибкой, обратитесь в службу поддержки.';
+  const htmlRole = roleName
+    ? `<p style="font-size:16px;margin:0 0 16px;">Новая роль: ${roleName}.</p>`
+    : '';
+  const htmlAddress = address
+    ? `<p style="font-size:16px;margin:0 0 16px;">Место проведения: ${address}${
+        yandexUrl ? ` (<a href="${yandexUrl}" target="_blank">Яндекс.Карты</a>)` : ''
+      }.</p>`
+    : '';
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">
+        Администратор изменил вашу роль на тренировке ${date} (МСК).
+      </p>
+      ${htmlRole}
+      ${htmlAddress}
+      <p style="font-size:12px;color:#777;margin:0;">
+        Если вы считаете это ошибкой, обратитесь в службу поддержки.
+      </p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderTrainingRoleChangedEmail };

--- a/src/validators/trainingRegistrationValidators.js
+++ b/src/validators/trainingRegistrationValidators.js
@@ -4,3 +4,5 @@ export const createRegistrationRules = [
   body('user_id').isUUID(),
   body('training_role_id').isUUID(),
 ];
+
+export const updateRegistrationRules = [body('training_role_id').isUUID()];

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -36,12 +36,14 @@ jest.unstable_mockModule('../src/services/trainingService.js', () => ({
 
 const sendRegEmailMock = jest.fn();
 const sendCancelEmailMock = jest.fn();
+const sendRoleChangedEmailMock = jest.fn();
 
 jest.unstable_mockModule('../src/services/emailService.js', () => ({
   __esModule: true,
   default: {
     sendTrainingRegistrationEmail: sendRegEmailMock,
     sendTrainingRegistrationCancelledEmail: sendCancelEmailMock,
+    sendTrainingRoleChangedEmail: sendRoleChangedEmailMock,
   },
 }));
 
@@ -57,6 +59,7 @@ beforeEach(() => {
   findRoleMock.mockReset();
   sendRegEmailMock.mockClear();
   sendCancelEmailMock.mockClear();
+  sendRoleChangedEmailMock.mockClear();
   findRegMock.mockResolvedValue(null);
   findTrainingRoleMock.mockResolvedValue({ id: 'role1' });
 });
@@ -149,4 +152,14 @@ test('add restores deleted registration', async () => {
     tr,
     { id: 'role1' }
   );
+});
+
+test('updateRole sends notification', async () => {
+  const updateMock = jest.fn();
+  findRegMock.mockResolvedValue({ update: updateMock });
+  findTrainingMock.mockResolvedValue(training);
+  findUserMock.mockResolvedValue({ id: 'u1', email: 'e' });
+  await service.updateRole('t1', 'u1', 'role3', 'admin');
+  expect(updateMock).toHaveBeenCalledWith({ training_role_id: 'role3', updated_by: 'admin' });
+  expect(sendRoleChangedEmailMock).toHaveBeenCalledWith({ id: 'u1', email: 'e' }, training, { id: 'role1' });
 });


### PR DESCRIPTION
## Summary
- allow updating training registration role in admin controller and service
- notify user via email when role changes
- expose PUT /camp-trainings/:id/registrations/:userId endpoint
- add email template for role change
- support role edits in admin UI
- test updateRole behaviour

## Testing
- `npm test` *(fails: Jest global coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_6866fcd33edc832dba0bb58109ea5fac