### PR TITLE
Implement training capacity check for self registration

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -132,6 +132,8 @@ function formatDeadline(start) {
           {{
             registrationNotStarted
               ? 'Регистрация не началась'
+              : training.available === 0
+              ? 'Мест нет'
               : 'Зарегистрироваться'
           }}
         </small>

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -44,7 +44,10 @@ async function listAvailable(userId, options = {}) {
   });
   return {
     rows: rows.map((t) => {
-      const registeredCount = t.TrainingRegistrations.length;
+      const participantRegs = t.TrainingRegistrations.filter(
+        (r) => r.TrainingRole?.alias === 'PARTICIPANT'
+      );
+      const registeredCount = participantRegs.length;
       const userRegistered = t.TrainingRegistrations.some(
         (r) => r.user_id === userId
       );
@@ -72,7 +75,7 @@ async function register(userId, trainingId, actorId) {
     Training.findByPk(trainingId, {
       include: [
         { model: RefereeGroup, through: { attributes: [] } },
-        { model: TrainingRegistration },
+        { model: TrainingRegistration, include: [TrainingRole] },
         { model: CampStadium, include: [Address] },
         { model: Season, where: { active: true }, required: true },
       ],
@@ -84,7 +87,13 @@ async function register(userId, trainingId, actorId) {
   if (!training.RefereeGroups.some((g) => g.id === link.group_id)) {
     throw new ServiceError('access_denied');
   }
-  const registeredCount = training.TrainingRegistrations.length;
+  const participantRegs = training.TrainingRegistrations.filter(
+    (r) => r.TrainingRole?.alias === 'PARTICIPANT'
+  );
+  const registeredCount = participantRegs.length;
+  if (training.capacity && registeredCount >= training.capacity) {
+    throw new ServiceError('training_full');
+  }
   if (!trainingService.isRegistrationOpen(training, registeredCount)) {
     throw new ServiceError('registration_closed');
   }
@@ -128,6 +137,7 @@ async function unregister(userId, trainingId) {
   });
   const count = await TrainingRegistration.count({
     where: { training_id: trainingId },
+    include: [{ model: TrainingRole, where: { alias: 'PARTICIPANT' } }],
   });
   if (!training || !trainingService.isRegistrationOpen(training, count)) {
     throw new ServiceError('registration_closed');
@@ -204,7 +214,10 @@ async function listUpcomingByUser(userId, options = {}) {
   );
   return {
     rows: mine.map((t) => {
-      const registeredCount = t.TrainingRegistrations.length;
+      const participantRegs = t.TrainingRegistrations.filter(
+        (r) => r.TrainingRole?.alias === 'PARTICIPANT'
+      );
+      const registeredCount = participantRegs.length;
       const plain = t.get();
       const available =
         typeof plain.capacity === 'number'

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -150,3 +150,18 @@ test('add restores deleted registration', async () => {
     { id: 'role1' }
   );
 });
+
+test('register rejects when training is full', async () => {
+  const tr = {
+    id: 't1',
+    start_at: '2024-01-01T10:00:00Z',
+    capacity: 1,
+    RefereeGroups: [{ id: 'g1' }],
+    TrainingRegistrations: [{ TrainingRole: { alias: 'PARTICIPANT' } }],
+  };
+  findTrainingMock.mockResolvedValue(tr);
+  findGroupUserMock.mockResolvedValue({ user_id: 'u1', group_id: 'g1' });
+  await expect(service.register('u1', 't1', 'u1')).rejects.toThrow(
+    'training_full'
+  );
+});


### PR DESCRIPTION
## Summary
- prevent users from registering for a training session once the participant limit is reached
- count only `PARTICIPANT` roles when calculating available slots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866fd7603b8832d961429c046f4224f