### PR TITLE
Fix duplicate entries when re-registering

### DIFF
--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -23,7 +23,7 @@ async function upsertRegistration(trainingId, userId, roleId, actorId) {
   });
 
   if (existing) {
-    if (!existing.deleted_at) {
+    if (!existing.deletedAt) {
       throw new ServiceError('already_registered');
     }
     await existing.restore();

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -89,7 +89,7 @@ test('register restores deleted registration', async () => {
   findTrainingMock.mockResolvedValue(training);
   findGroupUserMock.mockResolvedValue({ user_id: 'u1', group_id: 'g1' });
   findRegMock.mockResolvedValue({
-    deleted_at: new Date(),
+    deletedAt: new Date(),
     restore: restoreMock,
     update: updateMock,
   });
@@ -136,7 +136,7 @@ test('add restores deleted registration', async () => {
   findTrainingMock.mockResolvedValue(tr);
   findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] });
   findRegMock.mockResolvedValue({
-    deleted_at: new Date(),
+    deletedAt: new Date(),
     restore: restoreMock,
     update: updateMock,
   });


### PR DESCRIPTION
## Summary
- add upsert helper for training registration
- reuse upsert logic when registering and adding a referee

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866fdcf28f4832dbd48ed41503fdfd4