### PR TITLE
Add CI image publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,7 @@ SESSION_SECRET=supersecret
 # SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
 # SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
 
+# Container images for production compose file
+# APP_IMAGE=ghcr.io/your-organization/fhmoscow-pulse
+# CLIENT_IMAGE=ghcr.io/your-organization/fhmoscow-pulse-client
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,35 @@ jobs:
       - name: Run tests
         run: npm test
 
-      - name: Build Docker image
-        run: docker build -t fhmoscow-pulse .
+      - name: Set up Docker Buildx
+        if: github.ref == 'refs/heads/main'
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.ref == 'refs/heads/main'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push server image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+      - name: Build and push client image
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./client
+          file: ./client/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}-client:latest
+            ghcr.io/${{ github.repository }}-client:${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 - Request/response logging persisted to the `logs` table
 - Swagger documentation available at `/api-docs`
 - Docker and docker-compose setup for local development
+- CI builds and publishes Docker images to GitHub Container Registry
 - Redis-backed login attempt tracking
 - ESLint and Prettier for code quality
 - Jest unit tests
@@ -111,6 +112,12 @@ The API will be available at `http://localhost:3000` and Swagger docs at `http:/
 The frontend will be served at `http://localhost:5173`.
 
 On container start, migrations and seeders are run automatically.
+
+For production, prebuilt images are published by the CI pipeline to GitHub Container Registry. Configure `APP_IMAGE` and `CLIENT_IMAGE` in your `.env` file and run:
+
+```bash
+docker-compose -f docker-compose.prod.yml up -d
+```
 
 ### HTTPS deployment
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,60 @@
+services:
+  app:
+    image: ${APP_IMAGE}
+    container_name: app
+    env_file:
+      - .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+    networks:
+      - backend
+
+  client:
+    image: ${CLIENT_IMAGE}
+    container_name: client
+    depends_on:
+      - app
+    ports:
+      - "5173:4173"
+    networks:
+      - backend
+
+  db:
+    image: postgres:17.5
+    container_name: db
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASS}
+      POSTGRES_DB: ${DB_NAME}
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "${DB_USER}", "-d", "${DB_NAME}"]
+      interval: 5s
+      retries: 5
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - backend
+    restart: unless-stopped
+
+  redis:
+    image: redis:8.0.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - backend
+    restart: unless-stopped
+
+volumes:
+  db-data:
+
+networks:
+  backend:
+    driver: bridge


### PR DESCRIPTION
## Summary
- build and push Docker images in CI
- add a production compose file
- note published images in README
- provide image variables in example env file
- publish images only on main branch

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68671046fca8832d87292482808fa01b