### PR TITLE
Allow GitHub Actions to push images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 permissions:
   contents: read
+  packages: write
 
 on:
   push:


### PR DESCRIPTION
## Summary
- allow `packages: write` permission in CI to push Docker images

## Testing
- `gh --version` *(fails: command not found before installing `gh`)*
- `gh run list` *(fails: requires authentication)*

------
https://chatgpt.com/codex/tasks/task_e_68671831c004832db26892b43a76c952