### PR TITLE
Add Dozzle container for log viewing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ docker-compose up --build
 
 The API will be available at `http://localhost:3000` and Swagger docs at `http://localhost:3000/api-docs`.
 The frontend will be served at `http://localhost:5173`.
+Docker logs for all containers can be viewed at `http://localhost:8080` via [Dozzle](https://github.com/amir20/dozzle).
 
 On container start, migrations and seeders are run automatically.
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,17 @@ services:
       - backend
     restart: unless-stopped
 
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - backend
+    restart: unless-stopped
+
 volumes:
   db-data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,17 @@ services:
       - backend
     restart: unless-stopped
 
+  dozzle:
+    image: amir20/dozzle:latest
+    container_name: dozzle
+    ports:
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    networks:
+      - backend
+    restart: unless-stopped
+
 volumes:
   db-data:
 


### PR DESCRIPTION
## Summary
- add Dozzle container to development and production compose files
- document log viewer URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68673e1ebdf8832d9c82b62690a9cfb0