### PR TITLE
Fix Vite preview host

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,8 +1,8 @@
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
 
 // https://vite.dev/config/
-const target = process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000'
+const target = process.env.VITE_API_PROXY_TARGET || 'http://localhost:3000';
 
 export default defineConfig({
   plugins: [vue()],
@@ -11,4 +11,7 @@ export default defineConfig({
       '/auth': target,
     },
   },
-})
+  preview: {
+    allowedHosts: ['pulse.fhmoscow.com'],
+  },
+});


### PR DESCRIPTION
## Summary
- allow `pulse.fhmoscow.com` for the Vite preview server

## Testing
- `npx prettier -w client/vite.config.js`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68673de9e4dc832da19493e2a91f6276