### PR TITLE
Configure nginx reverse proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,8 +49,10 @@ SESSION_SECRET=supersecret
 # BASE_URL=https://pulse.fhmoscow.com
 # COOKIE_DOMAIN=pulse.fhmoscow.com
 # ALLOWED_ORIGINS=https://pulse.fhmoscow.com
+# VITE_API_BASE=/api
 # SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
 # SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
+# Uncomment the SSL_* variables only if you want the Node.js server to handle TLS.
 
 # Container images for production compose file
 # APP_IMAGE=ghcr.io/your-organization/fhmoscow-pulse

--- a/README.md
+++ b/README.md
@@ -122,20 +122,25 @@ docker-compose -f docker-compose.prod.yml up -d
 
 ### HTTPS deployment
 
-For deployment on `https://pulse.fhmoscow.com` configure the following
-environment variables in `.env`:
+In production HTTPS is terminated by **nginx**. Place your SSL certificate and
+key in `infra/nginx/certs` as `fullchain.pem` and `privkey.pem` respectively
+and adjust the reverse proxy configuration in `infra/nginx/conf.d/default.conf`
+if needed.
+
+The Node.js backend runs over plain HTTP internally while nginx handles TLS and
+forwards requests.
+
+Configure the following environment variables in `.env`:
 
 ```bash
 BASE_URL=https://pulse.fhmoscow.com
 COOKIE_DOMAIN=pulse.fhmoscow.com
 ALLOWED_ORIGINS=https://pulse.fhmoscow.com
-SSL_CERT_PATH=/etc/ssl/pulse/fullchain.pem
-SSL_KEY_PATH=/etc/ssl/pulse/privkey.pem
+VITE_API_BASE=/api
 ```
 
-When `SSL_CERT_PATH` and `SSL_KEY_PATH` are provided the server starts in
-HTTPS mode using the specified certificate. The client build should be configured
-with `VITE_API_BASE=https://pulse.fhmoscow.com`.
+Do **not** set `SSL_CERT_PATH` or `SSL_KEY_PATH` so that the Node.js application
+starts in HTTP mode and relies on nginx for TLS termination.
 
 ## Local development
 

--- a/bin/www
+++ b/bin/www
@@ -30,11 +30,18 @@ app.set('port', port);
  */
 let server;
 if (process.env.SSL_CERT_PATH && process.env.SSL_KEY_PATH) {
-  const options = {
-    cert: fs.readFileSync(process.env.SSL_CERT_PATH),
-    key: fs.readFileSync(process.env.SSL_KEY_PATH),
-  };
-  server = https.createServer(options, app);
+  try {
+    const options = {
+      cert: fs.readFileSync(process.env.SSL_CERT_PATH),
+      key: fs.readFileSync(process.env.SSL_KEY_PATH),
+    };
+    server = https.createServer(options, app);
+  } catch (err) {
+    console.warn(
+      `Could not load SSL certificates, falling back to HTTP: ${err.message}`,
+    );
+    server = http.createServer(app);
+  }
 } else {
   server = http.createServer(app);
 }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,8 +7,8 @@ services:
       - "80:80"
       - "443:443"
     volumes:
-      - /etc/nginx/conf.d:/etc/nginx/conf.d:ro
-      - /etc/nginx/certs:/etc/nginx/certs:ro
+      - ./infra/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ./infra/nginx/certs:/etc/nginx/certs:ro
     depends_on:
       - client
       - app
@@ -17,8 +17,8 @@ services:
     container_name: app
     env_file:
       - .env
-    ports:
-      - "3000:3000"
+    expose:
+      - "3000"
     depends_on:
       db:
         condition: service_healthy
@@ -33,8 +33,8 @@ services:
     container_name: client
     depends_on:
       - app
-    ports:
-      - "5173:4173"
+    expose:
+      - "4173"
     networks:
       - backend
     restart: unless-stopped

--- a/infra/nginx/conf.d/default.conf
+++ b/infra/nginx/conf.d/default.conf
@@ -1,0 +1,53 @@
+server {
+    listen 80;
+    server_name _;
+    # allow uploads up to 64 MB
+    client_max_body_size 64m;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name _;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    # Pass API requests to the Node.js backend
+    location /api/ {
+        proxy_pass http://app:3000/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Pass authentication endpoints without /api prefix
+    location /auth/ {
+        proxy_pass http://app:3000/auth/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+    }
+
+    # Serve the Vue application
+    location / {
+        proxy_pass http://client:4173/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Summary
- add nginx configuration
- expose backend and frontend for nginx
- document TLS termination through nginx
- update environment example
- gracefully fall back to HTTP if cert files missing
- clarify nginx handles TLS and increase client upload limit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6867467e2934832da5e647aa2d1abb8a