### PR TITLE
Fix blocked host in Vite preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ BASE_URL=https://pulse.fhmoscow.com
 COOKIE_DOMAIN=pulse.fhmoscow.com
 ALLOWED_ORIGINS=https://pulse.fhmoscow.com
 VITE_API_BASE=/api
+VITE_ALLOWED_HOSTS=pulse.fhmoscow.com
 ```
 
 Do **not** set `SSL_CERT_PATH` or `SSL_KEY_PATH` so that the Node.js application

--- a/client/package.json
+++ b/client/package.json
@@ -15,7 +15,7 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.2.3",
-    "vite": "^6.3.5"
+    "@vitejs/plugin-vue": "^6.0.0",
+    "vite": "^7.0.1"
   }
 }

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -12,6 +12,9 @@ export default defineConfig({
     },
   },
   preview: {
-    allowedHosts: ['pulse.fhmoscow.com'],
+    host: '0.0.0.0',
+    allowedHosts: process.env.VITE_ALLOWED_HOSTS
+      ? process.env.VITE_ALLOWED_HOSTS.split(',').map((h) => h.trim())
+      : ['pulse.fhmoscow.com'],
   },
 });


### PR DESCRIPTION
## Summary
- update Vite and plugin versions
- allow configuring preview allowed hosts via env var
- document VITE_ALLOWED_HOSTS in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68675239cfb8832d81ff649c0bd41cbb