### PR TITLE
Improve mobile auth pages

### DIFF
--- a/client/src/api.js
+++ b/client/src/api.js
@@ -1,8 +1,11 @@
 import { translateError } from './errors.js';
 import { clearAuth } from './auth.js';
-const API_BASE =
-  (typeof import.meta !== 'undefined' && import.meta.env && import.meta.env.VITE_API_BASE) ||
-  'http://localhost:3000';
+const API_BASE = (
+  (typeof import.meta !== 'undefined' &&
+    import.meta.env &&
+    import.meta.env.VITE_API_BASE) ||
+  'http://localhost:3000'
+).replace(/\/+$/, '');
 
 let accessToken = null;
 let refreshPromise = null;

--- a/client/src/components/CookieNotice.vue
+++ b/client/src/components/CookieNotice.vue
@@ -32,4 +32,14 @@ onMounted(() => {
 .cookie-notice {
   z-index: 1080;
 }
+
+@media (max-width: 576px) {
+  .cookie-notice {
+    position: static !important;
+    transform: none !important;
+    left: auto !important;
+    bottom: auto !important;
+    margin-bottom: 0 !important;
+  }
+}
 </style>

--- a/client/src/components/CookieNotice.vue
+++ b/client/src/components/CookieNotice.vue
@@ -1,7 +1,7 @@
 <template>
   <div
-    class="cookie-notice alert alert-info d-flex align-items-center position-fixed bottom-0 start-50 translate-middle-x mb-3 fade"
-    :class="{ show: visible }"
+    v-if="visible"
+    class="cookie-notice alert alert-info d-flex align-items-center position-fixed bottom-0 start-50 translate-middle-x mb-3 fade show"
     role="alert"
   >
     <span class="me-3">

--- a/client/src/views/AwaitingConfirmation.vue
+++ b/client/src/views/AwaitingConfirmation.vue
@@ -41,7 +41,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center vh-100">
+  <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100 text-center" style="max-width: 420px;">
       <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
       <h2 class="mb-3">Заявка отправлена</h2>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -80,7 +80,7 @@ async function login() {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center vh-100">
+  <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
       <h2 class="mb-4 text-center">Авторизация</h2>

--- a/client/src/views/PasswordReset.vue
+++ b/client/src/views/PasswordReset.vue
@@ -63,7 +63,7 @@ async function finish() {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center vh-100">
+  <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <h1 class="mb-4 text-center">Восстановление пароля</h1>
       <transition name="fade">

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -68,7 +68,7 @@ async function finish() {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center vh-100">
+  <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <h1 class="mb-1 text-center">Регистрация</h1>
       <p class="text-center mb-3">с использованием существующей учетной записи в личном кабинете судьи</p>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -11,6 +11,7 @@ export default defineConfig({
     allowedHosts: ['pulse.fhmoscow.com', 'localhost'],
     proxy: {
       '/auth': target,
+      '/api': target,
     },
   },
   preview: {


### PR DESCRIPTION
## Summary
- tweak CookieNotice placement on small screens so links remain clickable
- use `min-vh-100` for auth-related pages for better mobile layout

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686795872aac832d96b99d30daff77ac