### PR TITLE
Display stadiums table when empty

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -676,7 +676,7 @@ async function updateRegistration(reg) {
       <div v-if="isLoading" class="text-center my-3">
         <div class="spinner-border" role="status"></div>
       </div>
-      <div v-if="stadiums.length" class="card tile fade-in">
+      <div class="card tile fade-in">
         <div class="card-header d-flex justify-content-between align-items-center">
           <h2 class="h5 mb-0">Стадионы</h2>
           <button class="btn btn-brand" @click="openCreate">
@@ -684,7 +684,7 @@ async function updateRegistration(reg) {
           </button>
         </div>
         <div class="card-body p-3">
-          <div class="table-responsive">
+          <div v-if="stadiums.length" class="table-responsive">
             <table class="table admin-table table-striped align-middle mb-0">
           <thead>
           <tr>
@@ -726,6 +726,7 @@ async function updateRegistration(reg) {
           </tbody>
             </table>
           </div>
+          <div v-else-if="!isLoading" class="alert alert-warning mb-0">Стадионов нет.</div>
         </div>
       </div>
       <nav class="mt-3" v-if="totalPages > 1">


### PR DESCRIPTION
## Summary
- always render stadiums card
- show alert when the list of stadiums is empty

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867986282f4832d910b553b33752856