### PR TITLE
Fix CSRF issues on auth flows

### DIFF
--- a/client/src/components/NavBar.vue
+++ b/client/src/components/NavBar.vue
@@ -22,7 +22,7 @@
 import { onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { auth, fetchCurrentUser, clearAuth } from '../auth.js'
-import { apiFetch } from '../api.js'
+import { apiFetch, initCsrf } from '../api.js'
 import logo from '../assets/fhm-logo.svg'
 
 const router = useRouter()
@@ -38,10 +38,11 @@ onMounted(async () => {
   }
 })
 
-function logout() {
-  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
+async function logout() {
+  await apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
     clearAuth()
-    router.push('/login')
   })
+  await initCsrf().catch(() => {})
+  router.push('/login')
 }
 </script>

--- a/client/src/views/AwaitingConfirmation.vue
+++ b/client/src/views/AwaitingConfirmation.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
-import { apiFetch } from '../api.js'
+import { apiFetch, initCsrf } from '../api.js'
 import { clearAuth, fetchCurrentUser, auth } from '../auth.js'
 import logo from '../assets/fhm-logo.svg'
 
@@ -23,11 +23,12 @@ async function checkStatus() {
   }
 }
 
-function logout() {
-  apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
+async function logout() {
+  await apiFetch('/auth/logout', { method: 'POST' }).finally(() => {
     clearAuth()
-    router.push('/login')
   })
+  await initCsrf().catch(() => {})
+  router.push('/login')
 }
 
 onMounted(() => {

--- a/src/middlewares/csrf.js
+++ b/src/middlewares/csrf.js
@@ -1,7 +1,9 @@
 import csrf from '../config/csrf.js';
 
+const EXEMPT_PATHS = ['/csrf-token', '/auth/login', '/auth/logout', '/auth/refresh'];
+
 export default function csrfMiddleware(req, res, next) {
-  if (req.path === '/csrf-token') {
+  if (EXEMPT_PATHS.includes(req.path)) {
     return next();
   }
   return csrf(req, res, next);

--- a/tests/csrfMiddleware.test.js
+++ b/tests/csrfMiddleware.test.js
@@ -25,12 +25,15 @@ test('delegates to csrf for normal paths', () => {
   expect(csrfMock).toHaveBeenCalledWith(req, res, next);
 });
 
-test('bypasses middleware for /csrf-token', () => {
+test('bypasses middleware for exempt paths', () => {
   csrfMock.mockClear();
-  const req = buildReq('/csrf-token');
-  const res = buildRes();
-  const next = jest.fn();
-  csrfMiddleware(req, res, next);
-  expect(csrfMock).not.toHaveBeenCalled();
-  expect(next).toHaveBeenCalled();
+  for (const p of ['/csrf-token', '/auth/login', '/auth/logout', '/auth/refresh']) {
+    const req = buildReq(p);
+    const res = buildRes();
+    const next = jest.fn();
+    csrfMiddleware(req, res, next);
+    expect(csrfMock).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalled();
+    csrfMock.mockClear();
+  }
 });


### PR DESCRIPTION
## Summary
- relax CSRF middleware for auth routes so login/refresh/logout won't fail when the token expires
- refresh CSRF token on logout in Vue components
- update csrf middleware tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867cf093194832da427f541156c8410