### PR TITLE
Fix Docker client API base

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ least eight characters long and contain both letters and numbers.
 
 The easiest way to start the application together with PostgreSQL and Redis is using Docker Compose:
 
+The frontend build needs to know where the backend API is running. The
+`docker-compose.yml` file passes `VITE_API_BASE=http://localhost:3000` when
+building the client image so that API requests in development reach the backend
+directly.
+
 ```bash
 docker-compose up --build
 ```

--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -4,7 +4,7 @@
 FROM node:24-alpine AS build
 WORKDIR /usr/src/app
 
-# ARG VITE_API_BASE=/api
+ARG VITE_API_BASE=/api
 ENV VITE_API_BASE=$VITE_API_BASE
 
 # Install build deps for optional native addons (rollup, esbuild, etc.)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
     build:
       context: ./client
       dockerfile: Dockerfile
+      args:
+        - VITE_API_BASE=http://localhost:3000
     container_name: client
     depends_on:
       - app


### PR DESCRIPTION
## Summary
- pass `VITE_API_BASE` build arg when building client container
- document the build arg in README
- enable build arg in client Dockerfile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867cf84601c832d9d87d4b958b8dcb8