### PR TITLE
Improve stadium validation error messages

### DIFF
--- a/src/validators/campStadiumValidators.js
+++ b/src/validators/campStadiumValidators.js
@@ -1,17 +1,19 @@
 import { body } from 'express-validator';
 
 export const campStadiumCreateRules = [
-  body('name').isString().notEmpty(),
+  body('name').isString().notEmpty().withMessage('invalid_name'),
   body('address.result').notEmpty().withMessage('invalid_address'),
-  body('yandex_url').optional().isURL(),
-  body('capacity').optional().isInt({ min: 0 }),
+  body('yandex_url').optional().isURL().withMessage('invalid_url'),
+  body('capacity').optional().isInt({ min: 0 }).withMessage('invalid_capacity'),
   body('phone')
     .optional()
     .customSanitizer((v) => v.replace(/\D/g, ''))
-    .isMobilePhone('ru-RU'),
+    .isMobilePhone('ru-RU')
+    .withMessage('invalid_phone'),
   body('website')
     .optional()
     .isURL({ require_protocol: false })
+    .withMessage('invalid_website')
     .customSanitizer((v) => {
       if (v && !/^https?:\/\//i.test(v)) {
         return `http://${v}`;
@@ -21,6 +23,7 @@ export const campStadiumCreateRules = [
   body('parking')
     .optional()
     .isArray({ max: 1 })
+    .withMessage('invalid_parking')
     .custom((arr) => {
       if (arr.length === 0) return true;
       const p = arr[0];
@@ -38,17 +41,19 @@ export const campStadiumCreateRules = [
 ];
 
 export const campStadiumUpdateRules = [
-  body('name').optional().isString().notEmpty(),
-  body('address.result').optional().notEmpty(),
-  body('yandex_url').optional().isURL(),
-  body('capacity').optional().isInt({ min: 0 }),
+  body('name').optional().isString().notEmpty().withMessage('invalid_name'),
+  body('address.result').optional().notEmpty().withMessage('invalid_address'),
+  body('yandex_url').optional().isURL().withMessage('invalid_url'),
+  body('capacity').optional().isInt({ min: 0 }).withMessage('invalid_capacity'),
   body('phone')
     .optional()
     .customSanitizer((v) => v.replace(/\D/g, ''))
-    .isMobilePhone('ru-RU'),
+    .isMobilePhone('ru-RU')
+    .withMessage('invalid_phone'),
   body('website')
     .optional()
     .isURL({ require_protocol: false })
+    .withMessage('invalid_website')
     .customSanitizer((v) => {
       if (v && !/^https?:\/\//i.test(v)) {
         return `http://${v}`;
@@ -58,6 +63,7 @@ export const campStadiumUpdateRules = [
   body('parking')
     .optional()
     .isArray({ max: 1 })
+    .withMessage('invalid_parking')
     .custom((arr) => {
       if (arr.length === 0) return true;
       const p = arr[0];


### PR DESCRIPTION
## Summary
- clarify validation errors when creating or updating stadiums

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6867d3d66648832d9642d7b10a3492c2