### PR TITLE
Fix finished trainings display

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -156,7 +156,10 @@ const weekTrainings = computed(() => {
   const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
   return myTrainings.value.filter((t) => {
     const start = new Date(t.start_at);
-    return start >= now && start < end;
+    const finish = new Date(t.end_at);
+    // show only trainings that have not finished yet
+    // and start within the next week
+    return finish > now && start < end;
   });
 });
 


### PR DESCRIPTION
## Summary
- hide finished trainings in the "My Trainings" tab

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867dbe91fac832d87cde68ca8cb1591