### PR TITLE
Fix CSRF cookie and handle read‑only Redis/DB

### DIFF
--- a/src/config/csrf.js
+++ b/src/config/csrf.js
@@ -4,7 +4,7 @@ const csrfOptions = {
   angular: true,
   cookie: {
     options: {
-      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'strict',
+      sameSite: process.env.NODE_ENV === 'production' ? 'none' : 'lax',
       secure: process.env.NODE_ENV === 'production',
     },
   },

--- a/src/config/redis.js
+++ b/src/config/redis.js
@@ -6,10 +6,14 @@ dotenv.config();
 const url =
   process.env.REDIS_URL ||
   `redis://${process.env.REDIS_HOST || 'localhost'}:${process.env.REDIS_PORT || 6379}`;
+let redisWritable = true;
 const client = createClient({ url });
 
 client.on('error', (err) => {
   console.error('Redis Client Error', err);
+  if (err?.message?.includes('READONLY')) {
+    redisWritable = false;
+  }
 });
 
 export async function connectRedis() {
@@ -25,6 +29,9 @@ export async function connectRedis() {
 
 export async function closeRedis() {
   await client.quit();
+}
+export function isRedisWritable() {
+  return redisWritable;
 }
 
 export default client;

--- a/src/config/session.js
+++ b/src/config/session.js
@@ -2,10 +2,17 @@ import session from 'express-session';
 import { RedisStore } from 'connect-redis';
 import dotenv from 'dotenv';
 
-import redisClient from './redis.js';
+import redisClient, { isRedisWritable } from './redis.js';
 dotenv.config();
 
-const store = new RedisStore({ client: redisClient });
+let store;
+if (isRedisWritable()) {
+  store = new RedisStore({ client: redisClient });
+} else {
+  const { MemoryStore } = session;
+  store = new MemoryStore();
+}
+
 export default session({
   store,
   secret: process.env.SESSION_SECRET,

--- a/src/middlewares/requestLogger.js
+++ b/src/middlewares/requestLogger.js
@@ -15,6 +15,13 @@ const SENSITIVE_KEYS = [
   'token',
 ];
 
+function isReadonlyDbError(err) {
+  return (
+    err?.parent?.code === '25006' ||
+    /read[- ]only/i.test(err?.message || '')
+  );
+}
+
 /**
  * Middleware сохраняет каждый запрос+ответ в таблицу `logs`.
  * — фиксирует время запроса,
@@ -34,20 +41,25 @@ export default function requestLogger(req, res, next) {
         if (Object.keys(bodyClone).length === 0) bodyClone = null;
       }
 
-      await Log.create({
-        id: uuidv4(),
-        user_id: req.user?.id || null, // появится после внедрения auth
-        method: req.method,
-        path: req.originalUrl,
-        status_code: res.statusCode,
-        ip: req.ip,
-        user_agent: req.get('user-agent') || '',
-        response_time: duration,
-        request_body: bodyClone,
-        response_body: res.locals.body ?? null, // заполни, если нужен body
-      });
+      await Log.create(
+        {
+          id: uuidv4(),
+          user_id: req.user?.id || null, // появится после внедрения auth
+          method: req.method,
+          path: req.originalUrl,
+          status_code: res.statusCode,
+          ip: req.ip,
+          user_agent: req.get('user-agent') || '',
+          response_time: duration,
+          request_body: bodyClone,
+          response_body: res.locals.body ?? null, // заполни, если нужен body
+        },
+        { logging: false },
+      );
     } catch (err) {
-      logger.warn('DB log persistence failed: %s', err.message);
+      if (!isReadonlyDbError(err)) {
+        logger.warn('DB log persistence failed: %s', err.message);
+      }
     }
   });
 

--- a/src/services/loginAttempts.js
+++ b/src/services/loginAttempts.js
@@ -7,7 +7,7 @@ function key(id) {
   return `${PREFIX}${id}`;
 }
 
-function isReadonlyError(err) {
+export function isReadonlyError(err) {
   return err?.message?.includes('READONLY');
 }
 

--- a/tests/csrf.test.js
+++ b/tests/csrf.test.js
@@ -9,7 +9,7 @@ function buildRes() {
   return { cookie: jest.fn(), locals: {} };
 }
 
-test('csrf middleware sets strict cookie in development', async () => {
+test('csrf middleware sets lax cookie in development', async () => {
   process.env.NODE_ENV = 'development';
   jest.resetModules();
   const { default: csrf } = await import('../src/config/csrf.js');
@@ -20,7 +20,7 @@ test('csrf middleware sets strict cookie in development', async () => {
   expect(res.cookie).toHaveBeenCalledWith(
     'XSRF-TOKEN',
     expect.any(String),
-    expect.objectContaining({ sameSite: 'strict', secure: false })
+    expect.objectContaining({ sameSite: 'lax', secure: false })
   );
   expect(next).toHaveBeenCalled();
 });

--- a/tests/requestLogger.test.js
+++ b/tests/requestLogger.test.js
@@ -36,16 +36,19 @@ test('persists log entry on finish', async () => {
 
   expect(next).toHaveBeenCalled();
   expect(onFinishedMock).toHaveBeenCalledWith(res, expect.any(Function));
-  expect(createMock).toHaveBeenCalledWith(expect.objectContaining({
-    id: 'id',
-    method: 'GET',
-    path: '/x',
-    status_code: 200,
-    ip: '::1',
-    user_agent: 'ua',
-    request_body: {foo:'bar'},
-    response_body: 'ok',
-  }));
+  expect(createMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      id: 'id',
+      method: 'GET',
+      path: '/x',
+      status_code: 200,
+      ip: '::1',
+      user_agent: 'ua',
+      request_body: { foo: 'bar' },
+      response_body: 'ok',
+    }),
+    { logging: false },
+  );
 });
 
 test('omits sensitive fields from request body', async () => {
@@ -61,7 +64,8 @@ test('omits sensitive fields from request body', async () => {
   await requestLogger(req, res, () => {});
 
   expect(createMock).toHaveBeenCalledWith(
-    expect.objectContaining({ request_body: { foo: 'bar' } })
+    expect.objectContaining({ request_body: { foo: 'bar' } }),
+    { logging: false },
   );
   expect(req.body.password).toBe('secret');
   expect(req.body.refresh_token).toBe('r');
@@ -81,7 +85,8 @@ test('stores null when only sensitive fields present', async () => {
   await requestLogger(req, res, () => {});
 
   expect(createMock).toHaveBeenCalledWith(
-    expect.objectContaining({ request_body: null })
+    expect.objectContaining({ request_body: null }),
+    { logging: false },
   );
 });
 

--- a/tests/session.test.js
+++ b/tests/session.test.js
@@ -15,6 +15,7 @@ function buildMocks() {
   jest.unstable_mockModule('../src/config/redis.js', () => ({
     __esModule: true,
     default: {},
+    isRedisWritable: () => true,
   }));
   return { sessionMock, middleware };
 }


### PR DESCRIPTION
## Summary
- keep CSRF cookie with `sameSite` lax during development
- detect read-only Redis connections
- fall back to in-memory session store when Redis is read-only
- avoid noisy DB log errors on read-only databases
- export `isReadonlyError` helper
- update tests for new behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6867dcf80d4c832db326e0f7cce11c91