### PR TITLE
Add horizontal date filter for training registration

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -208,7 +208,12 @@ function showToast(message) {
 }
 
 function selectDate(id, iso) {
-  selectedDates.value = { ...selectedDates.value, [id]: iso };
+  const current = selectedDates.value[id];
+  const next = current === iso ? undefined : iso;
+  const copy = { ...selectedDates.value };
+  if (next) copy[id] = next;
+  else delete copy[id];
+  selectedDates.value = copy;
 }
 
 function dayTrainings(id) {
@@ -378,7 +383,7 @@ function dayTrainings(id) {
                     @register="register"
                   />
                 </div>
-                <p v-else class="text-muted small">Выберите дату</p>
+                
               </div>
             </div>
           </div>

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -214,9 +214,8 @@ function selectDate(id, iso) {
 function dayTrainings(id) {
   const group = groupedAllByDay.value.find((g) => g.stadium.id === id);
   if (!group || !group.days.length) return [];
-  const iso =
-    selectedDates.value[id] || group.days[0].date.toISOString();
-  if (!selectedDates.value[id]) selectDate(id, iso);
+  const iso = selectedDates.value[id];
+  if (!iso) return [];
   const day = group.days.find((d) => d.date.toISOString() === iso);
   return day ? day.trainings : [];
 }
@@ -369,7 +368,7 @@ function dayTrainings(id) {
                     {{ formatShortDate(d.date) }}
                   </button>
                 </div>
-                <div class="training-scroll d-flex flex-nowrap gap-3">
+                <div v-if="selectedDates[g.stadium.id]" class="training-scroll d-flex flex-nowrap gap-3">
                   <TrainingCard
                     v-for="t in dayTrainings(g.stadium.id)"
                     :key="t.id"
@@ -379,6 +378,7 @@ function dayTrainings(id) {
                     @register="register"
                   />
                 </div>
+                <p v-else class="text-muted small">Выберите дату</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- show only dates with sessions in the registration section
- allow switching available trainings by date per stadium

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a0eee9f1c832da4f616aceeed19b3