### PR TITLE
Remove patronymic from greeting

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -20,7 +20,7 @@ const isAdmin = computed(() => auth.roles.includes('ADMIN'))
 
 const shortName = computed(() => {
   if (!auth.user) return ''
-  return [auth.user.first_name, auth.user.patronymic].filter(Boolean).join(' ')
+  return [auth.user.first_name].filter(Boolean).join(' ')
 })
 
 const greeting = computed(() => {


### PR DESCRIPTION
## Summary
- show only first name in greeting on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a0dc57678832d9d61a127fd206890