### PR TITLE
Handle indefinite passport validity

### DIFF
--- a/client/src/components/AddPassportModal.vue
+++ b/client/src/components/AddPassportModal.vue
@@ -132,7 +132,10 @@ function calcValid() {
     until = new Date(birth)
     until.setFullYear(until.getFullYear() + 45)
   } else {
-    until = ''
+    until = new Date(birth)
+    until.setFullYear(until.getFullYear() + 100)
+    form.valid_until = until.toISOString().slice(0, 10)
+    return
   }
   if (until) {
     until.setDate(until.getDate() + 90)

--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -47,7 +47,9 @@ function calculateValidUntil(birthDate, issueDate) {
     until = new Date(birth)
     until.setFullYear(until.getFullYear() + 45)
   } else {
-    return ''
+    until = new Date(birth)
+    until.setFullYear(until.getFullYear() + 100)
+    return until.toISOString().slice(0, 10)
   }
   until.setDate(until.getDate() + 90)
   return until.toISOString().slice(0, 10)

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -23,7 +23,9 @@ function calculateValidUntil(birthDate, issueDate) {
     until = new Date(birth)
     until.setFullYear(until.getFullYear() + 45)
   } else {
-    return ''
+    until = new Date(birth)
+    until.setFullYear(until.getFullYear() + 100)
+    return until.toISOString().slice(0, 10)
   }
   until.setDate(until.getDate() + 90)
   return until.toISOString().slice(0, 10)

--- a/src/utils/passportUtils.js
+++ b/src/utils/passportUtils.js
@@ -13,7 +13,9 @@ export function calculateValidUntil(birthDate, issueDate) {
     until = new Date(birth);
     until.setFullYear(until.getFullYear() + 45);
   } else {
-    return null;
+    until = new Date(birth);
+    until.setFullYear(until.getFullYear() + 100);
+    return until.toISOString().slice(0, 10);
   }
   until.setDate(until.getDate() + 90);
   return until.toISOString().slice(0, 10);

--- a/tests/passportUtils.test.js
+++ b/tests/passportUtils.test.js
@@ -13,8 +13,8 @@ describe('passport utils', () => {
     expect(calculateValidUntil('1990-01-01', '2010-02-03')).toBe('2035-04-01');
   });
 
-  test('calculateValidUntil returns null for age 45+', () => {
-    expect(calculateValidUntil('1950-01-01', '2020-01-01')).toBe(null);
+  test('calculateValidUntil returns 100th birthday for age 45+', () => {
+    expect(calculateValidUntil('1950-01-01', '2020-01-01')).toBe('2050-01-01');
   });
 
   test('sanitizePassportData normalizes dates', () => {


### PR DESCRIPTION
## Summary
- update passport validity calculation to give a date when a passport is lifelong
- adjust UI helpers in Vue components
- update tests for new passport logic

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686a0d07c958832db95d54f01cb98ea6