### PR TITLE
Handle leading zeros when importing phone numbers

### DIFF
--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -36,7 +36,9 @@ export default {
       first_name: legacy.first_name,
       patronymic: legacy.second_name,
       birth_date: legacy.b_date,
-      phone: `7${legacy.phone_cod}${legacy.phone_number}`,
+      // phone_number in legacy DB may contain leading zeros
+      // ensure both parts remain strings when concatenated
+      phone: `7${String(legacy.phone_cod)}${String(legacy.phone_number)}`,
     };
     let user;
     try {

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -119,6 +119,28 @@ test('start returns code_sent when data is valid', async () => {
   expect(res.json).toHaveBeenCalledWith({ message: 'code_sent' });
 });
 
+test('start keeps leading zeros in phone number', async () => {
+  const legacyUser = {
+    id: 1,
+    last_name: 'L',
+    first_name: 'F',
+    second_name: 'P',
+    b_date: '2000-01-01',
+    phone_cod: '99',
+    phone_number: '0123456',
+  };
+  findUserMock.mockResolvedValueOnce(null);
+  findLegacyMock.mockResolvedValueOnce(legacyUser);
+  createUserMock.mockResolvedValueOnce({ id: 'u1' });
+  findSystemMock.mockResolvedValueOnce(null);
+  const req = { body: { email: 't@example.com' } };
+  const res = createRes();
+  await controller.start(req, res);
+  expect(createUserMock).toHaveBeenCalledWith(
+    expect.objectContaining({ phone: '7990123456' })
+  );
+});
+
 test('start returns 400 on validation errors', async () => {
   validationOk = false;
   const req = { body: {} };


### PR DESCRIPTION
## Summary
- keep legacy phone number parts as strings to preserve leading zeros
- test registration controller for phone numbers with leading zeros

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a107d4a30832d8bf421eb1566d89f