### PR TITLE
Enhance upcoming events card style

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -74,7 +74,7 @@ function formatStart(date) {
       <h3 class="mb-4 text-start">
         {{ greeting }}, {{ shortName || auth.user?.phone }}!
       </h3>
-      <div class="card mb-4 text-start">
+      <div class="card section-card mb-4 text-start">
         <div class="card-body">
           <h5 class="card-title mb-3">Ближайшие события</h5>
           <div v-if="loadingUpcoming" class="text-center py-3">
@@ -217,6 +217,7 @@ function formatStart(date) {
   margin: 0;
   scroll-snap-align: start;
   scroll-snap-stop: always;
+  border-radius: 1rem;
 }
 
 .upcoming-card i {
@@ -260,7 +261,7 @@ function formatStart(date) {
 }
 
 .section-card {
-  border-radius: 0.75rem;
+  border-radius: 1rem;
   overflow: hidden;
   border: 0;
 }

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -275,8 +275,8 @@ function formatStart(date) {
 
 .menu-card .icon {
   position: absolute;
-  bottom: 0.5rem;
-  right: 0.5rem;
+  bottom: 0.75rem;
+  right: 0.75rem;
   color: var(--brand-color);
 }
 

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -71,10 +71,10 @@ function formatStart(date) {
 <template>
   <div class="py-4">
     <div class="container">
-      <h3 class="mb-4 text-start">
+      <h3 class="mb-3 text-start">
         {{ greeting }}, {{ shortName || auth.user?.phone }}!
       </h3>
-      <div class="card section-card mb-4 text-start">
+      <div class="card section-card mb-2 text-start">
         <div class="card-body">
           <h5 class="card-title mb-3">Ближайшие события</h5>
           <div v-if="loadingUpcoming" class="text-center py-3">
@@ -111,7 +111,7 @@ function formatStart(date) {
           </div>
         </div>
       </div>
-      <div class="card section-card mb-3">
+      <div class="card section-card mb-2">
         <div class="card-body">
           <h5 class="card-title mb-3">Подготовка к сезону</h5>
           <div class="scroll-container">
@@ -132,7 +132,7 @@ function formatStart(date) {
         </div>
       </div>
 
-      <div class="card section-card mb-3">
+      <div class="card section-card mb-2">
         <div class="card-body">
           <h5 class="card-title mb-3">Рабочие сервисы</h5>
           <div class="scroll-container">
@@ -153,7 +153,7 @@ function formatStart(date) {
         </div>
       </div>
 
-      <div class="card section-card mb-3">
+      <div class="card section-card mb-2">
         <div class="card-body">
           <h5 class="card-title mb-3">Документы и формальности</h5>
           <div class="scroll-container">
@@ -174,7 +174,7 @@ function formatStart(date) {
         </div>
       </div>
 
-      <div v-if="isAdmin" class="mt-3">
+      <div v-if="isAdmin" class="mt-2">
         <RouterLink to="/admin" class="menu-card card text-decoration-none text-body tile fade-in d-inline-block">
           <div class="card-body">
             <span class="card-title small">Администрирование</span>


### PR DESCRIPTION
## Summary
- modernize layout for 'Upcoming events' on the home page
- increase rounding of section cards and upcoming event cards

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a1798d574832db6224ca98be3a17e