### PR TITLE
Change admin action buttons to icons

### DIFF
--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -285,21 +285,21 @@ async function copy(text) {
                 @click="blockUser(u.id)"
                 class="btn btn-sm btn-danger me-2"
               >
-                Заблокировать
+                <i class="bi bi-lock-fill"></i>
               </button>
               <button
                 v-if="u.status === 'INACTIVE'"
                 @click="unblockUser(u.id)"
                 class="btn btn-sm btn-success me-2"
               >
-                Разблокировать
+                <i class="bi bi-unlock-fill"></i>
               </button>
               <button
                 v-if="u.status === 'AWAITING_CONFIRMATION'"
                 @click="approveUser(u.id)"
                 class="btn btn-sm btn-success"
               >
-                Подтвердить
+                <i class="bi bi-check-lg"></i>
               </button>
             </td>
           </tr>


### PR DESCRIPTION
## Summary
- use icon-only buttons for block, unblock and approve actions in the admin user list

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a18ae1ce4832dafb96175981d5acc