### PR TITLE
Fix Camp page display issue

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -175,6 +175,13 @@ function formatDay(date) {
   return text.charAt(0).toUpperCase() + text.slice(1);
 }
 
+function formatTime(date) {
+  return new Date(date).toLocaleTimeString('ru-RU', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
 
 function formatShortDate(date) {
   const text = date.toLocaleDateString('ru-RU', {


### PR DESCRIPTION
## Summary
- add missing `formatTime` helper in `Camps.vue`
- keep training time formatting working for the day buttons

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a201ca608832d9db7b3113b2a6a31