### PR TITLE
Add alert for missing medical certificate

### DIFF
--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -174,7 +174,10 @@ onMounted(async () => {
             <p v-else class="text-muted mb-0">Нет файлов</p>
           </div>
           </template>
-          <p v-else class="text-muted mb-0">Действующее медицинское заключение отсутствует</p>
+          <div v-else class="alert alert-warning mb-0" role="alert">
+            Действующее медицинское заключение отсутствует в разделе
+            "Данные медицинских обследований"
+          </div>
         </div>
       </div>
       <div v-if="error" class="alert alert-danger mt-3" role="alert">{{ error }}</div>


### PR DESCRIPTION
## Summary
- show an alert in Medical page when no active medical certificate is present

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a5b79240c832d88d4fd606c3a0144