### PR TITLE
Show training seats

### DIFF
--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -42,12 +42,13 @@ function durationText(start, end) {
 }
 
 function seatStatus(t) {
-  if (typeof t.available === 'number') {
-    if (t.available === 0) return 'закончились';
-    if (t.available <= 5) return 'мало';
-    return 'много';
+  if (typeof t.available === 'number' && typeof t.capacity === 'number') {
+    return `${t.available} / ${t.capacity} мест свободно`;
   }
-  return 'много';
+  if (typeof t.available === 'number') {
+    return `${t.available} мест свободно`;
+  }
+  return '';
 }
 
 function registrationOpenTime(start) {
@@ -139,7 +140,7 @@ function formatDeadline(start) {
         </small>
       </button>
       <p class="seat-status text-muted mt-1 mb-0 text-center">
-        Мест: {{ seatStatus(training) }}
+        {{ seatStatus(training) }}
       </p>
     </div>
   </div>

--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -42,6 +42,9 @@ function durationText(start, end) {
 }
 
 function seatStatus(t) {
+  if (typeof t.available === 'number' && t.available <= 0) {
+    return '';
+  }
   if (typeof t.available === 'number' && typeof t.capacity === 'number') {
     return `${t.available} / ${t.capacity} мест свободно`;
   }
@@ -139,7 +142,7 @@ function formatDeadline(start) {
           }}
         </small>
       </button>
-      <p class="seat-status text-muted mt-1 mb-0 text-center">
+      <p v-if="seatStatus(training)" class="seat-status text-muted mt-1 mb-0 text-center">
         {{ seatStatus(training) }}
       </p>
     </div>


### PR DESCRIPTION
## Summary
- update TrainingCard seat status to show numerical availability
- display full seat info instead of descriptor text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6011919c832da68e5c8989859381