### PR TITLE
Add cancellation icon and email confirmation

### DIFF
--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -31,6 +31,7 @@ export const ERROR_MESSAGES = {
   training_not_found: 'Тренировка не найдена',
   registration_not_found: 'Запись не найдена',
   registration_closed: 'Запись закрыта',
+  cancellation_deadline_passed: 'Нельзя отменить запись менее чем за 48 часов до начала',
   already_registered: 'Уже зарегистрированы',
   referee_group_not_found: 'Группа судей не найдена',
   access_denied: 'Доступ запрещен',

--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -32,6 +32,7 @@ export const ERROR_MESSAGES = {
   registration_not_found: 'Запись не найдена',
   registration_closed: 'Запись закрыта',
   cancellation_deadline_passed: 'Нельзя отменить запись менее чем за 48 часов до начала',
+  cancellation_forbidden: 'Отменять запись могут только участники',
   already_registered: 'Уже зарегистрированы',
   referee_group_not_found: 'Группа судей не найдена',
   access_denied: 'Доступ запрещен',

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -101,7 +101,15 @@ function confirmUnregister(id) {
 }
 
 function canCancel(t) {
+  if (t.my_role?.alias !== 'PARTICIPANT') return false;
   return new Date(t.start_at).getTime() - Date.now() > 48 * 60 * 60 * 1000;
+}
+
+function cancelTooltip(t) {
+  if (t.my_role?.alias !== 'PARTICIPANT') {
+    return 'Отменять запись могут только участники';
+  }
+  return 'Отменить можно не позднее чем за 48 часов';
 }
 
 const myTrainings = computed(() => mine.value);
@@ -349,7 +357,7 @@ function dayOpen(day) {
                     :class="canCancel(t) ? 'text-danger' : 'text-secondary'"
                     @click="canCancel(t) ? confirmUnregister(t.id) : null"
                     :data-bs-toggle="canCancel(t) ? null : 'tooltip'"
-                    title="Отменить можно не позднее чем за 48 часов"
+                    :title="cancelTooltip(t)"
                   >
                     <i class="bi bi-x-lg" aria-hidden="true"></i>
                     <span class="visually-hidden">Отменить</span>

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -84,6 +84,11 @@ async function unregister(id) {
   }
 }
 
+function confirmUnregister(id) {
+  if (!confirm('Отменить запись на тренировку?')) return;
+  unregister(id);
+}
+
 const myTrainings = computed(() => mine.value);
 
 function groupDetailed(list) {
@@ -297,8 +302,9 @@ function dayOpen(day) {
                     </div>
                     <div class="text-muted small">{{ t.type?.name }}</div>
                   </div>
-                  <button class="btn btn-sm btn-secondary" @click="unregister(t.id)">
-                    Отменить
+                  <button class="btn btn-link text-danger p-0" @click="confirmUnregister(t.id)">
+                    <i class="bi bi-x-lg" aria-hidden="true"></i>
+                    <span class="visually-hidden">Отменить</span>
                   </button>
                 </li>
               </ul>

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -57,6 +57,9 @@ function sanitize(obj) {
     ).map((r) => userMapper.toPublic(r.User));
     if (inventory.length) res.equipment_managers = inventory;
   }
+  if (obj.my_role) {
+    res.my_role = { ...obj.my_role };
+  }
   return res;
 }
 

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -14,6 +14,7 @@ import { renderMedicalCertificateAddedEmail } from '../templates/medicalCertific
 import { renderAccountActivatedEmail } from '../templates/accountActivatedEmail.js';
 import { renderTrainingRegistrationEmail } from '../templates/trainingRegistrationEmail.js';
 import { renderTrainingRegistrationCancelledEmail } from '../templates/trainingRegistrationCancelledEmail.js';
+import { renderTrainingRegistrationSelfCancelledEmail } from '../templates/trainingRegistrationSelfCancelledEmail.js';
 import { renderTrainingRoleChangedEmail } from '../templates/trainingRoleChangedEmail.js';
 
 const transporter = nodemailer.createTransport({
@@ -72,6 +73,12 @@ export async function sendTrainingRegistrationCancelledEmail(user, training) {
   await sendMail(user.email, subject, text, html);
 }
 
+export async function sendTrainingRegistrationSelfCancelledEmail(user, training) {
+  const { subject, text, html } =
+    renderTrainingRegistrationSelfCancelledEmail(training);
+  await sendMail(user.email, subject, text, html);
+}
+
 export async function sendTrainingRoleChangedEmail(user, training, role) {
   const { subject, text, html } = renderTrainingRoleChangedEmail(
     training,
@@ -87,5 +94,6 @@ export default {
   sendAccountActivatedEmail,
   sendTrainingRegistrationEmail,
   sendTrainingRegistrationCancelledEmail,
+  sendTrainingRegistrationSelfCancelledEmail,
   sendTrainingRoleChangedEmail,
 };

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -245,6 +245,14 @@ async function listUpcomingByUser(userId, options = {}) {
         typeof plain.capacity === 'number'
           ? Math.max(0, plain.capacity - registeredCount)
           : null;
+      const myReg = t.TrainingRegistrations.find((r) => r.user_id === userId);
+      const myRole = myReg?.TrainingRole
+        ? {
+            id: myReg.TrainingRole.id,
+            name: myReg.TrainingRole.name,
+            alias: myReg.TrainingRole.alias,
+          }
+        : null;
       return {
         ...plain,
         available,
@@ -253,6 +261,7 @@ async function listUpcomingByUser(userId, options = {}) {
           registeredCount
         ),
         user_registered: true,
+        my_role: myRole,
       };
     }),
     count: mine.length,

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -139,8 +139,12 @@ async function register(userId, trainingId, actorId) {
 async function unregister(userId, trainingId) {
   const registration = await TrainingRegistration.findOne({
     where: { training_id: trainingId, user_id: userId },
+    include: [TrainingRole],
   });
   if (!registration) throw new ServiceError('registration_not_found', 404);
+  if (registration.TrainingRole?.alias !== 'PARTICIPANT') {
+    throw new ServiceError('cancellation_forbidden');
+  }
   const training = await Training.findByPk(trainingId, {
     include: [{ model: Season, where: { active: true }, required: true }],
   });

--- a/src/templates/trainingRegistrationSelfCancelledEmail.js
+++ b/src/templates/trainingRegistrationSelfCancelledEmail.js
@@ -1,0 +1,24 @@
+export function renderTrainingRegistrationSelfCancelledEmail(training) {
+  const date = new Date(training.start_at)
+    .toLocaleString('ru-RU', {
+      timeZone: 'Europe/Moscow',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    .replace(',', '');
+  const subject = 'Запись на тренировку отменена';
+  const text = `Вы отменили свою запись на тренировку ${date}.`;
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">
+        Вы отменили свою запись на тренировку ${date} (МСК).
+      </p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderTrainingRegistrationSelfCancelledEmail };

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -189,7 +189,10 @@ test('updateRole sends notification', async () => {
 });
 
 test('unregister sends notification', async () => {
-  findRegMock.mockResolvedValue({ destroy: destroyMock });
+  findRegMock.mockResolvedValue({
+    destroy: destroyMock,
+    TrainingRole: { alias: 'PARTICIPANT' },
+  });
   findTrainingMock.mockResolvedValue(training);
   findUserMock.mockResolvedValue({ id: 'u1', email: 'e' });
   await service.unregister('u1', 't1');
@@ -199,9 +202,21 @@ test('unregister sends notification', async () => {
 
 test('unregister rejects when deadline passed', async () => {
   const soon = { ...training, start_at: new Date(Date.now() + 1 * 60 * 60 * 1000).toISOString() };
-  findRegMock.mockResolvedValue({ destroy: destroyMock });
+  findRegMock.mockResolvedValue({
+    destroy: destroyMock,
+    TrainingRole: { alias: 'PARTICIPANT' },
+  });
   findTrainingMock.mockResolvedValue(soon);
   await expect(service.unregister('u1', 't1')).rejects.toThrow('cancellation_deadline_passed');
+});
+
+test('unregister rejects when role not participant', async () => {
+  findRegMock.mockResolvedValue({
+    destroy: destroyMock,
+    TrainingRole: { alias: 'COACH' },
+  });
+  findTrainingMock.mockResolvedValue(training);
+  await expect(service.unregister('u1', 't1')).rejects.toThrow('cancellation_forbidden');
 });
 
 test('listUpcomingByUser includes my role', async () => {


### PR DESCRIPTION
## Summary
- show red cross icon to cancel training in "Мои тренировки"
- send email when user cancels a training
- prevent cancellation less than 48h before start
- add new email template and error message
- update tests for registration service

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a6082a544832d871b4723ab79d99e