### PR TITLE
Remove obsolete training statuses table

### DIFF
--- a/src/migrations/20250705065000-drop-training-statuses.js
+++ b/src/migrations/20250705065000-drop-training-statuses.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface) {
+    await queryInterface.dropTable('training_statuses');
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.createTable('training_statuses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+};


### PR DESCRIPTION
## Summary
- drop unused `training_statuses` table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686a665b00b8832d890afeb041fbe652