### PR TITLE
Fix protocol in yandex links

### DIFF
--- a/client/src/utils/url.js
+++ b/client/src/utils/url.js
@@ -1,0 +1,4 @@
+export function withHttp(url) {
+  if (!url) return url;
+  return /^https?:\/\//i.test(url) ? url : `http://${url}`;
+}

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -6,6 +6,7 @@ import TrainingCard from '../components/TrainingCard.vue';
 import metroIcon from '../assets/metro.svg';
 import yandexLogo from '../assets/yandex-maps.svg';
 import Toast from 'bootstrap/js/dist/toast';
+import { withHttp } from '../utils/url.js';
 
 const selectedDates = ref({});
 
@@ -320,7 +321,7 @@ function dayOpen(day) {
                 <h2 class="h6 mb-1">{{ g.stadium.name }}</h2>
                 <a
                     v-if="g.stadium.yandex_url"
-                    :href="g.stadium.yandex_url"
+                    :href="withHttp(g.stadium.yandex_url)"
                     target="_blank"
                     rel="noopener"
                     aria-label="Открыть в Яндекс.Картах"

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -3,6 +3,7 @@ import { auth } from '../auth.js'
 import { computed, ref, onMounted } from 'vue'
 import { RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
+import { withHttp } from '../utils/url.js'
 
 const preparationSections = [
   { title: 'Сборы', icon: 'bi-people-fill', to: '/camps' },
@@ -87,7 +88,7 @@ function formatStart(date) {
             <a
               v-for="t in upcoming"
               :key="t.id"
-              :href="t.stadium?.yandex_url"
+              :href="withHttp(t.stadium?.yandex_url)"
               target="_blank"
               class="text-decoration-none text-body"
             >

--- a/src/validators/campStadiumValidators.js
+++ b/src/validators/campStadiumValidators.js
@@ -3,7 +3,16 @@ import { body } from 'express-validator';
 export const campStadiumCreateRules = [
   body('name').isString().notEmpty().withMessage('invalid_name'),
   body('address.result').notEmpty().withMessage('invalid_address'),
-  body('yandex_url').optional().isURL().withMessage('invalid_url'),
+  body('yandex_url')
+    .optional()
+    .isURL({ require_protocol: false })
+    .withMessage('invalid_url')
+    .customSanitizer((v) => {
+      if (v && !/^https?:\/\//i.test(v)) {
+        return `http://${v}`;
+      }
+      return v;
+    }),
   body('capacity').optional().isInt({ min: 0 }).withMessage('invalid_capacity'),
   body('phone')
     .optional()
@@ -43,7 +52,16 @@ export const campStadiumCreateRules = [
 export const campStadiumUpdateRules = [
   body('name').optional().isString().notEmpty().withMessage('invalid_name'),
   body('address.result').optional().notEmpty().withMessage('invalid_address'),
-  body('yandex_url').optional().isURL().withMessage('invalid_url'),
+  body('yandex_url')
+    .optional()
+    .isURL({ require_protocol: false })
+    .withMessage('invalid_url')
+    .customSanitizer((v) => {
+      if (v && !/^https?:\/\//i.test(v)) {
+        return `http://${v}`;
+      }
+      return v;
+    }),
   body('capacity').optional().isInt({ min: 0 }).withMessage('invalid_capacity'),
   body('phone')
     .optional()


### PR DESCRIPTION
## Summary
- add `withHttp()` helper to prepend http scheme
- use `withHttp()` for Yandex.Maps links
- sanitize `yandex_url` on stadium validators
- include new helper in views

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686a6a8fd23c832db1b85f2698ec2975