### PR TITLE
Redesign admin home

### DIFF
--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -1,39 +1,126 @@
 <script setup>
-import { RouterLink } from 'vue-router';
+import { RouterLink } from 'vue-router'
 
-const tiles = [
-  { title: 'Управление пользователями', icon: 'bi-people', to: '/users' },
-  {
-    title: 'Медицина',
-    icon: 'bi-file-earmark-medical',
-    to: '/medical-admin',
-  },
-  {
-    title: 'Управление сборами',
-    icon: 'bi-building',
-    to: '/camp-stadiums',
-  },
+const userSections = [
+  { title: 'Пользователи', icon: 'bi-people', to: '/users' },
+  { title: 'Медицина', icon: 'bi-file-earmark-medical', to: '/medical-admin' },
+]
+
+const refereeSections = [
+  { title: 'Управление сборами', icon: 'bi-building', to: '/camp-stadiums' },
   { title: 'Группы судей', icon: 'bi-people-fill', to: '/referee-groups' },
-];
+]
 </script>
 
 <template>
   <div class="container mt-4">
     <h1 class="mb-3 text-center">Администрирование</h1>
-    <div class="row g-4">
-      <div class="col-6 col-md-4" v-for="tile in tiles" :key="tile.to">
-        <RouterLink
-          :to="tile.to"
-          class="card h-100 text-center tile text-decoration-none text-body"
-        >
-          <div
-            class="card-body d-flex flex-column justify-content-center align-items-center"
+
+    <div class="card section-card mb-2">
+      <div class="card-body">
+        <h5 class="card-title mb-3">Пользователи системы</h5>
+        <div class="scroll-container">
+          <RouterLink
+            v-for="item in userSections"
+            :key="item.to"
+            :to="item.to"
+            class="menu-card card text-decoration-none text-body tile fade-in"
           >
-            <i :class="tile.icon + ' fs-1 mb-3'"></i>
-            <h5 class="card-title">{{ tile.title }}</h5>
-          </div>
-        </RouterLink>
+            <div class="card-body">
+              <p class="card-title small mb-2">{{ item.title }}</p>
+              <i :class="item.icon + ' icon fs-3'" aria-hidden="true"></i>
+            </div>
+          </RouterLink>
+        </div>
+      </div>
+    </div>
+
+    <div class="card section-card mb-2">
+      <div class="card-body">
+        <h5 class="card-title mb-3">Управление судейским корпусом</h5>
+        <div class="scroll-container">
+          <RouterLink
+            v-for="item in refereeSections"
+            :key="item.to"
+            :to="item.to"
+            class="menu-card card text-decoration-none text-body tile fade-in"
+          >
+            <div class="card-body">
+              <p class="card-title small mb-2">{{ item.title }}</p>
+              <i :class="item.icon + ' icon fs-3'" aria-hidden="true"></i>
+            </div>
+          </RouterLink>
+        </div>
       </div>
     </div>
   </div>
 </template>
+
+<style scoped>
+.scroll-container {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  scroll-snap-type: x mandatory;
+  gap: 0.75rem;
+  padding-bottom: 0.25rem;
+  justify-content: flex-start;
+}
+
+.menu-card {
+  width: 8rem;
+  flex: 0 0 auto;
+  height: 6.5rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 0.25rem 0.5rem rgba(0, 0, 0, 0.05);
+  scroll-snap-align: start;
+  scroll-snap-stop: always;
+  position: relative;
+}
+
+.menu-card .card-body {
+  padding: 0.75rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  height: 100%;
+}
+
+.menu-card .card-title {
+  line-height: 1.2;
+  font-weight: 600;
+}
+
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 575.98px) {
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+.menu-card .icon {
+  position: absolute;
+  bottom: 0.75rem;
+  right: 0.75rem;
+  color: var(--brand-color);
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>


### PR DESCRIPTION
## Summary
- redesign admin home page to mimic client main page layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bbacc8e94832db13c263c2afdef85