### PR TITLE
Improve admin users section with filters and responsive UI

### DIFF
--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -79,6 +79,16 @@
   word-wrap: break-word;
 }
 
+/* brand colors for pagination */
+.pagination .page-link {
+  color: var(--brand-color);
+}
+.pagination .page-item.active .page-link {
+  background-color: var(--brand-color);
+  border-color: var(--brand-color);
+  color: #fff;
+}
+
 .skip-link {
   position: absolute;
   top: -40px;

--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -16,6 +16,7 @@ export default {
       sort = 'last_name',
       order = 'asc',
       status = '',
+      role = '',
     } = req.query;
     const { rows, count } = await userService.listUsers({
       search,
@@ -24,6 +25,7 @@ export default {
       sort,
       order,
       status,
+      role,
     });
     return res.json({
       users: userMapper.toPublicArray(rows),

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -64,7 +64,12 @@ async function listUsers(options = {}) {
       { email: { [Op.iLike]: term } },
     ];
   }
-  const include = [Role];
+  const include = [];
+  if (options.role) {
+    include.push({ model: Role, where: { alias: options.role }, required: true });
+  } else {
+    include.push(Role);
+  }
   if (options.status) {
     include.push({
       model: UserStatus,

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -93,6 +93,22 @@ test('listUsers applies status filter', async () => {
   );
 });
 
+test('listUsers applies role filter', async () => {
+  findAndCountAllMock.mockResolvedValue({ rows: [], count: 0 });
+  await service.listUsers({ role: 'ADMIN' });
+  expect(findAndCountAllMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      include: expect.arrayContaining([
+        expect.objectContaining({
+          model: expect.anything(),
+          where: { alias: 'ADMIN' },
+          required: true,
+        }),
+      ]),
+    })
+  );
+});
+
 test('getUser throws on missing user', async () => {
   findByPkMock.mockResolvedValue(null);
   await expect(service.getUser('1')).rejects.toThrow('user_not_found');


### PR DESCRIPTION
## Summary
- add role filter backend support
- support role and page size filters on frontend
- style pagination with brand colors
- fetch user roles when listing users
- add tests for role filter

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686bc3e20b5c832d9b7d85e38c822c27