### PR TITLE
Add user sex reference

### DIFF
--- a/client/src/components/UserForm.vue
+++ b/client/src/components/UserForm.vue
@@ -5,7 +5,8 @@ import { suggestFio, cleanFio } from '../dadata.js'
 const props = defineProps({
   modelValue: Object,
   isNew: Boolean,
-  locked: Boolean
+  locked: Boolean,
+  sexes: { type: Array, default: () => [] }
 })
 const emit = defineEmits(['update:modelValue', 'editing-changed'])
 
@@ -14,6 +15,7 @@ const form = reactive({
   first_name: '',
   patronymic: '',
   birth_date: '',
+  sex_id: '',
   phone: '',
   email: '',
 })
@@ -115,6 +117,7 @@ function applySuggestion(sug) {
 function validate() {
   errors.last_name = form.last_name ? '' : 'Введите фамилию'
   errors.first_name = form.first_name ? '' : 'Введите имя'
+  errors.sex_id = form.sex_id ? '' : 'Выберите пол'
   if (!form.birth_date) {
     errors.birth_date = 'Введите дату рождения'
   } else {
@@ -258,6 +261,23 @@ defineExpose({ validate, unlock, lock, editing })
                 <label for="birthDate">Дата рождения</label>
                 <div class="invalid-feedback">{{ errors.birth_date }}</div>
               </div>
+            </div>
+          </div>
+          <div class="row g-3 mt-3">
+            <div class="col">
+              <label class="form-label">Пол</label>
+              <select
+                v-model="form.sex_id"
+                class="form-select"
+                :class="{ 'is-invalid': errors.sex_id }"
+                required
+              >
+                <option value="" disabled>Выберите...</option>
+                <option v-for="s in props.sexes" :key="s.id" :value="s.id">
+                  {{ s.name }}
+                </option>
+              </select>
+              <div class="invalid-feedback">{{ errors.sex_id }}</div>
             </div>
           </div>
           <div class="row row-cols-1 row-cols-sm-2 g-3 mt-3">

--- a/client/src/views/AdminUserCreate.vue
+++ b/client/src/views/AdminUserCreate.vue
@@ -6,6 +6,8 @@ import UserForm from '../components/UserForm.vue'
 import Modal from 'bootstrap/js/dist/modal'
 import Toast from 'bootstrap/js/dist/toast'
 
+const sexes = ref([])
+
 const router = useRouter()
 
 const user = ref({
@@ -13,6 +15,7 @@ const user = ref({
   first_name: '',
   patronymic: '',
   birth_date: '',
+  sex_id: '',
   phone: '',
   email: ''
 })
@@ -35,7 +38,17 @@ function generatePassword(len = 8) {
 
 onMounted(() => {
   passwordModal = new Modal(passwordModalRef.value)
+  loadSexes()
 })
+
+async function loadSexes() {
+  try {
+    const data = await apiFetch('/sexes')
+    sexes.value = data.sexes
+  } catch (_) {
+    sexes.value = []
+  }
+}
 
 async function save() {
   if (!formRef.value?.validate || !formRef.value.validate()) return
@@ -80,7 +93,7 @@ async function copyToClipboard(text) {
     </nav>
     <h1 class="mb-3">Новый пользователь</h1>
     <form @submit.prevent="save">
-      <UserForm ref="formRef" v-model="user" :isNew="true" />
+      <UserForm ref="formRef" v-model="user" :isNew="true" :sexes="sexes" />
       <div class="mt-3">
         <button type="submit" class="btn btn-brand me-2">Сохранить</button>
         <button type="button" class="btn btn-secondary" @click="close">Отмена</button>

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -20,6 +20,7 @@ const formRef = ref(null);
 const passportModalRef = ref(null);
 const passport = ref(null);
 const passportError = ref('');
+const sexes = ref([]);
 // Placeholder sections hidden until inventory feature is ready
 const placeholderSections = [];
 
@@ -56,7 +57,17 @@ async function loadUser() {
   }
 }
 
+async function loadSexes() {
+  try {
+    const data = await apiFetch('/sexes');
+    sexes.value = data.sexes;
+  } catch (_) {
+    sexes.value = [];
+  }
+}
+
 onMounted(loadUser);
+onMounted(loadSexes);
 
 async function loadPassport() {
   try {
@@ -172,6 +183,7 @@ async function save() {
           ref="formRef"
           v-model="user"
           :locked="true"
+          :sexes="sexes"
           @editing-changed="onEditingChanged"
         >
           <template #actions>

--- a/src/controllers/sexController.js
+++ b/src/controllers/sexController.js
@@ -1,0 +1,14 @@
+import sexService from '../services/sexService.js';
+import sexMapper from '../mappers/sexMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(_req, res) {
+    try {
+      const sexes = await sexService.list();
+      return res.json({ sexes: sexes.map(sexMapper.toPublic) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+};

--- a/src/mappers/sexMapper.js
+++ b/src/mappers/sexMapper.js
@@ -1,0 +1,12 @@
+function sanitize(obj) {
+  const { id, name, alias } = obj;
+  return { id, name, alias };
+}
+
+function toPublic(sex) {
+  if (!sex) return null;
+  const plain = typeof sex.get === 'function' ? sex.get({ plain: true }) : sex;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/mappers/userMapper.js
+++ b/src/mappers/userMapper.js
@@ -58,6 +58,10 @@ function toPublic(user) {
     sanitized.status = plain.UserStatus.alias;
     sanitized.status_name = plain.UserStatus.name;
   }
+  if (plain.Sex) {
+    sanitized.sex = plain.Sex.alias;
+    sanitized.sex_name = plain.Sex.name;
+  }
   return sanitized;
 }
 

--- a/src/migrations/20250706000000-create-sexes.js
+++ b/src/migrations/20250706000000-create-sexes.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('sexes', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(50), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(50), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('sexes');
+  },
+};

--- a/src/migrations/20250706001000-add-sex-id-to-users.js
+++ b/src/migrations/20250706001000-add-sex-id-to-users.js
@@ -1,0 +1,23 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('users', 'sex_id', {
+      type: Sequelize.UUID,
+      allowNull: false,
+    });
+    await queryInterface.addConstraint('users', {
+      fields: ['sex_id'],
+      type: 'foreign key',
+      name: 'fk_users_sex',
+      references: { table: 'sexes', field: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'RESTRICT',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeConstraint('users', 'fk_users_sex');
+    await queryInterface.removeColumn('users', 'sex_id');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -35,10 +35,15 @@ import MedicalExamStatus from './medicalExamStatus.js';
 import MedicalExam from './medicalExam.js';
 import TrainingRegistration from './trainingRegistration.js';
 import TrainingRole from './trainingRole.js';
+import Sex from './sex.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
 User.belongsTo(UserStatus, { foreignKey: 'status_id' });
+
+/* sex → users */
+Sex.hasMany(User, { foreignKey: 'sex_id' });
+User.belongsTo(Sex, { foreignKey: 'sex_id' });
 
 /* многие-ко-многим: пользователь ↔ роли */
 User.belongsToMany(Role, { through: UserRole, foreignKey: 'user_id' });
@@ -211,4 +216,5 @@ export {
   MedicalExam,
   TrainingRole,
   TrainingRegistration,
+  Sex,
 };

--- a/src/models/sex.js
+++ b/src/models/sex.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class Sex extends Model {}
+
+Sex.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(50), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(50), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'Sex',
+    tableName: 'sexes',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default Sex;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -28,6 +28,7 @@ import refereeGroupUsersRouter from './refereeGroupUsers.js';
 import medicalCentersRouter from './medicalCenters.js';
 import medicalExamsRouter from './medicalExams.js';
 import trainingRolesRouter from './trainingRoles.js';
+import sexesRouter from './sexes.js';
 
 const router = express.Router();
 
@@ -43,6 +44,7 @@ router.use('/bank-accounts', bankAccountsRouter);
 router.use('/medical-certificates', medicalCertificatesRouter);
 router.use('/taxations', taxationsRouter);
 router.use('/roles', rolesRouter);
+router.use('/sexes', sexesRouter);
 router.use('/training-roles', trainingRolesRouter);
 router.use('/register', registerRouter);
 router.use('/profile', profileRouter);

--- a/src/routes/sexes.js
+++ b/src/routes/sexes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/sexController.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('ADMIN'), controller.list);
+
+export default router;

--- a/src/seeders/20250607131850-create-sexes.js
+++ b/src/seeders/20250607131850-create-sexes.js
@@ -1,0 +1,37 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM sexes WHERE alias IN (\'MALE\',\'FEMALE\');'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'sexes',
+      [
+        {
+          id: uuidv4(),
+          name: 'Мужской',
+          alias: 'MALE',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Женский',
+          alias: 'FEMALE',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('sexes', { alias: ['MALE', 'FEMALE'] });
+  },
+};

--- a/src/seeders/20250607132137-seed-default-user.js
+++ b/src/seeders/20250607132137-seed-default-user.js
@@ -30,6 +30,13 @@ module.exports = {
              LIMIT 1;`,
       { type: Sequelize.QueryTypes.SELECT }
     );
+    const [sex] = await queryInterface.sequelize.query(
+      `SELECT id
+             FROM sexes
+             WHERE alias = 'MALE'
+             LIMIT 1;`,
+      { type: Sequelize.QueryTypes.SELECT }
+    );
 
     const userId = uuidv4();
 
@@ -45,6 +52,7 @@ module.exports = {
         password:
           '$2y$10$QRGlP7C.Ezw7Gbg3nLOAi..IV2UnRqy.DbGQ9TQ9v7IuM6xuK11Mi',
         status_id: status.id,
+        sex_id: sex.id,
         created_at: now,
         updated_at: now,
       },

--- a/src/services/sexService.js
+++ b/src/services/sexService.js
@@ -1,0 +1,7 @@
+import { Sex } from '../models/index.js';
+
+async function list() {
+  return Sex.findAll();
+}
+
+export default { list };

--- a/src/validators/userValidators.js
+++ b/src/validators/userValidators.js
@@ -3,6 +3,7 @@ import { body } from 'express-validator';
 export const createUserRules = [
   body('first_name').isString().notEmpty(),
   body('last_name').isString().notEmpty(),
+  body('sex_id').isUUID().withMessage('sex_required'),
   body('birth_date')
     .isISO8601()
     .custom((v) => {
@@ -19,6 +20,7 @@ export const updateUserRules = [
   body('first_name').optional().isString().notEmpty(),
   body('last_name').optional().isString().notEmpty(),
   body('patronymic').optional().isString(),
+  body('sex_id').optional().isUUID(),
   body('birth_date')
     .optional()
     .isISO8601()

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -14,6 +14,7 @@ const updateMock = jest.fn();
 const user = { addRole: addRoleMock, removeRole: removeRoleMock, update: updateMock };
 const findRoleMock = jest.fn();
 const statusFindMock = jest.fn();
+const sexFindMock = jest.fn();
 
 beforeEach(() => {
   addRoleMock.mockClear();
@@ -27,6 +28,7 @@ beforeEach(() => {
   updateMock.mockClear();
   findRoleMock.mockClear();
   statusFindMock.mockClear();
+  sexFindMock.mockClear();
 });
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -40,6 +42,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Role: { findOne: findRoleMock },
   UserRole: { findOne: userRoleFindMock },
   UserStatus: { findOne: statusFindMock },
+  Sex: { findByPk: sexFindMock },
 }));
 
 const { default: service } = await import('../src/services/userService.js');
@@ -122,7 +125,9 @@ test('createUser passes data to model', async () => {
     phone: '123',
     email: 'test@example.com',
     password: 'pass',
+    sex_id: 's1',
   };
+  sexFindMock.mockResolvedValueOnce({ id: 's1' });
   const res = await service.createUser(data);
   expect(createMock).toHaveBeenCalledWith({ ...data, status_id: unconfirmed.id });
   expect(res).toBe(user);
@@ -135,8 +140,9 @@ test('createUser throws if phone exists', async () => {
   findOneMock.mockResolvedValueOnce({}); // phone
   findOneMock.mockResolvedValueOnce(null); // email
   findOneMock.mockResolvedValueOnce(null); // name
+  sexFindMock.mockResolvedValueOnce({ id: 's1' });
   await expect(
-    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p' })
+    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p', sex_id: 's1' })
   ).rejects.toThrow('phone_exists');
 });
 
@@ -146,8 +152,9 @@ test('createUser throws if email exists', async () => {
   findOneMock.mockResolvedValueOnce(null); // phone
   findOneMock.mockResolvedValueOnce({}); // email
   findOneMock.mockResolvedValueOnce(null); // name
+  sexFindMock.mockResolvedValueOnce({ id: 's1' });
   await expect(
-    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p' })
+    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p', sex_id: 's1' })
   ).rejects.toThrow('email_exists');
 });
 
@@ -157,8 +164,9 @@ test('createUser throws if user exists by name', async () => {
   findOneMock.mockResolvedValueOnce(null); // phone
   findOneMock.mockResolvedValueOnce(null); // email
   findOneMock.mockResolvedValueOnce({}); // name
+  sexFindMock.mockResolvedValueOnce({ id: 's1' });
   await expect(
-    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p' })
+    service.createUser({ phone: '123', email: 'e', last_name: 'L', first_name: 'F', patronymic: 'P', birth_date: '2000-01-01', password: 'p', sex_id: 's1' })
   ).rejects.toThrow('user_exists');
 });
 


### PR DESCRIPTION
## Summary
- add sexes API and service
- extend admin user form to edit sex
- expose sexes in router

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686c2dc4198c832d826aa64ca5d33007