### PR TITLE
Add health check endpoint

### DIFF
--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -58,6 +58,19 @@ router.use('/medical-exams', medicalExamsRouter);
 
 /**
  * @swagger
+ * /health:
+ *   get:
+ *     summary: Health check endpoint
+ *     responses:
+ *       200:
+ *         description: Service status
+ */
+router.get('/health', (_req, res) => {
+  res.json({ status: 'ok' });
+});
+
+/**
+ * @swagger
  * /csrf-token:
  *   get:
  *     summary: Retrieve CSRF token


### PR DESCRIPTION
## Summary
- add a `/health` route to respond with a basic status

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686c39c4e384832d85359841ba97b417