### PR TITLE
Restrict camps & medical sections to REFEREE role

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -23,8 +23,16 @@ import ServerError from './views/ServerError.vue';
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true, fluid: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
-  { path: '/medical', component: Medical, meta: { requiresAuth: true } },
-  { path: '/camps', component: Camps, meta: { requiresAuth: true } },
+  {
+    path: '/medical',
+    component: Medical,
+    meta: { requiresAuth: true, requiresReferee: true },
+  },
+  {
+    path: '/camps',
+    component: Camps,
+    meta: { requiresAuth: true, requiresReferee: true },
+  },
   {
     path: '/admin',
     component: AdminHome,
@@ -113,6 +121,8 @@ router.beforeEach(async (to, _from, next) => {
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/login');
   } else if (to.meta.requiresAdmin && !roles.includes('ADMIN')) {
+    next('/forbidden');
+  } else if (to.meta.requiresReferee && !roles.includes('REFEREE')) {
     next('/forbidden');
   } else if (
     isAuthenticated &&

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -5,10 +5,10 @@ import { RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { withHttp } from '../utils/url.js'
 
-const preparationSections = [
-  { title: 'Сборы', icon: 'bi-people-fill', to: '/camps' },
-  { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical' },
-  { title: 'Результаты тестов', icon: 'bi-graph-up' }
+const basePreparationSections = [
+  { title: 'Сборы', icon: 'bi-people-fill', to: '/camps', referee: true },
+  { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical', referee: true },
+  { title: 'Результаты тестов', icon: 'bi-graph-up' },
 ]
 
 const workSections = [
@@ -24,6 +24,10 @@ const docsSections = [
 ]
 
 const isAdmin = computed(() => auth.roles.includes('ADMIN'))
+const isReferee = computed(() => auth.roles.includes('REFEREE'))
+const preparationSections = computed(() =>
+  basePreparationSections.filter((s) => !s.referee || isReferee.value)
+)
 
 const shortName = computed(() => {
   if (!auth.user) return ''

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -24,8 +24,8 @@ router.post(
   trainingCreateRules,
   controller.create
 );
-router.get('/available', auth, selfController.available);
-router.get('/me/upcoming', auth, selfController.upcoming);
+router.get('/available', auth, authorize('REFEREE'), selfController.available);
+router.get('/me/upcoming', auth, authorize('REFEREE'), selfController.upcoming);
 router.get('/:id', auth, authorize('ADMIN'), controller.get);
 router.put(
   '/:id',
@@ -63,7 +63,17 @@ router.delete(
   registrationsController.remove
 );
 
-router.post('/:id/register', auth, selfController.register);
-router.delete('/:id/register', auth, selfController.unregister);
+router.post(
+  '/:id/register',
+  auth,
+  authorize('REFEREE'),
+  selfController.register
+);
+router.delete(
+  '/:id/register',
+  auth,
+  authorize('REFEREE'),
+  selfController.unregister
+);
 
 export default router;

--- a/src/routes/medicalCertificates.js
+++ b/src/routes/medicalCertificates.js
@@ -13,11 +13,27 @@ const upload = multer();
 
 const router = express.Router();
 
-router.get('/me', auth, medicalCertificateController.me);
-router.get('/me/history', auth, medicalCertificateController.history);
-router.post('/', auth, medicalCertificateRules, selfController.create);
-router.delete('/', auth, selfController.remove);
-router.get('/me/files', auth, fileController.listMe);
+router.get(
+  '/me',
+  auth,
+  authorize('REFEREE'),
+  medicalCertificateController.me
+);
+router.get(
+  '/me/history',
+  auth,
+  authorize('REFEREE'),
+  medicalCertificateController.history
+);
+router.post(
+  '/',
+  auth,
+  authorize('REFEREE'),
+  medicalCertificateRules,
+  selfController.create
+);
+router.delete('/', auth, authorize('REFEREE'), selfController.remove);
+router.get('/me/files', auth, authorize('REFEREE'), fileController.listMe);
 
 router.get(
   '/role/:alias',

--- a/src/routes/medicalExams.js
+++ b/src/routes/medicalExams.js
@@ -14,8 +14,8 @@ import { updateRegistrationRules } from '../validators/medicalExamRegistrationVa
 const router = express.Router();
 
 router.get('/', auth, authorize('ADMIN'), controller.list);
-router.get('/available', auth, selfController.available);
-router.get('/me/upcoming', auth, selfController.upcoming);
+router.get('/available', auth, authorize('REFEREE'), selfController.available);
+router.get('/me/upcoming', auth, authorize('REFEREE'), selfController.upcoming);
 router.post(
   '/',
   auth,
@@ -53,7 +53,17 @@ router.delete(
   registrationsController.remove
 );
 
-router.post('/:id/register', auth, selfController.register);
-router.delete('/:id/register', auth, selfController.unregister);
+router.post(
+  '/:id/register',
+  auth,
+  authorize('REFEREE'),
+  selfController.register
+);
+router.delete(
+  '/:id/register',
+  auth,
+  authorize('REFEREE'),
+  selfController.unregister
+);
 
 export default router;


### PR DESCRIPTION
## Summary
- hide "Сборы" and "Медосмотр" sections for non-referees
- restrict `/medical` and `/camps` routes to referees in the frontend router
- block access to camps and medical endpoints unless user has `REFEREE` role

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686c4195caa0832d8e7445bb2ab6b4be