### PR TITLE
Allow users to reapply for medical exams

### DIFF
--- a/client/src/components/MedicalExamCard.vue
+++ b/client/src/components/MedicalExamCard.vue
@@ -5,8 +5,13 @@ import metroIcon from '../assets/metro.svg';
 const props = defineProps({
   exam: { type: Object, required: true },
   loading: { type: Boolean, default: false },
+  pendingExamId: { type: String, default: null },
 });
 const emit = defineEmits(['toggle']);
+
+const hasOtherPending = computed(
+  () => props.pendingExamId && props.pendingExamId !== props.exam.id
+);
 
 function formatStart(date) {
   const d = new Date(date);
@@ -41,6 +46,7 @@ function seatStatus(e) {
 }
 
 const btnClass = computed(() => {
+  if (hasOtherPending.value) return 'btn-secondary';
   if (!props.exam.registered) return 'btn-brand';
   if (props.exam.registration_status === 'PENDING') return 'btn-secondary';
   if (props.exam.registration_status === 'APPROVED') return 'btn-success';
@@ -49,6 +55,7 @@ const btnClass = computed(() => {
 });
 
 const btnText = computed(() => {
+  if (hasOtherPending.value) return 'Есть активная заявка';
   if (!props.exam.registered) return 'Записаться';
   if (props.exam.registration_status === 'PENDING') return 'На рассмотрении';
   if (props.exam.registration_status === 'APPROVED') return 'Подтверждена';
@@ -57,6 +64,7 @@ const btnText = computed(() => {
 });
 
 const btnIcon = computed(() => {
+  if (hasOtherPending.value) return 'bi-hourglass';
   if (!props.exam.registered) return 'bi-plus-lg';
   if (props.exam.registration_status === 'PENDING') return 'bi-hourglass';
   if (props.exam.registration_status === 'APPROVED') return 'bi-check-lg';
@@ -66,6 +74,7 @@ const btnIcon = computed(() => {
 
 const disabled = computed(
   () =>
+    hasOtherPending.value ||
     props.exam.registration_status === 'APPROVED' ||
     props.exam.registration_status === 'COMPLETED' ||
     props.exam.registration_status === 'CANCELED' ||

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -13,6 +13,12 @@ const exams = ref([]);
 const examsError = ref('');
 const examsLoading = ref(true);
 const registering = ref(null);
+const pendingExamId = computed(() => {
+  const e = exams.value.find(
+    (ex) => ex.registered && ex.registration_status === 'PENDING'
+  );
+  return e ? e.id : null;
+});
 const isValid = (cert) => {
   const today = new Date();
   return new Date(cert.issue_date) <= today && new Date(cert.valid_until) >= today;
@@ -242,6 +248,7 @@ async function toggleExam(exam) {
               :key="ex.id"
               :exam="ex"
               :loading="registering === ex.id"
+              :pending-exam-id="pendingExamId"
               class="flex-shrink-0"
               @toggle="toggleExam"
             />

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -157,7 +157,6 @@ async function register(userId, examId, actorId) {
 
   const existing = await MedicalExamRegistration.findOne({
     where: { medical_exam_id: examId, user_id: userId },
-    paranoid: false,
   });
   if (existing) throw new ServiceError('already_registered');
 
@@ -179,8 +178,7 @@ async function unregister(userId, examId) {
   const pendingId = await getStatusId('PENDING');
   if (reg.status_id !== pendingId)
     throw new ServiceError('cancellation_forbidden');
-  const canceledId = await getStatusId('CANCELED');
-  await reg.update({ status_id: canceledId });
+  await reg.destroy();
 }
 
 async function setStatus(examId, userId, status, actorId) {

--- a/tests/medicalExamRegistrationService.test.js
+++ b/tests/medicalExamRegistrationService.test.js
@@ -5,6 +5,7 @@ const findAllMock = jest.fn();
 const createRegMock = jest.fn();
 const findRegMock = jest.fn();
 const updateMock = jest.fn();
+const destroyMock = jest.fn();
 const findStatusMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -28,6 +29,7 @@ beforeEach(() => {
   createRegMock.mockReset();
   findRegMock.mockReset();
   updateMock.mockReset();
+  destroyMock.mockReset();
   findStatusMock.mockReset();
   findStatusMock.mockImplementation(({ where: { alias } }) => statuses[alias]);
 });
@@ -52,7 +54,6 @@ test('register creates new registration', async () => {
   await service.register('u1', 'e1', 'u1');
   expect(findRegMock).toHaveBeenCalledWith({
     where: { medical_exam_id: 'e1', user_id: 'u1' },
-    paranoid: false,
   });
   expect(createRegMock).toHaveBeenCalledWith({
     medical_exam_id: 'e1',
@@ -69,10 +70,13 @@ test('register fails if already registered', async () => {
   await expect(service.register('u1', 'e1', 'u1')).rejects.toBeTruthy();
 });
 
-test('unregister updates status to canceled', async () => {
-  findRegMock.mockResolvedValue({ status_id: statuses.PENDING.id, update: updateMock });
+test('unregister removes pending registration', async () => {
+  findRegMock.mockResolvedValue({
+    status_id: statuses.PENDING.id,
+    destroy: destroyMock,
+  });
   await service.unregister('u1', 'e1');
-  expect(updateMock).toHaveBeenCalledWith({ status_id: statuses.CANCELED.id });
+  expect(destroyMock).toHaveBeenCalled();
 });
 
 test('unregister fails when approved', async () => {


### PR DESCRIPTION
## Summary
- allow deleting medical exam applications when cancelling
- block new registrations while another request is pending
- show message about active request on other exam cards
- update unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686c407d3d88832db6351640203b410e