### PR TITLE
Show all events in upcoming week

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -51,8 +51,8 @@ async function loadUpcoming() {
   loadingUpcoming.value = true
   try {
     const [trainingData, examData] = await Promise.all([
-      apiFetch('/camp-trainings/me/upcoming?limit=3'),
-      apiFetch('/medical-exams/me/upcoming?limit=3')
+      apiFetch('/camp-trainings/me/upcoming?limit=100'),
+      apiFetch('/medical-exams/me/upcoming?limit=100')
     ])
     const trainings = (trainingData.trainings || []).map((t) => ({
       ...t,
@@ -66,9 +66,14 @@ async function loadUpcoming() {
         ...e,
         kind: 'exam'
       }))
+    const now = new Date()
+    const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000)
     upcoming.value = [...trainings, ...exams]
+      .filter((e) => {
+        const start = new Date(e.start_at)
+        return start >= now && start < end
+      })
       .sort((a, b) => new Date(a.start_at) - new Date(b.start_at))
-      .slice(0, 3)
   } catch (_err) {
     upcoming.value = []
   } finally {

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -89,6 +89,7 @@ async function listUpcomingByUser(userId, options = {}) {
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
   const offset = (page - 1) * limit;
   const now = new Date();
+  const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
   const { rows } = await MedicalExam.findAndCountAll({
     include: [
       { model: MedicalCenter, include: [Address] },
@@ -103,7 +104,7 @@ async function listUpcomingByUser(userId, options = {}) {
         include: [MedicalExamRegistrationStatus],
       },
     ],
-    where: { start_at: { [Op.gt]: now } },
+    where: { start_at: { [Op.between]: [now, end] } },
     order: [['start_at', 'ASC']],
     limit,
     offset,

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -222,6 +222,7 @@ async function listUpcomingByUser(userId, options = {}) {
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
   const offset = (page - 1) * limit;
   const now = new Date();
+  const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
   const { rows } = await Training.findAndCountAll({
     include: [
       TrainingType,
@@ -232,7 +233,7 @@ async function listUpcomingByUser(userId, options = {}) {
         include: [User, TrainingRole],
       },
     ],
-    where: { start_at: { [Op.gte]: now } },
+    where: { start_at: { [Op.between]: [now, end] } },
     order: [['start_at', 'ASC']],
     limit,
     offset,


### PR DESCRIPTION
## Summary
- filter upcoming trainings and exams for the next 7 days
- request more items from API and filter client side

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686cd242e444832dbb3646fb14b394f0