### PR TITLE
Update admin exam registration numbering

### DIFF
--- a/client/src/views/AdminExamRegistrations.vue
+++ b/client/src/views/AdminExamRegistrations.vue
@@ -17,6 +17,17 @@ const error = ref('');
 
 const totalPages = computed(() => Math.max(1, Math.ceil(total.value / pageSize)));
 
+const approvedIndices = computed(() => {
+  let num = 0;
+  return list.value.map((r) => {
+    if (r.status === 'APPROVED') {
+      num += 1;
+      return num;
+    }
+    return null;
+  });
+});
+
 onMounted(() => {
   loadExam();
   loadRegistrations();
@@ -127,7 +138,7 @@ async function setStatus(userId, status) {
             </thead>
             <tbody>
               <tr v-for="(r, idx) in list" :key="r.user.id">
-                <td>{{ (page - 1) * pageSize + idx + 1 }}</td>
+                <td>{{ approvedIndices[idx] !== null ? approvedIndices[idx] : '' }}</td>
                 <td>{{ r.user.last_name }} {{ r.user.first_name }} {{ r.user.patronymic }}</td>
                 <td>{{ formatDateTime(r.created_at) }}</td>
                 <td>{{ r.user.email }}</td>


### PR DESCRIPTION
## Summary
- display numbering only for approved medical exam registrations in Admin panel

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686cd2bc2548832d81849457547fb155