### PR TITLE
Fix registration gender requirement

### DIFF
--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -5,6 +5,7 @@ import { User } from '../models/index.js';
 import emailVerificationService from '../services/emailVerificationService.js';
 import legacyService from '../services/legacyUserService.js';
 import userService from '../services/userService.js';
+import sexService from '../services/sexService.js';
 import authService from '../services/authService.js';
 import passportService from '../services/passportService.js';
 import bankAccountService from '../services/bankAccountService.js';
@@ -42,7 +43,8 @@ export default {
     };
     let user;
     try {
-      user = await userService.createUser(data);
+      const male = await sexService.getByAlias('MALE');
+      user = await userService.createUser({ ...data, sex_id: male.id });
     } catch (err) {
       return sendError(res, err);
     }

--- a/src/services/sexService.js
+++ b/src/services/sexService.js
@@ -1,7 +1,14 @@
 import { Sex } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
 
 async function list() {
   return Sex.findAll();
 }
 
-export default { list };
+async function getByAlias(alias) {
+  const sex = await Sex.findOne({ where: { alias } });
+  if (!sex) throw new ServiceError('sex_not_found', 404);
+  return sex;
+}
+
+export default { list, getByAlias };

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -53,6 +53,13 @@ jest.unstable_mockModule('../src/services/addressService.js', () => ({
   default: { fetchFromLegacy: fetchAddressMock },
 }));
 
+const getByAliasMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/sexService.js', () => ({
+  __esModule: true,
+  default: { getByAlias: getByAliasMock },
+}));
+
 
 const issueTokensMock = jest.fn(() => ({
   accessToken: 'a',
@@ -109,12 +116,15 @@ test('start returns code_sent when data is valid', async () => {
   };
   findUserMock.mockResolvedValueOnce(null); // no existing
   findLegacyMock.mockResolvedValueOnce(legacyUser);
+  getByAliasMock.mockResolvedValueOnce({ id: 'm1' });
   createUserMock.mockResolvedValueOnce({ id: 'u1' });
   findSystemMock.mockResolvedValueOnce(null);
   const req = { body: { email: 't@example.com' } };
   const res = createRes();
   await controller.start(req, res);
-  expect(createUserMock).toHaveBeenCalled();
+  expect(createUserMock).toHaveBeenCalledWith(
+    expect.objectContaining({ sex_id: 'm1' })
+  );
   expect(sendCodeMock).toHaveBeenCalled();
   expect(res.json).toHaveBeenCalledWith({ message: 'code_sent' });
 });
@@ -131,13 +141,14 @@ test('start keeps leading zeros in phone number', async () => {
   };
   findUserMock.mockResolvedValueOnce(null);
   findLegacyMock.mockResolvedValueOnce(legacyUser);
+  getByAliasMock.mockResolvedValueOnce({ id: 'm1' });
   createUserMock.mockResolvedValueOnce({ id: 'u1' });
   findSystemMock.mockResolvedValueOnce(null);
   const req = { body: { email: 't@example.com' } };
   const res = createRes();
   await controller.start(req, res);
   expect(createUserMock).toHaveBeenCalledWith(
-    expect.objectContaining({ phone: '7990123456' })
+    expect.objectContaining({ phone: '7990123456', sex_id: 'm1' })
   );
 });
 


### PR DESCRIPTION
## Summary
- add ability to fetch Sex by alias
- set default male sex when registering users
- adjust registration controller tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ce494059c832d817792ad78257d0b