### PR TITLE
Ensure audits for deletions

### DIFF
--- a/src/controllers/addressAdminController.js
+++ b/src/controllers/addressAdminController.js
@@ -58,7 +58,11 @@ export default {
 
   async remove(req, res) {
     try {
-      await addressService.removeForUser(req.params.id, req.params.type);
+      await addressService.removeForUser(
+        req.params.id,
+        req.params.type,
+        req.user.id
+      );
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/addressSelfController.js
+++ b/src/controllers/addressSelfController.js
@@ -43,7 +43,11 @@ export default {
 
   async remove(req, res) {
     try {
-      await addressService.removeForUser(req.user.id, req.params.type);
+      await addressService.removeForUser(
+        req.user.id,
+        req.params.type,
+        req.user.id
+      );
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/bankAccountAdminController.js
+++ b/src/controllers/bankAccountAdminController.js
@@ -78,7 +78,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await bankAccountService.removeForUser(req.params.id);
+      await bankAccountService.removeForUser(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/bankAccountSelfController.js
+++ b/src/controllers/bankAccountSelfController.js
@@ -37,7 +37,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await bankAccountService.removeForUser(req.user.id);
+      await bankAccountService.removeForUser(req.user.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/campStadiumAdminController.js
+++ b/src/controllers/campStadiumAdminController.js
@@ -55,7 +55,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await campStadiumService.remove(req.params.id);
+      await campStadiumService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/innAdminController.js
+++ b/src/controllers/innAdminController.js
@@ -52,7 +52,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await innService.remove(req.params.id);
+      await innService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/medicalCenterAdminController.js
+++ b/src/controllers/medicalCenterAdminController.js
@@ -55,7 +55,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await medicalCenterService.remove(req.params.id);
+      await medicalCenterService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/medicalCertificateAdminController.js
+++ b/src/controllers/medicalCertificateAdminController.js
@@ -103,7 +103,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await medicalCertificateService.remove(req.params.id);
+      await medicalCertificateService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/medicalCertificateFileController.js
+++ b/src/controllers/medicalCertificateFileController.js
@@ -56,7 +56,7 @@ async function remove(req, res) {
     if (cert.user_id !== req.user.id && !admin) {
       return res.status(403).json({ error: 'Доступ запрещён' });
     }
-    await fileService.remove(req.params.fileId);
+    await fileService.remove(req.params.fileId, req.user.id);
     return res.status(204).send();
   } catch (err) {
     return sendError(res, err, 400);

--- a/src/controllers/medicalCertificateSelfController.js
+++ b/src/controllers/medicalCertificateSelfController.js
@@ -26,7 +26,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await medicalCertificateService.removeForUser(req.user.id);
+      await medicalCertificateService.removeForUser(req.user.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/medicalExamAdminController.js
+++ b/src/controllers/medicalExamAdminController.js
@@ -55,7 +55,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await medicalExamService.remove(req.params.id);
+      await medicalExamService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/medicalExamRegistrationAdminController.js
+++ b/src/controllers/medicalExamRegistrationAdminController.js
@@ -51,7 +51,8 @@ export default {
     try {
       await medicalExamRegistrationService.remove(
         req.params.id,
-        req.params.userId
+        req.params.userId,
+        req.user.id
       );
       return res.status(204).end();
     } catch (err) {

--- a/src/controllers/medicalExamSelfController.js
+++ b/src/controllers/medicalExamSelfController.js
@@ -53,7 +53,8 @@ export default {
     try {
       await medicalExamRegistrationService.unregister(
         req.user.id,
-        req.params.id
+        req.params.id,
+        req.user.id
       );
       return res.status(204).end();
     } catch (err) {

--- a/src/controllers/passportSelfController.js
+++ b/src/controllers/passportSelfController.js
@@ -26,7 +26,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await passportService.removeByUser(req.user.id);
+      await passportService.removeByUser(req.user.id, req.user.id);
       return res.status(204).send();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/passwordResetController.js
+++ b/src/controllers/passwordResetController.js
@@ -28,7 +28,7 @@ export default {
     if (!user) return res.status(404).json({ error: 'not_found' });
     try {
       await passwordResetService.verifyCode(user, code);
-      await userService.resetPassword(user.id, password);
+      await userService.resetPassword(user.id, password, user.id);
       return res.json({ message: 'password_updated' });
     } catch (err) {
       return sendError(res, err);

--- a/src/controllers/profileCompletionController.js
+++ b/src/controllers/profileCompletionController.js
@@ -6,7 +6,8 @@ export default {
     try {
       const user = await userService.setStatus(
         req.user.id,
-        'AWAITING_CONFIRMATION'
+        'AWAITING_CONFIRMATION',
+        req.user.id
       );
       return res.json({
         user: { id: user.id, status: 'AWAITING_CONFIRMATION' },
@@ -22,7 +23,7 @@ export default {
       return res.status(400).json({ error: 'status_required' });
     }
     try {
-      const user = await userService.setStatus(req.user.id, status);
+      const user = await userService.setStatus(req.user.id, status, req.user.id);
       return res.json({ user: { id: user.id, status } });
     } catch (err) {
       return sendError(res, err);

--- a/src/controllers/refereeGroupAdminController.js
+++ b/src/controllers/refereeGroupAdminController.js
@@ -56,7 +56,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await refereeGroupService.remove(req.params.id);
+      await refereeGroupService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/refereeGroupUserAdminController.js
+++ b/src/controllers/refereeGroupUserAdminController.js
@@ -44,7 +44,7 @@ export default {
 
   async clearGroup(req, res) {
     try {
-      await refereeGroupService.removeUser(req.params.id);
+      await refereeGroupService.removeUser(req.params.id, req.user.id);
       const user = await refereeGroupService.getReferee(req.params.id);
       return res.json({
         judge: {

--- a/src/controllers/registrationController.js
+++ b/src/controllers/registrationController.js
@@ -82,7 +82,7 @@ export default {
         code,
         'REGISTRATION_STEP_1'
       );
-      await userService.resetPassword(user.id, password);
+      await userService.resetPassword(user.id, password, user.id);
       await addressService.fetchFromLegacy(user.id);
       await bankAccountService.fetchFromLegacy(user.id);
       await passportService.fetchFromLegacy(user.id);

--- a/src/controllers/snilsAdminController.js
+++ b/src/controllers/snilsAdminController.js
@@ -52,7 +52,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await snilsService.remove(req.params.id);
+      await snilsService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/trainingAdminController.js
+++ b/src/controllers/trainingAdminController.js
@@ -57,7 +57,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await trainingService.remove(req.params.id);
+      await trainingService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/trainingRegistrationAdminController.js
+++ b/src/controllers/trainingRegistrationAdminController.js
@@ -68,7 +68,8 @@ export default {
     try {
       await trainingRegistrationService.remove(
         req.params.id,
-        req.params.userId
+        req.params.userId,
+        req.user.id
       );
       return res.status(204).end();
     } catch (err) {

--- a/src/controllers/trainingSelfController.js
+++ b/src/controllers/trainingSelfController.js
@@ -45,7 +45,11 @@ export default {
 
   async unregister(req, res) {
     try {
-      await trainingRegistrationService.unregister(req.user.id, req.params.id);
+      await trainingRegistrationService.unregister(
+        req.user.id,
+        req.params.id,
+        req.user.id
+      );
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/trainingTypeAdminController.js
+++ b/src/controllers/trainingTypeAdminController.js
@@ -55,7 +55,7 @@ export default {
 
   async remove(req, res) {
     try {
-      await trainingTypeService.remove(req.params.id);
+      await trainingTypeService.remove(req.params.id, req.user.id);
       return res.status(204).end();
     } catch (err) {
       return sendError(res, err, 404);

--- a/src/controllers/userAdminController.js
+++ b/src/controllers/userAdminController.js
@@ -46,7 +46,7 @@ export default {
     if (!errors.isEmpty()) {
       return res.status(400).json({ errors: errors.array() });
     }
-    const user = await userService.createUser(req.body);
+    const user = await userService.createUser(req.body, req.user.id);
     return res.status(201).json({ user: userMapper.toPublic(user) });
   },
 
@@ -56,7 +56,11 @@ export default {
       return res.status(400).json({ errors: errors.array() });
     }
     try {
-      const user = await userService.updateUser(req.params.id, req.body);
+      const user = await userService.updateUser(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
       return sendError(res, err, 404);
@@ -65,7 +69,11 @@ export default {
 
   async block(req, res) {
     try {
-      const user = await userService.setStatus(req.params.id, 'INACTIVE');
+      const user = await userService.setStatus(
+        req.params.id,
+        'INACTIVE',
+        req.user.id
+      );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
       return sendError(res, err, 404);
@@ -74,7 +82,11 @@ export default {
 
   async unblock(req, res) {
     try {
-      const user = await userService.setStatus(req.params.id, 'ACTIVE');
+      const user = await userService.setStatus(
+        req.params.id,
+        'ACTIVE',
+        req.user.id
+      );
       await emailService.sendAccountActivatedEmail(user);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
@@ -84,7 +96,11 @@ export default {
 
   async approve(req, res) {
     try {
-      const user = await userService.setStatus(req.params.id, 'ACTIVE');
+      const user = await userService.setStatus(
+        req.params.id,
+        'ACTIVE',
+        req.user.id
+      );
       await emailService.sendAccountActivatedEmail(user);
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
@@ -100,7 +116,8 @@ export default {
     try {
       const user = await userService.resetPassword(
         req.params.id,
-        req.body.password
+        req.body.password,
+        req.user.id
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
@@ -112,7 +129,8 @@ export default {
     try {
       const user = await userService.assignRole(
         req.params.id,
-        req.params.roleAlias
+        req.params.roleAlias,
+        req.user.id
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
@@ -124,7 +142,8 @@ export default {
     try {
       const user = await userService.removeRole(
         req.params.id,
-        req.params.roleAlias
+        req.params.roleAlias,
+        req.user.id
       );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {

--- a/src/controllers/userSelfController.js
+++ b/src/controllers/userSelfController.js
@@ -11,7 +11,11 @@ export default {
       return res.status(400).json({ errors: errors.array() });
     }
     try {
-      const user = await userService.updateUser(req.user.id, req.body);
+      const user = await userService.updateUser(
+        req.user.id,
+        req.body,
+        req.user.id
+      );
       return res.json({ user: userMapper.toPublic(user) });
     } catch (err) {
       return sendError(res, err);

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -1,3 +1,6 @@
+import { DataTypes } from 'sequelize';
+import sequelize from '../config/database.js';
+
 import User from './user.js';
 import Role from './role.js';
 import UserRole from './userRole.js';
@@ -188,6 +191,15 @@ Passport.belongsTo(Country, { foreignKey: 'country_id' });
 /* email verification codes */
 User.hasMany(EmailCode, { foreignKey: 'user_id' });
 EmailCode.belongsTo(User, { foreignKey: 'user_id' });
+
+const auditExclude = ['Log'];
+for (const model of Object.values(sequelize.models)) {
+  if (!auditExclude.includes(model.name)) {
+    model.rawAttributes.created_by = { type: DataTypes.UUID };
+    model.rawAttributes.updated_by = { type: DataTypes.UUID };
+    model.refreshAttributes();
+  }
+}
 
 export {
   User,

--- a/src/services/addressService.js
+++ b/src/services/addressService.js
@@ -69,7 +69,7 @@ async function updateForUser(userId, alias, data, actorId) {
   return addr;
 }
 
-async function removeForUser(userId, alias) {
+async function removeForUser(userId, alias, actorId = null) {
   const type = await AddressType.findOne({ where: { alias } });
   if (!type) throw new ServiceError('address_type_not_found', 404);
   const ua = await UserAddress.findOne({
@@ -77,7 +77,9 @@ async function removeForUser(userId, alias) {
     include: [Address],
   });
   if (!ua) throw new ServiceError('address_not_found', 404);
+  await ua.Address.update({ updated_by: actorId });
   await ua.Address.destroy();
+  await ua.update({ updated_by: actorId });
   await ua.destroy();
 }
 

--- a/src/services/bankAccountService.js
+++ b/src/services/bankAccountService.js
@@ -37,9 +37,10 @@ async function updateForUser(userId, data, actorId) {
   return acc;
 }
 
-async function removeForUser(userId) {
+async function removeForUser(userId, actorId = null) {
   const acc = await BankAccount.findOne({ where: { user_id: userId } });
   if (!acc) throw new ServiceError('bank_account_not_found', 404);
+  await acc.update({ updated_by: actorId });
   await acc.destroy();
 }
 

--- a/src/services/campStadiumService.js
+++ b/src/services/campStadiumService.js
@@ -103,10 +103,14 @@ async function update(id, data, actorId) {
   return getById(id);
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const stadium = await CampStadium.findByPk(id, { include: [Address] });
   if (!stadium) throw new ServiceError('stadium_not_found', 404);
-  if (stadium.Address) await stadium.Address.destroy();
+  if (stadium.Address) {
+    await stadium.Address.update({ updated_by: actorId });
+    await stadium.Address.destroy();
+  }
+  await stadium.update({ updated_by: actorId });
   await stadium.destroy();
 }
 

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -88,12 +88,14 @@ async function getDownloadUrl(file) {
   );
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const attachment = await MedicalCertificateFile.findOne({
     where: { file_id: id },
     include: [File],
   });
   if (!attachment) throw new ServiceError('file_not_found', 404);
+  await attachment.update({ updated_by: actorId });
+  await attachment.File.update({ updated_by: actorId });
   await attachment.destroy();
   await attachment.File.destroy();
 }

--- a/src/services/innService.js
+++ b/src/services/innService.js
@@ -34,9 +34,10 @@ async function update(userId, number, actorId) {
   return inn;
 }
 
-async function remove(userId) {
+async function remove(userId, actorId = null) {
   const inn = await Inn.findOne({ where: { user_id: userId } });
   if (!inn) throw new ServiceError('inn_not_found', 404);
+  await inn.update({ updated_by: actorId });
   await inn.destroy();
   await taxationService.removeByUser(userId);
 }

--- a/src/services/medicalCenterService.js
+++ b/src/services/medicalCenterService.js
@@ -83,10 +83,14 @@ async function update(id, data, actorId) {
   return getById(id);
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const center = await MedicalCenter.findByPk(id, { include: [Address] });
   if (!center) throw new ServiceError('center_not_found', 404);
-  if (center.Address) await center.Address.destroy();
+  if (center.Address) {
+    await center.Address.update({ updated_by: actorId });
+    await center.Address.destroy();
+  }
+  await center.update({ updated_by: actorId });
   await center.destroy();
 }
 

--- a/src/services/medicalCertificateService.js
+++ b/src/services/medicalCertificateService.js
@@ -47,12 +47,13 @@ async function createForUser(userId, data, actorId) {
   return certificate;
 }
 
-async function removeForUser(userId) {
+async function removeForUser(userId, actorId = null) {
   const cert = await MedicalCertificate.findOne({
     where: { user_id: userId },
     order: [['valid_until', 'DESC']],
   });
   if (!cert) throw new ServiceError('certificate_not_found', 404);
+  await cert.update({ updated_by: actorId });
   await cert.destroy();
 }
 
@@ -157,9 +158,10 @@ async function update(id, data, actorId) {
   return cert;
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const cert = await MedicalCertificate.findByPk(id);
   if (!cert) throw new ServiceError('certificate_not_found', 404);
+  await cert.update({ updated_by: actorId });
   await cert.destroy();
 }
 

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -242,7 +242,7 @@ async function register(userId, examId, actorId) {
   }
 }
 
-async function unregister(userId, examId) {
+async function unregister(userId, examId, actorId = null) {
   const reg = await MedicalExamRegistration.findOne({
     where: { medical_exam_id: examId, user_id: userId },
   });
@@ -250,6 +250,7 @@ async function unregister(userId, examId) {
   const pendingId = await getStatusId('PENDING');
   if (reg.status_id !== pendingId)
     throw new ServiceError('cancellation_forbidden');
+  await reg.update({ updated_by: actorId });
   await reg.destroy();
   const [exam, user] = await Promise.all([
     MedicalExam.findByPk(examId, {
@@ -301,11 +302,12 @@ async function setStatus(examId, userId, status, actorId) {
   }
 }
 
-async function remove(examId, userId) {
+async function remove(examId, userId, actorId = null) {
   const reg = await MedicalExamRegistration.findOne({
     where: { medical_exam_id: examId, user_id: userId },
   });
   if (!reg) throw new ServiceError('registration_not_found', 404);
+  await reg.update({ updated_by: actorId });
   await reg.destroy();
   const [exam, user] = await Promise.all([
     MedicalExam.findByPk(examId, {

--- a/src/services/medicalExamService.js
+++ b/src/services/medicalExamService.js
@@ -47,9 +47,10 @@ async function update(id, data, actorId) {
   return getById(id);
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const exam = await MedicalExam.findByPk(id);
   if (!exam) throw new ServiceError('exam_not_found', 404);
+  await exam.update({ updated_by: actorId });
   await exam.destroy();
 }
 

--- a/src/services/passportService.js
+++ b/src/services/passportService.js
@@ -81,9 +81,10 @@ async function createForUser(userId, data, adminId) {
   return getByUser(userId);
 }
 
-async function removeByUser(userId) {
+async function removeByUser(userId, actorId = null) {
   const passport = await Passport.findOne({ where: { user_id: userId } });
   if (!passport) throw new ServiceError('passport_not_found', 404);
+  await passport.update({ updated_by: actorId });
   await passport.destroy();
   return true;
 }

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -134,16 +134,20 @@ async function setUserGroup(userId, groupId, actorId) {
   return link;
 }
 
-async function removeUser(userId) {
+async function removeUser(userId, actorId = null) {
   const link = await RefereeGroupUser.findOne({ where: { user_id: userId } });
-  if (link) await link.destroy();
+  if (link) {
+    await link.update({ updated_by: actorId });
+    await link.destroy();
+  }
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const group = await RefereeGroup.findByPk(id);
   if (!group) throw new ServiceError('referee_group_not_found', 404);
   const userCount = await RefereeGroupUser.count({ where: { group_id: id } });
   if (userCount > 0) throw new ServiceError('referee_group_not_empty');
+  await group.update({ updated_by: actorId });
   await group.destroy();
 }
 

--- a/src/services/seasonService.js
+++ b/src/services/seasonService.js
@@ -51,9 +51,10 @@ async function getActive() {
   return Season.findOne({ where: { active: true } });
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const season = await Season.findByPk(id);
   if (!season) throw new ServiceError('season_not_found', 404);
+  await season.update({ updated_by: actorId });
   await season.destroy();
 }
 

--- a/src/services/snilsService.js
+++ b/src/services/snilsService.js
@@ -31,9 +31,10 @@ async function update(userId, number, actorId) {
   return snils;
 }
 
-async function remove(userId) {
+async function remove(userId, actorId = null) {
   const snils = await Snils.findOne({ where: { user_id: userId } });
   if (!snils) throw new ServiceError('snils_not_found', 404);
+  await snils.update({ updated_by: actorId });
   await snils.destroy();
 }
 

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -136,7 +136,7 @@ async function register(userId, trainingId, actorId) {
   }
 }
 
-async function unregister(userId, trainingId) {
+async function unregister(userId, trainingId, actorId = null) {
   const registration = await TrainingRegistration.findOne({
     where: { training_id: trainingId, user_id: userId },
     include: [TrainingRole],
@@ -162,6 +162,7 @@ async function unregister(userId, trainingId) {
   if (!training || !trainingService.isRegistrationOpen(training, count)) {
     throw new ServiceError('registration_closed');
   }
+  await registration.update({ updated_by: actorId });
   await registration.destroy();
 
   const user = await User.findByPk(userId);
@@ -292,11 +293,12 @@ async function listByTraining(trainingId, options = {}) {
   });
 }
 
-async function remove(trainingId, userId) {
+async function remove(trainingId, userId, actorId = null) {
   const registration = await TrainingRegistration.findOne({
     where: { training_id: trainingId, user_id: userId },
   });
   if (!registration) throw new ServiceError('registration_not_found', 404);
+  await registration.update({ updated_by: actorId });
   await registration.destroy();
   const [training, user] = await Promise.all([
     Training.findByPk(trainingId, {

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -167,9 +167,10 @@ async function update(id, data, actorId) {
   return getById(id);
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const training = await Training.findByPk(id);
   if (!training) throw new ServiceError('training_not_found', 404);
+  await training.update({ updated_by: actorId });
   await training.destroy();
 }
 

--- a/src/services/trainingTypeService.js
+++ b/src/services/trainingTypeService.js
@@ -45,9 +45,10 @@ async function update(id, data, actorId) {
   return type;
 }
 
-async function remove(id) {
+async function remove(id, actorId = null) {
   const type = await TrainingType.findByPk(id);
   if (!type) throw new ServiceError('training_type_not_found', 404);
+  await type.update({ updated_by: actorId });
   await type.destroy();
 }
 

--- a/tests/innService.test.js
+++ b/tests/innService.test.js
@@ -60,15 +60,21 @@ test('update throws when record missing', async () => {
 
 test('remove destroys record and taxation removed', async () => {
   const destroyMock = jest.fn();
-  findOneMock.mockResolvedValueOnce({ ...innInstance, destroy: destroyMock });
+  const updateMockLocal = jest.fn();
+  findOneMock.mockResolvedValueOnce({
+    ...innInstance,
+    destroy: destroyMock,
+    update: updateMockLocal,
+  });
   const taxation = await import('../src/services/taxationService.js');
-  await service.remove('u1');
+  await service.remove('u1', 'admin');
+  expect(updateMockLocal).toHaveBeenCalledWith({ updated_by: 'admin' });
   expect(destroyMock).toHaveBeenCalled();
   expect(taxation.default.removeByUser).toHaveBeenCalledWith('u1');
 });
 
 test('remove throws when record not found', async () => {
   findOneMock.mockResolvedValueOnce(null);
-  await expect(service.remove('u1')).rejects.toThrow('inn_not_found');
+  await expect(service.remove('u1', 'admin')).rejects.toThrow('inn_not_found');
 });
 

--- a/tests/passwordResetController.test.js
+++ b/tests/passwordResetController.test.js
@@ -80,7 +80,7 @@ test('finish resets password when code valid', async () => {
   const res = createRes();
   await controller.finish(req, res);
   expect(verifyCodeMock).toHaveBeenCalledWith(user, '123');
-  expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd');
+  expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd', 'u1');
   expect(res.json).toHaveBeenCalledWith({ message: 'password_updated' });
 });
 

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -30,14 +30,15 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
 const { default: service } = await import('../src/services/refereeGroupService.js');
 
 test('removeUser soft deletes assignment', async () => {
-  findOneMock.mockResolvedValue({ destroy: destroyMock });
-  await service.removeUser('u1');
+  findOneMock.mockResolvedValue({ destroy: destroyMock, update: updateMock });
+  await service.removeUser('u1', 'admin');
+  expect(updateMock).toHaveBeenCalledWith({ updated_by: 'admin' });
   expect(destroyMock).toHaveBeenCalled();
 });
 
 test('removeUser does nothing when link missing', async () => {
   findOneMock.mockResolvedValue(null);
-  await service.removeUser('u1');
+  await service.removeUser('u1', 'admin');
   expect(destroyMock).not.toHaveBeenCalled();
 });
 
@@ -53,8 +54,8 @@ test('setUserGroup restores deleted record', async () => {
 
 test('user can be reassigned after removal', async () => {
   // soft delete existing assignment
-  findOneMock.mockResolvedValueOnce({ destroy: destroyMock });
-  await service.removeUser('u1');
+  findOneMock.mockResolvedValueOnce({ destroy: destroyMock, update: updateMock });
+  await service.removeUser('u1', 'admin');
   expect(destroyMock).toHaveBeenCalled();
 
   // assign user to a group again

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -184,7 +184,7 @@ test('finish issues tokens after valid code', async () => {
     '123',
     'REGISTRATION_STEP_1'
   );
-  expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd');
+  expect(resetPasswordMock).toHaveBeenCalledWith('u1', 'Passw0rd', 'u1');
   expect(fetchAddressMock).toHaveBeenCalledWith('u1');
   expect(fetchBankMock).toHaveBeenCalledWith('u1');
   expect(fetchPassportMock).toHaveBeenCalledWith('u1');

--- a/tests/seasonService.test.js
+++ b/tests/seasonService.test.js
@@ -72,13 +72,15 @@ test('update modifies existing season', async () => {
 });
 
 test('remove deletes season', async () => {
-  findByPkMock.mockResolvedValue({ destroy: destroyMock });
-  await service.remove('s1');
+  const updateMockLocal = jest.fn();
+  findByPkMock.mockResolvedValue({ destroy: destroyMock, update: updateMockLocal });
+  await service.remove('s1', 'admin');
+  expect(updateMockLocal).toHaveBeenCalledWith({ updated_by: 'admin' });
   expect(destroyMock).toHaveBeenCalled();
 });
 
 test('remove throws when missing', async () => {
   findByPkMock.mockResolvedValue(null);
-  await expect(service.remove('s1')).rejects.toThrow('season_not_found');
+  await expect(service.remove('s1', 'admin')).rejects.toThrow('season_not_found');
 });
 

--- a/tests/snilsService.test.js
+++ b/tests/snilsService.test.js
@@ -56,12 +56,18 @@ test('update throws when record missing', async () => {
 
 test('remove deletes snils', async () => {
   const destroyMock = jest.fn();
-  findOneMock.mockResolvedValueOnce({ ...snilsInstance, destroy: destroyMock });
-  await service.remove('u1');
+  const updateMockLocal = jest.fn();
+  findOneMock.mockResolvedValueOnce({
+    ...snilsInstance,
+    destroy: destroyMock,
+    update: updateMockLocal,
+  });
+  await service.remove('u1', 'admin');
+  expect(updateMockLocal).toHaveBeenCalledWith({ updated_by: 'admin' });
   expect(destroyMock).toHaveBeenCalled();
 });
 
 test('remove throws when not found', async () => {
   findOneMock.mockResolvedValueOnce(null);
-  await expect(service.remove('u1')).rejects.toThrow('snils_not_found');
+  await expect(service.remove('u1', 'admin')).rejects.toThrow('snils_not_found');
 });

--- a/tests/trainingTypeService.test.js
+++ b/tests/trainingTypeService.test.js
@@ -51,12 +51,16 @@ test('create generates alias from name', async () => {
 });
 
 test('remove deletes training type', async () => {
-  findByPkMock.mockResolvedValue({ ...instance });
-  await service.remove('t1');
+  const updateMockLocal = jest.fn();
+  findByPkMock.mockResolvedValue({ ...instance, update: updateMockLocal });
+  await service.remove('t1', 'admin');
+  expect(updateMockLocal).toHaveBeenCalledWith({ updated_by: 'admin' });
   expect(destroyMock).toHaveBeenCalled();
 });
 
 test('remove throws when not found', async () => {
   findByPkMock.mockResolvedValue(null);
-  await expect(service.remove('t1')).rejects.toThrow('training_type_not_found');
+  await expect(service.remove('t1', 'admin')).rejects.toThrow(
+    'training_type_not_found'
+  );
 });

--- a/tests/userAdminController.test.js
+++ b/tests/userAdminController.test.js
@@ -55,29 +55,29 @@ beforeEach(() => {
 
 test('approve updates user status to ACTIVE', async () => {
   setStatusMock.mockResolvedValue({ id: '1' });
-  const req = { params: { id: '1' } };
+  const req = { params: { id: '1' }, user: { id: 'admin' } };
   const res = { json: jest.fn() };
   await controller.approve(req, res);
-  expect(setStatusMock).toHaveBeenCalledWith('1', 'ACTIVE');
+  expect(setStatusMock).toHaveBeenCalledWith('1', 'ACTIVE', 'admin');
   expect(sendActivationEmailMock).toHaveBeenCalledWith({ id: '1' });
   expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
 });
 
 test('block updates user status to INACTIVE', async () => {
   setStatusMock.mockResolvedValue({ id: '2' });
-  const req = { params: { id: '2' } };
+  const req = { params: { id: '2' }, user: { id: 'admin' } };
   const res = { json: jest.fn() };
   await controller.block(req, res);
-  expect(setStatusMock).toHaveBeenCalledWith('2', 'INACTIVE');
+  expect(setStatusMock).toHaveBeenCalledWith('2', 'INACTIVE', 'admin');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '2' } });
 });
 
 test('unblock updates user status to ACTIVE', async () => {
   setStatusMock.mockResolvedValue({ id: '3' });
-  const req = { params: { id: '3' } };
+  const req = { params: { id: '3' }, user: { id: 'admin' } };
   const res = { json: jest.fn() };
   await controller.unblock(req, res);
-  expect(setStatusMock).toHaveBeenCalledWith('3', 'ACTIVE');
+  expect(setStatusMock).toHaveBeenCalledWith('3', 'ACTIVE', 'admin');
   expect(sendActivationEmailMock).toHaveBeenCalledWith({ id: '3' });
   expect(res.json).toHaveBeenCalledWith({ user: { id: '3' } });
 });
@@ -85,28 +85,28 @@ test('unblock updates user status to ACTIVE', async () => {
 
 test('resetPassword returns updated user', async () => {
   resetPasswordMock.mockResolvedValue({ id: '4' });
-  const req = { params: { id: '4' }, body: { password: 'P' } };
+  const req = { params: { id: '4' }, body: { password: 'P' }, user: { id: 'admin' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.resetPassword(req, res);
-  expect(resetPasswordMock).toHaveBeenCalledWith('4', 'P');
+  expect(resetPasswordMock).toHaveBeenCalledWith('4', 'P', 'admin');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '4' } });
 });
 
 test('assignRole assigns role to user', async () => {
   assignRoleMock.mockResolvedValue({ id: '5' });
-  const req = { params: { id: '5', roleAlias: 'ADMIN' } };
+  const req = { params: { id: '5', roleAlias: 'ADMIN' }, user: { id: 'admin' } };
   const res = { json: jest.fn() };
   await controller.assignRole(req, res);
-  expect(assignRoleMock).toHaveBeenCalledWith('5', 'ADMIN');
+  expect(assignRoleMock).toHaveBeenCalledWith('5', 'ADMIN', 'admin');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '5' } });
 });
 
 test('removeRole removes role from user', async () => {
   removeRoleMock.mockResolvedValue({ id: '6' });
-  const req = { params: { id: '6', roleAlias: 'ADMIN' } };
+  const req = { params: { id: '6', roleAlias: 'ADMIN' }, user: { id: 'admin' } };
   const res = { json: jest.fn() };
   await controller.removeRole(req, res);
-  expect(removeRoleMock).toHaveBeenCalledWith('6', 'ADMIN');
+  expect(removeRoleMock).toHaveBeenCalledWith('6', 'ADMIN', 'admin');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '6' } });
 });
 

--- a/tests/userSelfController.test.js
+++ b/tests/userSelfController.test.js
@@ -39,6 +39,6 @@ test('update returns updated user', async () => {
   const req = { user: { id: '1' }, body: { first_name: 'A' } };
   const res = { json: jest.fn(), status: jest.fn().mockReturnThis() };
   await controller.update(req, res);
-  expect(updateUserMock).toHaveBeenCalledWith('1', { first_name: 'A' });
+  expect(updateUserMock).toHaveBeenCalledWith('1', { first_name: 'A' }, '1');
   expect(res.json).toHaveBeenCalledWith({ user: { id: '1' } });
 });


### PR DESCRIPTION
## Summary
- track actor ID when deleting or unregistering records
- propagate actor ID from controllers to services on removals
- keep deletion audit info for files, personal data and registrations
- update unit tests for new audit parameters

## Testing
- ❌ `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d164fe2dc832d9a94bb3443378f6f