### PR TITLE
Implement attendance marking UI

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -16,6 +16,7 @@ import AdminCampStadiums from './views/AdminCampStadiums.vue';
 import AdminRefereeGroups from './views/AdminRefereeGroups.vue';
 import AdminMedicalManagement from './views/AdminMedicalManagement.vue';
 import AdminExamRegistrations from './views/AdminExamRegistrations.vue';
+import TrainingAttendance from './views/TrainingAttendance.vue';
 import PasswordReset from './views/PasswordReset.vue';
 import NotFound from './views/NotFound.vue';
 import Forbidden from './views/Forbidden.vue';
@@ -33,6 +34,11 @@ const routes = [
     path: '/camps',
     component: Camps,
     meta: { requiresAuth: true, requiresReferee: true },
+  },
+  {
+    path: '/trainings/:id/attendance',
+    component: TrainingAttendance,
+    meta: { requiresAuth: true },
   },
   {
     path: '/admin',

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -363,6 +363,16 @@ function dayOpen(day) {
                     <i class="bi bi-x-lg" aria-hidden="true"></i>
                     <span class="visually-hidden">Отменить</span>
                   </button>
+                  <RouterLink
+                    v-if="t.my_role?.alias === 'COACH'"
+                    :to="`/trainings/${t.id}/attendance`"
+                    class="btn btn-link p-0 ms-2"
+                    :class="t.attendance_marked ? 'text-success' : 'text-secondary'"
+                    :title="t.attendance_marked ? 'Посещаемость отмечена' : 'Отметить посещаемость'"
+                  >
+                    <i class="bi bi-check2-square" aria-hidden="true"></i>
+                    <span class="visually-hidden">Посещаемость</span>
+                  </RouterLink>
                 </li>
               </ul>
             </div>

--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -1,0 +1,162 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useRoute, RouterLink } from 'vue-router';
+import { apiFetch } from '../api.js';
+import Toast from 'bootstrap/js/dist/toast';
+
+const route = useRoute();
+const training = ref(null);
+const registrations = ref([]);
+const loading = ref(false);
+const error = ref('');
+const toastRef = ref(null);
+const toastMessage = ref('');
+let toast;
+
+onMounted(loadData);
+
+async function loadData() {
+  loading.value = true;
+  try {
+    const data = await apiFetch(`/camp-trainings/${route.params.id}/attendance`);
+    training.value = data.training;
+    registrations.value = data.registrations || [];
+    error.value = '';
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    loading.value = false;
+  }
+}
+
+function formatDateTime(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  return d.toLocaleString('ru-RU', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
+
+async function setPresence(userId, value) {
+  try {
+    await apiFetch(`/camp-trainings/${route.params.id}/registrations/${userId}/presence`, {
+      method: 'PUT',
+      body: JSON.stringify({ present: value }),
+    });
+    showToast('Сохранено');
+    await loadData();
+  } catch (e) {
+    alert(e.message);
+  }
+}
+
+async function finish() {
+  try {
+    await apiFetch(`/camp-trainings/${route.params.id}/attendance`, {
+      method: 'PUT',
+      body: JSON.stringify({ attendance_marked: true }),
+    });
+    showToast('Посещаемость отмечена');
+    await loadData();
+  } catch (e) {
+    alert(e.message);
+  }
+}
+
+function showToast(message) {
+  toastMessage.value = message;
+  if (!toast) {
+    toast = new Toast(toastRef.value);
+  }
+  toast.show();
+}
+</script>
+
+<template>
+  <div class="py-3 training-attendance-page">
+    <div class="container">
+      <nav aria-label="breadcrumb" class="mb-3">
+        <ol class="breadcrumb mb-0">
+          <li class="breadcrumb-item">
+            <RouterLink to="/camps">Мои тренировки</RouterLink>
+          </li>
+          <li class="breadcrumb-item active" aria-current="page">Посещаемость</li>
+        </ol>
+      </nav>
+      <h1 class="mb-3">Посещаемость</h1>
+      <div v-if="error" class="alert alert-danger">{{ error }}</div>
+      <div v-if="loading" class="text-center my-5">
+        <div class="spinner-border" role="status" aria-label="Загрузка">
+          <span class="visually-hidden">Загрузка…</span>
+        </div>
+      </div>
+      <div v-else>
+        <p v-if="training" class="mb-3">
+          <strong>{{ training.type?.name }}</strong>,
+          {{ formatDateTime(training.start_at) }} –
+          {{ new Date(training.end_at).toLocaleTimeString('ru-RU', { hour: '2-digit', minute: '2-digit' }) }}
+        </p>
+        <div v-if="registrations.length" class="card section-card tile fade-in shadow-sm">
+          <div class="card-body table-responsive p-3">
+            <table class="table table-striped align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Участник</th>
+                  <th>Роль</th>
+                  <th class="text-end">Присутствие</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="r in registrations" :key="r.user.id">
+                  <td>{{ r.user.last_name }} {{ r.user.first_name }}</td>
+                  <td>{{ r.role?.name }}</td>
+                  <td class="text-end">
+                    <select
+                      class="form-select form-select-sm w-auto d-inline"
+                      :value="r.present === null ? '' : r.present"
+                      @change="setPresence(r.user.id, $event.target.value === '' ? null : $event.target.value === 'true')"
+                    >
+                      <option value="">Не отмечено</option>
+                      <option :value="true">Да</option>
+                      <option :value="false">Нет</option>
+                    </select>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+        <p v-else class="text-muted">Нет записей</p>
+        <button class="btn btn-brand mt-3" @click="finish" :disabled="!registrations.length">
+          Завершить
+        </button>
+      </div>
+      <div class="toast-container position-fixed bottom-0 end-0 p-3">
+        <div ref="toastRef" class="toast text-bg-secondary" role="status" data-bs-delay="1500" data-bs-autohide="true">
+          <div class="toast-body">{{ toastMessage }}</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 575.98px) {
+  .training-attendance-page {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+</style>

--- a/src/controllers/trainingAdminController.js
+++ b/src/controllers/trainingAdminController.js
@@ -55,6 +55,23 @@ export default {
     }
   },
 
+  async setAttendance(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const training = await trainingService.setAttendanceMarked(
+        req.params.id,
+        req.body.attendance_marked,
+        req.user.id
+      );
+      return res.json({ training: mapper.toPublic(training) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
   async remove(req, res) {
     try {
       await trainingService.remove(req.params.id);

--- a/src/controllers/trainingRegistrationAdminController.js
+++ b/src/controllers/trainingRegistrationAdminController.js
@@ -2,6 +2,7 @@ import { validationResult } from 'express-validator';
 
 import trainingRegistrationService from '../services/trainingRegistrationService.js';
 import userMapper from '../mappers/userMapper.js';
+import trainingMapper from '../mappers/trainingMapper.js';
 import { sendError } from '../utils/api.js';
 
 export default {
@@ -21,8 +22,35 @@ export default {
               alias: r.TrainingRole.alias,
             }
           : null,
+        present: r.present,
       }));
       return res.json({ registrations, total: count });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async listForAttendance(req, res) {
+    try {
+      const { rows, training } = await trainingRegistrationService.listForAttendance(
+        req.params.id,
+        req.user.id
+      );
+      const registrations = rows.map((r) => ({
+        user: userMapper.toPublic(r.User),
+        role: r.TrainingRole
+          ? {
+              id: r.TrainingRole.id,
+              name: r.TrainingRole.name,
+              alias: r.TrainingRole.alias,
+            }
+          : null,
+        present: r.present,
+      }));
+      return res.json({
+        training: trainingMapper.toPublic(training),
+        registrations,
+      });
     } catch (err) {
       return sendError(res, err, 404);
     }
@@ -56,6 +84,20 @@ export default {
         req.params.id,
         req.params.userId,
         req.body.training_role_id,
+        req.user.id
+      );
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async updatePresence(req, res) {
+    try {
+      await trainingRegistrationService.updatePresence(
+        req.params.id,
+        req.params.userId,
+        req.body.present,
         req.user.id
       );
       return res.status(204).end();

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -9,6 +9,7 @@ function sanitize(obj) {
     capacity,
     camp_stadium_id,
     season_id,
+    attendance_marked,
     TrainingType,
     CampStadium,
     Season,
@@ -26,6 +27,7 @@ function sanitize(obj) {
     registration_open: obj.registration_open,
     registered: obj.user_registered,
     registered_count,
+    attendance_marked,
   };
   if (TrainingType) {
     res.type = {

--- a/src/migrations/20250906004200-add-present-to-training-registrations.js
+++ b/src/migrations/20250906004200-add-present-to-training-registrations.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('training_registrations', 'present', {
+      type: Sequelize.BOOLEAN,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('training_registrations', 'present');
+  },
+};

--- a/src/migrations/20250906004300-add-attendance-marked-to-trainings.js
+++ b/src/migrations/20250906004300-add-attendance-marked-to-trainings.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('trainings', 'attendance_marked', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('trainings', 'attendance_marked');
+  },
+};

--- a/src/models/training.js
+++ b/src/models/training.js
@@ -17,6 +17,11 @@ Training.init(
     end_at: { type: DataTypes.DATE, allowNull: false },
     capacity: { type: DataTypes.INTEGER },
     camp_stadium_id: { type: DataTypes.UUID },
+    attendance_marked: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    },
   },
   {
     sequelize,

--- a/src/models/trainingRegistration.js
+++ b/src/models/trainingRegistration.js
@@ -11,6 +11,7 @@ TrainingRegistration.init(
       defaultValue: DataTypes.UUIDV4,
       primaryKey: true,
     },
+    present: { type: DataTypes.BOOLEAN, allowNull: true },
   },
   {
     sequelize,

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -12,7 +12,9 @@ import {
 import {
   createRegistrationRules,
   updateRegistrationRules,
+  updatePresenceRules,
 } from '../validators/trainingRegistrationValidators.js';
+import { updateAttendanceRules } from '../validators/trainingValidators.js';
 
 const router = express.Router();
 
@@ -56,6 +58,18 @@ router.put(
   updateRegistrationRules,
   registrationsController.update
 );
+router.put(
+  '/:id/registrations/:userId/presence',
+  auth,
+  updatePresenceRules,
+  registrationsController.updatePresence
+);
+router.get(
+  '/:id/attendance',
+  auth,
+  registrationsController.listForAttendance
+);
+router.put('/:id/attendance', auth, updateAttendanceRules, controller.setAttendance);
 router.delete(
   '/:id/registrations/:userId',
   auth,

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -264,6 +264,10 @@ async function listForAttendance(trainingId, actorId) {
     page: 1,
     limit: 1000,
   });
+
+  const filtered = isAdmin
+    ? rows
+    : rows.filter((r) => r.TrainingRole?.alias !== 'COACH');
   const training = await Training.findByPk(trainingId, {
     include: [
       TrainingType,
@@ -271,7 +275,7 @@ async function listForAttendance(trainingId, actorId) {
       { model: Season, where: { active: true }, required: true },
     ],
   });
-  return { rows, count, training: training ? training.get() : null };
+  return { rows: filtered, count: filtered.length, training: training ? training.get() : null };
 }
 
 async function listUpcomingByUser(userId, options = {}) {

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -8,6 +8,7 @@ import {
   Address,
   User,
   TrainingRole,
+  Role,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 import TrainingRegistration from '../models/trainingRegistration.js';
@@ -173,11 +174,34 @@ async function remove(id) {
   await training.destroy();
 }
 
+async function setAttendanceMarked(id, marked, actorId) {
+  const training = await Training.findByPk(id);
+  if (!training) throw new ServiceError('training_not_found', 404);
+  const actor = await User.findByPk(actorId, { include: [Role] });
+  if (!actor) throw new ServiceError('user_not_found', 404);
+  const isAdmin = actor.Roles.some((r) => r.alias === 'ADMIN');
+  if (!isAdmin) {
+    if (!actor.Roles.some((r) => r.alias === 'REFEREE')) {
+      throw new ServiceError('access_denied');
+    }
+    const coachReg = await TrainingRegistration.findOne({
+      where: { training_id: id, user_id: actorId },
+      include: [TrainingRole],
+    });
+    if (coachReg?.TrainingRole?.alias !== 'COACH') {
+      throw new ServiceError('access_denied');
+    }
+  }
+  await training.update({ attendance_marked: marked, updated_by: actorId });
+  return getById(id);
+}
+
 export default {
   listAll,
   getById,
   create,
   update,
+  setAttendanceMarked,
   remove,
   isRegistrationOpen,
 };

--- a/src/validators/trainingRegistrationValidators.js
+++ b/src/validators/trainingRegistrationValidators.js
@@ -6,3 +6,7 @@ export const createRegistrationRules = [
 ];
 
 export const updateRegistrationRules = [body('training_role_id').isUUID()];
+
+export const updatePresenceRules = [
+  body('present').optional({ nullable: true }).isBoolean(),
+];

--- a/src/validators/trainingValidators.js
+++ b/src/validators/trainingValidators.js
@@ -31,3 +31,7 @@ export const trainingUpdateRules = [
   body('groups').optional().isArray(),
   body('groups.*').isUUID(),
 ];
+
+export const updateAttendanceRules = [
+  body('attendance_marked').isBoolean(),
+];

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -235,3 +235,20 @@ test('listUpcomingByUser includes my role', async () => {
   expect(res.rows[0].my_role).toEqual({ id: 'r1', name: 'Участник', alias: 'PARTICIPANT' });
   expect(findAndCountAllMock).toHaveBeenCalled();
 });
+
+test('updatePresence updates value for admin', async () => {
+  const updateMock = jest.fn();
+  findRegMock.mockResolvedValueOnce({ update: updateMock });
+  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'ADMIN' }] });
+  await service.updatePresence('t1', 'u1', true, 'admin');
+  expect(updateMock).toHaveBeenCalledWith({ present: true, updated_by: 'admin' });
+});
+
+test('updatePresence rejects when not coach', async () => {
+  findRegMock.mockResolvedValueOnce({});
+  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'REFEREE' }] });
+  findRegMock.mockResolvedValueOnce(null);
+  await expect(
+    service.updatePresence('t1', 'u1', false, 'u2')
+  ).rejects.toThrow('access_denied');
+});


### PR DESCRIPTION
## Summary
- add trainer attendance page and routes
- allow trainers to fetch attendance list
- show attendance icon next to cancel icon in "My trainings"
- update service with listForAttendance logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e03b72bb4832d8e317fa1477c3141