### PR TITLE
Add personal data consent PDF

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -15,6 +15,7 @@ import AdminUserCreate from './views/AdminUserCreate.vue';
 import AdminCampStadiums from './views/AdminCampStadiums.vue';
 import AdminMedicalManagement from './views/AdminMedicalManagement.vue';
 import AdminExamRegistrations from './views/AdminExamRegistrations.vue';
+import AdminDocuments from './views/AdminDocuments.vue';
 import TrainingAttendance from './views/TrainingAttendance.vue';
 import PasswordReset from './views/PasswordReset.vue';
 import NotFound from './views/NotFound.vue';
@@ -62,6 +63,11 @@ const routes = [
   {
     path: '/medical-admin',
     component: AdminMedicalManagement,
+    meta: { requiresAuth: true, requiresAdmin: true },
+  },
+  {
+    path: '/documents-admin',
+    component: AdminDocuments,
     meta: { requiresAuth: true, requiresAdmin: true },
   },
   {

--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -1,0 +1,99 @@
+<script setup>
+import { ref, watch } from 'vue';
+import { RouterLink } from 'vue-router';
+import { apiFetch, apiFetchBlob } from '../api.js';
+
+const userQuery = ref('');
+const userSuggestions = ref([]);
+const selectedUser = ref(null);
+let userTimeout;
+
+watch(userQuery, () => {
+  clearTimeout(userTimeout);
+  if (selectedUser.value) selectedUser.value = null;
+  if (!userQuery.value || userQuery.value.length < 2) {
+    userSuggestions.value = [];
+    return;
+  }
+  userTimeout = setTimeout(async () => {
+    try {
+      const params = new URLSearchParams({ search: userQuery.value, limit: 5 });
+      const data = await apiFetch(`/users?${params}`);
+      userSuggestions.value = data.users;
+    } catch (_err) {
+      userSuggestions.value = [];
+    }
+  }, 300);
+});
+
+function selectUser(u) {
+  selectedUser.value = u;
+  userQuery.value = `${u.last_name} ${u.first_name}`;
+  userSuggestions.value = [];
+}
+
+async function downloadConsent() {
+  if (!selectedUser.value) return;
+  try {
+    const blob = await apiFetchBlob(`/documents/consent/${selectedUser.value.id}`);
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'consent.pdf';
+    a.click();
+    URL.revokeObjectURL(url);
+  } catch (e) {
+    alert(e.message);
+  }
+}
+</script>
+
+<template>
+  <div class="container mt-4">
+    <nav aria-label="breadcrumb" class="mb-3">
+      <ol class="breadcrumb mb-0">
+        <li class="breadcrumb-item">
+          <RouterLink to="/admin">Администрирование</RouterLink>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">Документы</li>
+      </ol>
+    </nav>
+    <h1 class="mb-3">Документы</h1>
+    <div class="card section-card tile fade-in shadow-sm">
+      <div class="card-body">
+        <div class="mb-3 position-relative">
+          <div class="form-floating">
+            <input
+              id="userSearch"
+              v-model="userQuery"
+              class="form-control"
+              placeholder="Пользователь"
+            />
+            <label for="userSearch">Пользователь</label>
+          </div>
+          <ul
+            v-if="userSuggestions.length"
+            class="list-group position-absolute w-100"
+            style="z-index: 1050"
+          >
+            <li
+              v-for="u in userSuggestions"
+              :key="u.id"
+              class="list-group-item list-group-item-action"
+              @mousedown.prevent="selectUser(u)"
+            >
+              {{ u.last_name }} {{ u.first_name }}
+            </li>
+          </ul>
+        </div>
+        <button
+          class="btn btn-brand"
+          :disabled="!selectedUser"
+          @click="downloadConsent"
+        >
+          Скачать согласие
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, watch } from 'vue';
+import { ref, watch, nextTick } from 'vue';
 import { RouterLink } from 'vue-router';
 import { apiFetch, apiFetchBlob } from '../api.js';
 
@@ -7,10 +7,11 @@ const userQuery = ref('');
 const userSuggestions = ref([]);
 const selectedUser = ref(null);
 let userTimeout;
+let selecting = false;
 
 watch(userQuery, () => {
   clearTimeout(userTimeout);
-  if (selectedUser.value) selectedUser.value = null;
+  if (!selecting && selectedUser.value) selectedUser.value = null;
   if (!userQuery.value || userQuery.value.length < 2) {
     userSuggestions.value = [];
     return;
@@ -27,9 +28,13 @@ watch(userQuery, () => {
 });
 
 function selectUser(u) {
+  selecting = true;
   selectedUser.value = u;
   userQuery.value = `${u.last_name} ${u.first_name}`;
   userSuggestions.value = [];
+  nextTick(() => {
+    selecting = false;
+  });
 }
 
 async function downloadConsent() {

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -3,6 +3,7 @@ import { RouterLink } from 'vue-router'
 
 const userSections = [
   { title: 'Пользователи', icon: 'bi-people', to: '/users' },
+  { title: 'Документы', icon: 'bi-file-earmark', to: '/documents-admin' },
   { title: 'Медицина', icon: 'bi-file-earmark-medical', to: '/medical-admin' },
 ]
 

--- a/src/controllers/documentAdminController.js
+++ b/src/controllers/documentAdminController.js
@@ -1,0 +1,18 @@
+import documentService from '../services/documentService.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async downloadConsent(req, res) {
+    try {
+      const pdf = await documentService.generatePersonalDataConsent(req.params.id);
+      res.setHeader('Content-Type', 'application/pdf');
+      res.setHeader(
+        'Content-Disposition',
+        'attachment; filename="consent.pdf"'
+      );
+      return res.end(pdf);
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/migrations/20250906004500-add-generated-to-document-types.js
+++ b/src/migrations/20250906004500-add-generated-to-document-types.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('document_types', 'generated', {
+      type: Sequelize.BOOLEAN,
+      allowNull: false,
+      defaultValue: false,
+    });
+    // ensure existing rows get the default value
+    await queryInterface.sequelize.query(
+      'UPDATE document_types SET generated = FALSE WHERE generated IS NULL'
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('document_types', 'generated');
+  },
+};

--- a/src/models/documentType.js
+++ b/src/models/documentType.js
@@ -13,6 +13,7 @@ DocumentType.init(
     },
     name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
     alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    generated: { type: DataTypes.BOOLEAN, allowNull: false, defaultValue: false },
   },
   {
     sequelize,

--- a/src/routes/documents.js
+++ b/src/routes/documents.js
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/documentAdminController.js';
+
+const router = express.Router();
+
+router.get('/consent/:id', auth, authorize('ADMIN'), controller.downloadConsent);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -29,6 +29,7 @@ import medicalCentersRouter from './medicalCenters.js';
 import medicalExamsRouter from './medicalExams.js';
 import trainingRolesRouter from './trainingRoles.js';
 import sexesRouter from './sexes.js';
+import documentsRouter from './documents.js';
 
 const router = express.Router();
 
@@ -57,6 +58,7 @@ router.use('/referee-groups', refereeGroupsRouter);
 router.use('/referee-group-users', refereeGroupUsersRouter);
 router.use('/medical-centers', medicalCentersRouter);
 router.use('/medical-exams', medicalExamsRouter);
+router.use('/documents', documentsRouter);
 
 /**
  * @swagger

--- a/src/seeders/20250906004600-add-personal-data-consent-doc.js
+++ b/src/seeders/20250906004600-add-personal-data-consent-doc.js
@@ -1,0 +1,33 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM document_types WHERE alias = \'PERSONAL_DATA_CONSENT\';'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'document_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Согласие на обработку персональных данных',
+          alias: 'PERSONAL_DATA_CONSENT',
+          generated: true,
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('document_types', {
+      alias: ['PERSONAL_DATA_CONSENT'],
+    });
+  },
+};

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -1,0 +1,44 @@
+import PDFDocument from 'pdfkit';
+
+import { User, Sex } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+function formatDate(str) {
+  if (!str) return '';
+  const [year, month, day] = str.split('-');
+  return `${day}.${month}.${year}`;
+}
+
+async function generatePersonalDataConsent(userId) {
+  const user = await User.findByPk(userId, { include: [Sex] });
+  if (!user) throw new ServiceError('user_not_found', 404);
+  const doc = new PDFDocument({ margin: 30, size: 'A4' });
+  doc.registerFont('DejaVu', '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf');
+  doc.font('DejaVu');
+  doc.fontSize(14).text('Согласие на обработку персональных данных', { align: 'center' });
+  doc.moveDown();
+  const fullName = [user.last_name, user.first_name, user.patronymic]
+    .filter(Boolean)
+    .join(' ');
+  doc
+    .fontSize(12)
+    .text(
+      `Я, ${fullName}, ${formatDate(
+        user.birth_date
+      )} года рождения, даю согласие Федерации хоккея Москвы на обработку моих персональных данных в соответствии с законодательством Российской Федерации.`
+    );
+  doc.moveDown();
+  doc.text('Подпись: ______________________', { align: 'right' });
+  doc.moveDown();
+  doc.text('Дата: ______________________', { align: 'right' });
+
+  const chunks = [];
+  return new Promise((resolve, reject) => {
+    doc.on('data', (c) => chunks.push(c));
+    doc.on('end', () => resolve(Buffer.concat(chunks)));
+    doc.on('error', reject);
+    doc.end();
+  });
+}
+
+export default { generatePersonalDataConsent };


### PR DESCRIPTION
## Summary
- support generated documents by adding a `generated` flag to `document_types`
- seed personal data consent document type
- implement service and API to generate personal data consent PDF
- expose new `/documents/consent/:id` route
- add Documents admin page and navigation link
- ensure migration sets `generated` flag to false for existing records

## Testing
- `npm run lint`
- `npm test` *(fails: passportService and trainingService)*

------
https://chatgpt.com/codex/tasks/task_e_686e0f1f0b94832da7b2c8e56483eda7