### PR TITLE
Fix medical exam registration PDF export

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,5 +58,5 @@ SESSION_SECRET=supersecret
 # APP_IMAGE=ghcr.io/your-organization/fhmoscow-pulse
 # CLIENT_IMAGE=ghcr.io/your-organization/fhmoscow-pulse-client
 
-# Path to TrueType font for PDF export
-PDF_FONT_PATH=/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf
+# Directory with SBSansText fonts for PDF export
+PDF_FONT_DIR=./assets/fonts

--- a/.env.example
+++ b/.env.example
@@ -58,3 +58,5 @@ SESSION_SECRET=supersecret
 # APP_IMAGE=ghcr.io/your-organization/fhmoscow-pulse
 # CLIENT_IMAGE=ghcr.io/your-organization/fhmoscow-pulse-client
 
+# Path to TrueType font for PDF export
+PDF_FONT_PATH=/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf

--- a/README.md
+++ b/README.md
@@ -146,12 +146,11 @@ VITE_ALLOWED_HOSTS=pulse.fhmoscow.com
 ```
 
 To enable Cyrillic text in exported PDF documents, provide the
-`PDF_FONT_PATH` variable with the full path to a TrueType font that
-supports the Russian alphabet (for example `DejaVuSans.ttf`). The file is
-not included in the repository; place it in `assets/fonts` or reference an
-existing system font. If the configured font cannot be read, the service
-falls back to the default PDF font which may render Cyrillic characters
-incorrectly.
+`PDF_FONT_DIR` variable pointing to a directory that contains the
+`SBSansText` TrueType fonts. Copy the font files into `assets/fonts` or
+reference an existing directory on the system. If the fonts are missing or
+cannot be read, the service falls back to builtin PDF fonts which may render
+Cyrillic characters incorrectly.
 
 Do **not** set `SSL_CERT_PATH` or `SSL_KEY_PATH` so that the Node.js application
 starts in HTTP mode and relies on nginx for TLS termination.

--- a/README.md
+++ b/README.md
@@ -147,9 +147,11 @@ VITE_ALLOWED_HOSTS=pulse.fhmoscow.com
 
 To enable Cyrillic text in exported PDF documents, provide the
 `PDF_FONT_PATH` variable with the full path to a TrueType font that
-supports the Russian alphabet, for example `DejaVuSans.ttf`. The file
-is not included in the repository; place it in `assets/fonts` or
-reference an existing system font.
+supports the Russian alphabet (for example `DejaVuSans.ttf`). The file is
+not included in the repository; place it in `assets/fonts` or reference an
+existing system font. If the configured font cannot be read, the service
+falls back to the default PDF font which may render Cyrillic characters
+incorrectly.
 
 Do **not** set `SSL_CERT_PATH` or `SSL_KEY_PATH` so that the Node.js application
 starts in HTTP mode and relies on nginx for TLS termination.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,12 @@ VITE_API_BASE=/api
 VITE_ALLOWED_HOSTS=pulse.fhmoscow.com
 ```
 
+To enable Cyrillic text in exported PDF documents, provide the
+`PDF_FONT_PATH` variable with the full path to a TrueType font that
+supports the Russian alphabet, for example `DejaVuSans.ttf`. The file
+is not included in the repository; place it in `assets/fonts` or
+reference an existing system font.
+
 Do **not** set `SSL_CERT_PATH` or `SSL_KEY_PATH` so that the Node.js application
 starts in HTTP mode and relies on nginx for TLS termination.
 

--- a/src/config/pdf.js
+++ b/src/config/pdf.js
@@ -5,14 +5,23 @@ import { fileURLToPath } from 'url';
 
 dotenv.config();
 
-const defaultPath = path.resolve(
+const DEFAULT_FONT = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
   '../../assets/fonts/DejaVuSans.ttf'
 );
 
-const candidate = process.env.PDF_FONT_PATH || defaultPath;
+function isReadable(file) {
+  try {
+    fs.accessSync(file, fs.constants.R_OK);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}
+
+const candidate = process.env.PDF_FONT_PATH || DEFAULT_FONT;
 let fontPath;
-if (fs.existsSync(candidate)) {
+if (isReadable(candidate)) {
   fontPath = candidate;
 } else {
   if (process.env.PDF_FONT_PATH) {

--- a/src/config/pdf.js
+++ b/src/config/pdf.js
@@ -5,29 +5,30 @@ import { fileURLToPath } from 'url';
 
 dotenv.config();
 
-const DEFAULT_FONT = path.resolve(
+const DEFAULT_DIR = path.resolve(
   path.dirname(fileURLToPath(import.meta.url)),
-  '../../assets/fonts/DejaVuSans.ttf'
+  '../../assets/fonts'
 );
 
-function isReadable(file) {
+function readable(file) {
   try {
     fs.accessSync(file, fs.constants.R_OK);
     return true;
-  } catch (_) {
+  } catch {
     return false;
   }
 }
 
-const candidate = process.env.PDF_FONT_PATH || DEFAULT_FONT;
-let fontPath;
-if (isReadable(candidate)) {
-  fontPath = candidate;
-} else {
-  if (process.env.PDF_FONT_PATH) {
-    console.warn(`PDF font not found at ${candidate}, falling back to default`);
-  }
-  fontPath = undefined;
+const dir = process.env.PDF_FONT_DIR || DEFAULT_DIR;
+
+function resolveFont(name) {
+  const file = path.join(dir, name);
+  return readable(file) ? file : undefined;
 }
 
-export const PDF_FONT_PATH = fontPath;
+export const PDF_FONTS = {
+  regular: resolveFont('SBSansText-Regular.ttf'),
+  bold: resolveFont('SBSansText-Bold.ttf'),
+  italic: resolveFont('SBSansText-Italic.ttf'),
+  boldItalic: resolveFont('SBSansText-BoldItalic.ttf'),
+};

--- a/src/config/pdf.js
+++ b/src/config/pdf.js
@@ -1,2 +1,14 @@
-const fontPath = process.env.PDF_FONT_PATH || new URL('../../assets/fonts/DejaVuSans.ttf', import.meta.url).pathname;
-export const PDF_FONT_PATH = fontPath;
+import fs from 'fs';
+import path from 'path';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+
+dotenv.config();
+
+const defaultPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../assets/fonts/DejaVuSans.ttf'
+);
+
+const candidate = process.env.PDF_FONT_PATH || defaultPath;
+export const PDF_FONT_PATH = fs.existsSync(candidate) ? candidate : undefined;

--- a/src/config/pdf.js
+++ b/src/config/pdf.js
@@ -1,0 +1,2 @@
+const fontPath = process.env.PDF_FONT_PATH || new URL('../../assets/fonts/DejaVuSans.ttf', import.meta.url).pathname;
+export const PDF_FONT_PATH = fontPath;

--- a/src/config/pdf.js
+++ b/src/config/pdf.js
@@ -11,4 +11,14 @@ const defaultPath = path.resolve(
 );
 
 const candidate = process.env.PDF_FONT_PATH || defaultPath;
-export const PDF_FONT_PATH = fs.existsSync(candidate) ? candidate : undefined;
+let fontPath;
+if (fs.existsSync(candidate)) {
+  fontPath = candidate;
+} else {
+  if (process.env.PDF_FONT_PATH) {
+    console.warn(`PDF font not found at ${candidate}, falling back to default`);
+  }
+  fontPath = undefined;
+}
+
+export const PDF_FONT_PATH = fontPath;

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -26,7 +26,7 @@ const schema = Joi.object({
   SSL_KEY_PATH: Joi.string().optional(),
   COOKIE_DOMAIN: Joi.string().optional(),
   ALLOWED_ORIGINS: Joi.string().optional(),
-  PDF_FONT_PATH: Joi.string().optional(),
+  PDF_FONT_DIR: Joi.string().optional(),
 }).unknown(true);
 
 export default function validateEnv() {

--- a/src/config/validateEnv.js
+++ b/src/config/validateEnv.js
@@ -26,6 +26,7 @@ const schema = Joi.object({
   SSL_KEY_PATH: Joi.string().optional(),
   COOKIE_DOMAIN: Joi.string().optional(),
   ALLOWED_ORIGINS: Joi.string().optional(),
+  PDF_FONT_PATH: Joi.string().optional(),
 }).unknown(true);
 
 export default function validateEnv() {

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -1,4 +1,5 @@
 import PDFDocument from 'pdfkit-table';
+import { PDF_FONT_PATH } from '../config/pdf.js';
 
 import {
   MedicalExam,
@@ -362,12 +363,13 @@ async function exportApprovedPdf(examId) {
   const regs = await listApproved(examId);
   const doc = new PDFDocument({ margin: 30, size: 'A4' });
   let fontName = 'Helvetica';
-  try {
-    const { PDF_FONT_PATH } = await import('../config/pdf.js');
-    doc.registerFont('DejaVu', PDF_FONT_PATH);
-    fontName = 'DejaVu';
-  } catch (_err) {
-    // keep default Helvetica font
+  if (PDF_FONT_PATH) {
+    try {
+      doc.registerFont('DejaVu', PDF_FONT_PATH);
+      fontName = 'DejaVu';
+    } catch (_err) {
+      // keep default Helvetica font
+    }
   }
   doc.font(fontName);
   doc.fontSize(14).text('Подтверждённые заявки', { align: 'center' });

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -1,5 +1,5 @@
 import PDFDocument from 'pdfkit-table';
-import { PDF_FONT_PATH } from '../config/pdf.js';
+import { PDF_FONTS } from '../config/pdf.js';
 
 import {
   MedicalExam,
@@ -361,29 +361,43 @@ function formatDate(str) {
 
 async function exportApprovedPdf(examId) {
   const regs = await listApproved(examId);
-  const doc = new PDFDocument({ margin: 30, size: 'A4' });
-  let fontName = 'Helvetica';
-  if (PDF_FONT_PATH) {
+  const doc = new PDFDocument({ margin: 40, size: 'A4', layout: 'landscape' });
+  const regular = PDF_FONTS.regular ? 'SB-Regular' : 'Helvetica';
+  const bold = PDF_FONTS.bold ? 'SB-Bold' : 'Helvetica-Bold';
+
+  if (PDF_FONTS.regular) {
     try {
-      doc.registerFont('DejaVu', PDF_FONT_PATH);
-      fontName = 'DejaVu';
-    } catch (_err) {
-      // keep default Helvetica font
-    }
+      doc.registerFont('SB-Regular', PDF_FONTS.regular);
+    } catch {}
   }
-  doc.font(fontName);
-  doc.fontSize(14).text('Подтверждённые заявки', { align: 'center' });
+  if (PDF_FONTS.bold) {
+    try {
+      doc.registerFont('SB-Bold', PDF_FONTS.bold);
+    } catch {}
+  }
+  if (PDF_FONTS.italic) {
+    try {
+      doc.registerFont('SB-Italic', PDF_FONTS.italic);
+    } catch {}
+  }
+  if (PDF_FONTS.boldItalic) {
+    try {
+      doc.registerFont('SB-BoldItalic', PDF_FONTS.boldItalic);
+    } catch {}
+  }
+
+  doc.font(bold).fontSize(16).text('Подтверждённые заявки', { align: 'center' });
   doc.moveDown();
 
   const table = {
     headers: [
-      { label: 'Фамилия', property: 'last', width: 70 },
-      { label: 'Имя', property: 'first', width: 60 },
-      { label: 'Отчество', property: 'patronymic', width: 70 },
-      { label: 'Пол', property: 'sex', width: 40 },
-      { label: 'Дата рождения', property: 'birth', width: 60 },
-      { label: 'Email', property: 'email', width: 120 },
-      { label: 'Телефон', property: 'phone', width: 70 },
+      { label: 'Фамилия', property: 'last', width: 90 },
+      { label: 'Имя', property: 'first', width: 80 },
+      { label: 'Отчество', property: 'patronymic', width: 90 },
+      { label: 'Пол', property: 'sex', width: 50 },
+      { label: 'Дата рождения', property: 'birth', width: 70 },
+      { label: 'Email', property: 'email', width: 150 },
+      { label: 'Телефон', property: 'phone', width: 90 },
     ],
     datas: regs.map((r) => ({
       last: r.User.last_name,
@@ -397,8 +411,10 @@ async function exportApprovedPdf(examId) {
   };
 
   await doc.table(table, {
-    prepareHeader: () => doc.font(fontName).fontSize(10),
-    prepareRow: () => doc.font(fontName).fontSize(10),
+    prepareHeader: () => doc.font(bold).fontSize(10),
+    prepareRow: () => doc.font(regular).fontSize(10),
+    columnSpacing: 5,
+    padding: 4,
   });
 
   const chunks = [];

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -361,8 +361,15 @@ function formatDate(str) {
 async function exportApprovedPdf(examId) {
   const regs = await listApproved(examId);
   const doc = new PDFDocument({ margin: 30, size: 'A4' });
-  doc.registerFont('DejaVu', '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf');
-  doc.font('DejaVu');
+  let fontName = 'Helvetica';
+  try {
+    const { PDF_FONT_PATH } = await import('../config/pdf.js');
+    doc.registerFont('DejaVu', PDF_FONT_PATH);
+    fontName = 'DejaVu';
+  } catch (_err) {
+    // keep default Helvetica font
+  }
+  doc.font(fontName);
   doc.fontSize(14).text('Подтверждённые заявки', { align: 'center' });
   doc.moveDown();
 
@@ -388,8 +395,8 @@ async function exportApprovedPdf(examId) {
   };
 
   await doc.table(table, {
-    prepareHeader: () => doc.font('DejaVu').fontSize(10),
-    prepareRow: () => doc.font('DejaVu').fontSize(10),
+    prepareHeader: () => doc.font(fontName).fontSize(10),
+    prepareRow: () => doc.font(fontName).fontSize(10),
   });
 
   const chunks = [];


### PR DESCRIPTION
## Summary
- allow configuring PDF font via `PDF_FONT_PATH`
- use configured font in medical exam registration PDF generation
- document font path in `.env.example`
- add font directory placeholder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e1275ae70832d84e9335eab063806