### PR TITLE
Improve attendance page selectors

### DIFF
--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -16,6 +16,11 @@ const visibleRegistrations = computed(() =>
       return aName.localeCompare(bName, 'ru');
     })
 );
+const allMarked = computed(() =>
+  visibleRegistrations.value.every(
+    (r) => r.present === true || r.present === false
+  )
+);
 const loading = ref(false);
 const error = ref('');
 const toastRef = ref(null);
@@ -65,6 +70,10 @@ async function setPresence(userId, value) {
 }
 
 async function finish() {
+  if (!allMarked.value) {
+    alert('Отметьте посещаемость для всех участников');
+    return;
+  }
   try {
     await apiFetch(`/camp-trainings/${route.params.id}/attendance`, {
       method: 'PUT',
@@ -166,7 +175,11 @@ function showToast(message) {
           </div>
         </div>
         <p v-else class="text-muted">Нет записей</p>
-        <button class="btn btn-brand mt-3" @click="finish" :disabled="!visibleRegistrations.length">
+        <button
+          class="btn btn-brand mt-3"
+          @click="finish"
+          :disabled="!visibleRegistrations.length || !allMarked"
+        >
           Завершить
         </button>
       </div>

--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -121,7 +121,7 @@ function showToast(message) {
                   <td>{{ r.user.last_name }} {{ r.user.first_name }}</td>
                   <td>{{ new Date(r.user.birth_date).getFullYear() }}</td>
                   <td class="text-end">
-                    <div class="btn-group btn-group-sm" role="group">
+                    <div class="btn-group btn-group-sm presence-group" role="group">
                       <input
                         type="radio"
                         class="btn-check"
@@ -132,10 +132,11 @@ function showToast(message) {
                         @change="setPresence(r.user.id, true)"
                       />
                       <label
-                        class="btn btn-outline-success"
+                        class="btn btn-outline-success presence-btn"
                         :for="`present-yes-${r.user.id}`"
                       >
-                        Да
+                        <i class="bi bi-check-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Да</span>
                       </label>
                       <input
                         type="radio"
@@ -147,10 +148,11 @@ function showToast(message) {
                         @change="setPresence(r.user.id, false)"
                       />
                       <label
-                        class="btn btn-outline-danger"
+                        class="btn btn-outline-danger presence-btn"
                         :for="`present-no-${r.user.id}`"
                       >
-                        Нет
+                        <i class="bi bi-x-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Нет</span>
                       </label>
                     </div>
                   </td>
@@ -178,6 +180,14 @@ function showToast(message) {
   border-radius: 1rem;
   overflow: hidden;
   border: 0;
+}
+
+.presence-group .presence-btn {
+  width: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0;
 }
 
 @media (max-width: 575.98px) {

--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -11,8 +11,8 @@ const visibleRegistrations = computed(() =>
   registrations.value
     .filter((r) => r.role?.alias !== 'COACH')
     .sort((a, b) => {
-      const aName = `${a.user.last_name} ${a.user.first_name}`;
-      const bName = `${b.user.last_name} ${b.user.first_name}`;
+      const aName = formatName(a.user);
+      const bName = formatName(b.user);
       return aName.localeCompare(bName, 'ru');
     })
 );
@@ -21,6 +21,10 @@ const error = ref('');
 const toastRef = ref(null);
 const toastMessage = ref('');
 let toast;
+
+function formatName(u) {
+  return `${u.last_name} ${u.first_name} ${u.patronymic || ''}`.trim();
+}
 
 onMounted(loadData);
 
@@ -118,7 +122,7 @@ function showToast(message) {
               </thead>
               <tbody>
                 <tr v-for="r in visibleRegistrations" :key="r.user.id">
-                  <td>{{ r.user.last_name }} {{ r.user.first_name }}</td>
+                  <td>{{ formatName(r.user) }}</td>
                   <td>{{ new Date(r.user.birth_date).getFullYear() }}</td>
                   <td class="text-end">
                     <div class="btn-group btn-group-sm presence-group" role="group">
@@ -144,7 +148,7 @@ function showToast(message) {
                         :id="`present-no-${r.user.id}`"
                         :name="`present-${r.user.id}`"
                         autocomplete="off"
-                        :checked="r.present !== true"
+                        :checked="r.present === false"
                         @change="setPresence(r.user.id, false)"
                       />
                       <label


### PR DESCRIPTION
## Summary
- make 'Yes' and 'No' selectors visually consistent
- add icons for clearer UI
- ensure presence buttons have equal width

## Testing
- `npm test` *(fails: passportService.test.js, trainingService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_686e433ab288832d897a12156e363d9f