### PR TITLE
Improve PDF font handling

### DIFF
--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -2,6 +2,7 @@ import PDFDocument from 'pdfkit';
 
 import { User, Sex } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
+import { applyFonts } from '../utils/pdf.js';
 
 function formatDate(str) {
   if (!str) return '';
@@ -13,8 +14,8 @@ async function generatePersonalDataConsent(userId) {
   const user = await User.findByPk(userId, { include: [Sex] });
   if (!user) throw new ServiceError('user_not_found', 404);
   const doc = new PDFDocument({ margin: 30, size: 'A4' });
-  doc.registerFont('DejaVu', '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf');
-  doc.font('DejaVu');
+  const { regular } = applyFonts(doc);
+  doc.font(regular);
   doc
     .fontSize(14)
     .text('Согласие на обработку персональных данных', { align: 'center' });

--- a/src/services/medicalExamRegistrationService.js
+++ b/src/services/medicalExamRegistrationService.js
@@ -1,6 +1,6 @@
 import PDFDocument from 'pdfkit-table';
 
-import { PDF_FONTS } from '../config/pdf.js';
+import { applyFonts } from '../utils/pdf.js';
 import {
   MedicalExam,
   MedicalExamRegistration,
@@ -362,37 +362,7 @@ function formatDate(str) {
 async function exportApprovedPdf(examId) {
   const regs = await listApproved(examId);
   const doc = new PDFDocument({ margin: 40, size: 'A4', layout: 'landscape' });
-  const regular = PDF_FONTS.regular ? 'SB-Regular' : 'Helvetica';
-  const bold = PDF_FONTS.bold ? 'SB-Bold' : 'Helvetica-Bold';
-
-  if (PDF_FONTS.regular) {
-    try {
-      doc.registerFont('SB-Regular', PDF_FONTS.regular);
-    } catch {
-      /* empty */
-    }
-  }
-  if (PDF_FONTS.bold) {
-    try {
-      doc.registerFont('SB-Bold', PDF_FONTS.bold);
-    } catch {
-      /* empty */
-    }
-  }
-  if (PDF_FONTS.italic) {
-    try {
-      doc.registerFont('SB-Italic', PDF_FONTS.italic);
-    } catch {
-      /* empty */
-    }
-  }
-  if (PDF_FONTS.boldItalic) {
-    try {
-      doc.registerFont('SB-BoldItalic', PDF_FONTS.boldItalic);
-    } catch {
-      /* empty */
-    }
-  }
+  const { regular, bold } = applyFonts(doc);
 
   doc
     .font(bold)

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,0 +1,70 @@
+import fs from 'fs';
+
+import { PDF_FONTS } from '../config/pdf.js';
+
+const FALLBACK_REGULAR = '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf';
+const FALLBACK_BOLD = '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf';
+
+export function applyFonts(doc) {
+  let regular = 'Helvetica';
+  let bold = 'Helvetica-Bold';
+
+  if (PDF_FONTS.regular) {
+    try {
+      fs.accessSync(PDF_FONTS.regular, fs.constants.R_OK);
+      doc.registerFont('SB-Regular', PDF_FONTS.regular);
+      regular = 'SB-Regular';
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (PDF_FONTS.bold) {
+    try {
+      fs.accessSync(PDF_FONTS.bold, fs.constants.R_OK);
+      doc.registerFont('SB-Bold', PDF_FONTS.bold);
+      bold = 'SB-Bold';
+    } catch {
+      /* empty */
+    }
+  }
+
+  // Fallback fonts for Cyrillic support
+  if (regular === 'Helvetica') {
+    try {
+      doc.registerFont('Default-Regular', FALLBACK_REGULAR);
+      regular = 'Default-Regular';
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (bold === 'Helvetica-Bold') {
+    try {
+      doc.registerFont('Default-Bold', FALLBACK_BOLD);
+      bold = 'Default-Bold';
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (PDF_FONTS.italic) {
+    try {
+      fs.accessSync(PDF_FONTS.italic, fs.constants.R_OK);
+      doc.registerFont('SB-Italic', PDF_FONTS.italic);
+    } catch {
+      /* empty */
+    }
+  }
+
+  if (PDF_FONTS.boldItalic) {
+    try {
+      fs.accessSync(PDF_FONTS.boldItalic, fs.constants.R_OK);
+      doc.registerFont('SB-BoldItalic', PDF_FONTS.boldItalic);
+    } catch {
+      /* empty */
+    }
+  }
+
+  return { regular, bold };
+}


### PR DESCRIPTION
## Summary
- centralize PDF font setup in `applyFonts` utility
- use `applyFonts` for personal data consent PDFs
- share the same font helper when exporting approved medical exam registrations

## Testing
- `npm run lint`
- `npm test` *(fails: passportService.removeByUser and trainingService)*

------
https://chatgpt.com/codex/tasks/task_e_686f7dfdafbc832daa00e3b813511def