### PR TITLE
Add admin profile completion overview

### DIFF
--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -203,7 +203,7 @@ async function copy(text) {
     <h1 class="mb-3">Пользователи</h1>
     <div class="card tile mb-3">
       <div class="card-body p-2">
-        <ul class="nav nav-pills nav-fill justify-content-between mb-0">
+        <ul class="nav nav-pills nav-fill mb-0 tab-selector">
           <li class="nav-item">
             <button class="nav-link" :class="{ active: activeTab === 'users' }" @click="activeTab = 'users'">Пользователи</button>
           </li>
@@ -413,7 +413,7 @@ async function copy(text) {
         <div v-if="completionLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div v-if="completion.length" class="table-responsive">
+        <div v-if="completion.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-hover table-striped align-middle mb-0">
             <thead>
               <tr>
@@ -441,6 +441,22 @@ async function copy(text) {
             </tbody>
           </table>
         </div>
+        <div v-if="completion.length" class="d-block d-sm-none">
+          <div v-for="p in completion" :key="p.id" class="card profile-card mb-2">
+            <div class="card-body p-2">
+              <h6 class="mb-1">{{ p.last_name }} {{ p.first_name }} {{ p.patronymic }}</h6>
+              <p class="mb-1 small">{{ formatDate(p.birth_date) }}</p>
+              <div class="d-flex flex-wrap gap-2">
+                <span><i :class="p.passport ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> Паспорт</span>
+                <span><i :class="p.inn ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> ИНН</span>
+                <span><i :class="p.snils ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> СНИЛС</span>
+                <span><i :class="p.bank_account ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> Банк</span>
+                <span><i :class="p.addresses ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> Адрес</span>
+                <span><i class="bi"></i> {{ p.taxation_type }}</span>
+              </div>
+            </div>
+          </div>
+        </div>
         <p v-else-if="!completionLoading" class="text-muted mb-0">Нет данных.</p>
       </div>
     </div>
@@ -458,10 +474,21 @@ async function copy(text) {
 .sortable i {
   margin-left: 4px;
 }
+.tab-selector {
+  gap: 0.5rem;
+}
+
+.tab-selector .nav-link {
+  border-radius: 0.5rem;
+}
 .section-card {
   border-radius: 1rem;
   overflow: hidden;
   border: 0;
+}
+.profile-card {
+  border-radius: 0.5rem;
+  border: 1px solid #dee2e6;
 }
 
 @media (max-width: 575.98px) {

--- a/src/controllers/profileCompletionAdminController.js
+++ b/src/controllers/profileCompletionAdminController.js
@@ -1,0 +1,14 @@
+import profileService from '../services/profileCompletionService.js';
+import mapper from '../mappers/profileCompletionMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    try {
+      const users = await profileService.listByRole('REFEREE');
+      return res.json({ profiles: mapper.toPublicArray(users) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+};

--- a/src/mappers/profileCompletionMapper.js
+++ b/src/mappers/profileCompletionMapper.js
@@ -1,0 +1,23 @@
+function toPublic(entry) {
+  if (!entry) return null;
+  const plain = typeof entry.get === 'function' ? entry.get({ plain: true }) : entry;
+  return {
+    id: plain.id,
+    first_name: plain.first_name,
+    last_name: plain.last_name,
+    patronymic: plain.patronymic,
+    birth_date: plain.birth_date,
+    passport: !!plain.Passport,
+    inn: !!plain.Inn,
+    snils: !!plain.Snils,
+    bank_account: !!plain.BankAccount,
+    addresses: plain.UserAddresses && plain.UserAddresses.length > 0,
+    taxation_type: plain.Taxation?.TaxationType?.alias || null,
+  };
+}
+
+function toPublicArray(arr = []) {
+  return arr.map(toPublic);
+}
+
+export default { toPublic, toPublicArray };

--- a/src/mappers/profileCompletionMapper.js
+++ b/src/mappers/profileCompletionMapper.js
@@ -9,10 +9,10 @@ function toPublic(entry) {
     birth_date: plain.birth_date,
     passport: !!plain.Passport,
     inn: !!plain.Inn,
-    snils: !!plain.Snils,
+    snils: !!(plain.Snils || plain.Snil),
     bank_account: !!plain.BankAccount,
     addresses: plain.UserAddresses && plain.UserAddresses.length > 0,
-    taxation_type: plain.Taxation?.TaxationType?.alias || null,
+    taxation_type: plain.Taxation?.TaxationType?.name || null,
   };
 }
 

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -4,6 +4,7 @@ import auth from '../middlewares/auth.js';
 import authorize from '../middlewares/authorize.js';
 import userMapper from '../mappers/userMapper.js';
 import admin from '../controllers/userAdminController.js';
+import profileCompletionAdmin from '../controllers/profileCompletionAdminController.js';
 import selfController from '../controllers/userSelfController.js';
 import innAdmin from '../controllers/innAdminController.js';
 import snilsAdmin from '../controllers/snilsAdminController.js';
@@ -827,6 +828,24 @@ router.get(
   auth,
   authorize('ADMIN'),
   medicalCertificateAdmin.get
+);
+
+/**
+ * @swagger
+ * /users/profile-completion:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: List profile completion for referees
+ *     responses:
+ *       200:
+ *         description: Array of profile statuses
+ */
+router.get(
+  '/profile-completion',
+  auth,
+  authorize('ADMIN'),
+  profileCompletionAdmin.list
 );
 
 export default router;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -70,6 +70,24 @@ router.get('/', auth, authorize('ADMIN'), admin.list);
 
 /**
  * @swagger
+ * /users/profile-completion:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: List profile completion for referees
+ *     responses:
+ *       200:
+ *         description: Array of profile statuses
+ */
+router.get(
+  '/profile-completion',
+  auth,
+  authorize('ADMIN'),
+  profileCompletionAdmin.list
+);
+
+/**
+ * @swagger
  * /users/{id}:
  *   get:
  *     security:
@@ -828,24 +846,6 @@ router.get(
   auth,
   authorize('ADMIN'),
   medicalCertificateAdmin.get
-);
-
-/**
- * @swagger
- * /users/profile-completion:
- *   get:
- *     security:
- *       - bearerAuth: []
- *     summary: List profile completion for referees
- *     responses:
- *       200:
- *         description: Array of profile statuses
- */
-router.get(
-  '/profile-completion',
-  auth,
-  authorize('ADMIN'),
-  profileCompletionAdmin.list
 );
 
 export default router;

--- a/src/services/profileCompletionService.js
+++ b/src/services/profileCompletionService.js
@@ -1,0 +1,27 @@
+import { User, Role, Passport, Inn, Snils, BankAccount, UserAddress, Taxation, TaxationType } from '../models/index.js';
+
+async function listByRole(alias) {
+  return User.findAll({
+    include: [
+      { model: Role, where: { alias }, through: { attributes: [] }, required: true },
+      { model: Passport, attributes: ['id'], required: false },
+      { model: Inn, attributes: ['id'], required: false },
+      { model: Snils, attributes: ['id'], required: false },
+      { model: BankAccount, attributes: ['id'], required: false },
+      { model: UserAddress, attributes: ['id'], required: false },
+      {
+        model: Taxation,
+        attributes: ['id'],
+        include: [{ model: TaxationType }],
+        required: false,
+      },
+    ],
+    order: [
+      ['last_name', 'ASC'],
+      ['first_name', 'ASC'],
+    ],
+    distinct: true,
+  });
+}
+
+export default { listByRole };


### PR DESCRIPTION
## Summary
- add service and controller to fetch profile completion data for referees
- expose `/users/profile-completion` API endpoint
- extend admin user management page with new "Заполнение профиля" tab

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f7f7d0078832dacf692f3630374c6