### PR TITLE
Add task assignment

### DIFF
--- a/src/controllers/taskAdminController.js
+++ b/src/controllers/taskAdminController.js
@@ -1,0 +1,64 @@
+import { validationResult } from 'express-validator';
+
+import taskService from '../services/taskService.js';
+import taskMapper from '../mappers/taskMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    try {
+      const tasks = await taskService.listByUser(req.params.id);
+      return res.json({ tasks: tasks.map(taskMapper.toPublic) });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const task = await taskService.createForUser(
+        req.params.id,
+        req.body,
+        req.user.id
+      );
+      return res.status(201).json({ task: taskMapper.toPublic(task) });
+    } catch (err) {
+      return sendError(res, err, err.status === 404 ? 404 : undefined);
+    }
+  },
+
+  async update(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    try {
+      const task = await taskService.updateForUser(
+        req.params.id,
+        req.params.taskId,
+        req.body,
+        req.user.id
+      );
+      return res.json({ task: taskMapper.toPublic(task) });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
+  async remove(req, res) {
+    try {
+      await taskService.removeForUser(
+        req.params.id,
+        req.params.taskId,
+        req.user.id
+      );
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/mappers/taskMapper.js
+++ b/src/mappers/taskMapper.js
@@ -1,0 +1,27 @@
+function sanitize(obj) {
+  const { id, title, description, TaskType, TaskStatus } = obj;
+  const res = { id, title, description };
+  if (TaskType) {
+    res.type = {
+      id: TaskType.id,
+      name: TaskType.name,
+      alias: TaskType.alias,
+    };
+  }
+  if (TaskStatus) {
+    res.status = {
+      id: TaskStatus.id,
+      name: TaskStatus.name,
+      alias: TaskStatus.alias,
+    };
+  }
+  return res;
+}
+
+function toPublic(task) {
+  if (!task) return null;
+  const plain = typeof task.get === 'function' ? task.get({ plain: true }) : task;
+  return sanitize(plain);
+}
+
+export default { toPublic };

--- a/src/migrations/20250907000000-create-task-types.js
+++ b/src/migrations/20250907000000-create-task-types.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('task_types', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('task_types');
+  },
+};

--- a/src/migrations/20250907001000-create-task-statuses.js
+++ b/src/migrations/20250907001000-create-task-statuses.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('task_statuses', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('task_statuses');
+  },
+};

--- a/src/migrations/20250907002000-create-tasks.js
+++ b/src/migrations/20250907002000-create-tasks.js
@@ -1,0 +1,61 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('tasks', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      type_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'task_types', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+      },
+      status_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'task_statuses', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+      },
+      title: { type: Sequelize.STRING(255), allowNull: false },
+      description: { type: Sequelize.TEXT },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('tasks');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -41,6 +41,9 @@ import MedicalExamRegistrationStatus from './medicalExamRegistrationStatus.js';
 import TrainingRegistration from './trainingRegistration.js';
 import TrainingRole from './trainingRole.js';
 import Sex from './sex.js';
+import TaskType from './taskType.js';
+import TaskStatus from './taskStatus.js';
+import Task from './task.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -193,6 +196,14 @@ Passport.belongsTo(Country, { foreignKey: 'country_id' });
 User.hasMany(EmailCode, { foreignKey: 'user_id' });
 EmailCode.belongsTo(User, { foreignKey: 'user_id' });
 
+/* tasks */
+TaskType.hasMany(Task, { foreignKey: 'type_id' });
+Task.belongsTo(TaskType, { foreignKey: 'type_id' });
+TaskStatus.hasMany(Task, { foreignKey: 'status_id' });
+Task.belongsTo(TaskStatus, { foreignKey: 'status_id' });
+User.hasMany(Task, { foreignKey: 'user_id' });
+Task.belongsTo(User, { foreignKey: 'user_id' });
+
 const auditExclude = ['Log'];
 for (const model of Object.values(sequelize.models)) {
   if (!auditExclude.includes(model.name)) {
@@ -242,4 +253,7 @@ export {
   TrainingRole,
   TrainingRegistration,
   Sex,
+  Task,
+  TaskType,
+  TaskStatus,
 };

--- a/src/models/task.js
+++ b/src/models/task.js
@@ -1,0 +1,38 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class Task extends Model {}
+
+Task.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    type_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    status_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    title: { type: DataTypes.STRING(255), allowNull: false },
+    description: { type: DataTypes.TEXT },
+  },
+  {
+    sequelize,
+    modelName: 'Task',
+    tableName: 'tasks',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default Task;

--- a/src/models/taskStatus.js
+++ b/src/models/taskStatus.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TaskStatus extends Model {}
+
+TaskStatus.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'TaskStatus',
+    tableName: 'task_statuses',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default TaskStatus;

--- a/src/models/taskType.js
+++ b/src/models/taskType.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class TaskType extends Model {}
+
+TaskType.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'TaskType',
+    tableName: 'task_types',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default TaskType;

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -11,6 +11,7 @@ import bankAccountAdmin from '../controllers/bankAccountAdminController.js';
 import taxationAdmin from '../controllers/taxationAdminController.js';
 import addressAdmin from '../controllers/addressAdminController.js';
 import medicalCertificateAdmin from '../controllers/medicalCertificateAdminController.js';
+import taskAdmin from '../controllers/taskAdminController.js';
 import {
   createUserRules,
   updateUserRules,
@@ -21,6 +22,7 @@ import { bankAccountRules } from '../validators/bankAccountValidators.js';
 import { addressRules } from '../validators/addressValidators.js';
 import { medicalCertificateRules } from '../validators/medicalCertificateValidators.js';
 import { createPassportRules } from '../validators/passportValidators.js';
+import { createTaskRules, updateTaskRules } from '../validators/taskValidators.js';
 
 const router = express.Router();
 
@@ -827,6 +829,48 @@ router.get(
   auth,
   authorize('ADMIN'),
   medicalCertificateAdmin.get
+);
+
+/**
+ * @swagger
+ * /users/{id}/tasks:
+ *   get:
+ *     security:
+ *       - bearerAuth: []
+ *     summary: List user's tasks
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: Array of tasks
+ */
+router.get('/:id/tasks', auth, authorize('ADMIN'), taskAdmin.list);
+
+router.post(
+  '/:id/tasks',
+  auth,
+  authorize('ADMIN'),
+  createTaskRules,
+  taskAdmin.create
+);
+
+router.put(
+  '/:id/tasks/:taskId',
+  auth,
+  authorize('ADMIN'),
+  updateTaskRules,
+  taskAdmin.update
+);
+
+router.delete(
+  '/:id/tasks/:taskId',
+  auth,
+  authorize('ADMIN'),
+  taskAdmin.remove
 );
 
 export default router;

--- a/src/seeders/20250916000000-create-task-statuses.js
+++ b/src/seeders/20250916000000-create-task-statuses.js
@@ -1,0 +1,46 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM task_statuses WHERE alias IN (\'PENDING\',\'IN_PROGRESS\',\'COMPLETED\');'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'task_statuses',
+      [
+        {
+          id: uuidv4(),
+          name: 'В ожидании',
+          alias: 'PENDING',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'В работе',
+          alias: 'IN_PROGRESS',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Завершена',
+          alias: 'COMPLETED',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('task_statuses', {
+      alias: ['PENDING', 'IN_PROGRESS', 'COMPLETED'],
+    });
+  },
+};

--- a/src/seeders/20250916001000-create-task-types.js
+++ b/src/seeders/20250916001000-create-task-types.js
@@ -1,0 +1,32 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      'SELECT COUNT(*) AS cnt FROM task_types WHERE alias = \'SELF_EMPLOYMENT_REGISTRATION\';'
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'task_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Зарегистрироваться как самозанятый или ИП',
+          alias: 'SELF_EMPLOYMENT_REGISTRATION',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('task_types', {
+      alias: ['SELF_EMPLOYMENT_REGISTRATION'],
+    });
+  },
+};

--- a/src/services/taskService.js
+++ b/src/services/taskService.js
@@ -1,0 +1,71 @@
+import { Task, TaskType, TaskStatus, User } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+async function listByUser(userId) {
+  return Task.findAll({
+    where: { user_id: userId },
+    include: [TaskType, TaskStatus],
+    order: [['created_at', 'ASC']],
+  });
+}
+
+async function createForUser(userId, data, actorId) {
+  const [user, type, status] = await Promise.all([
+    User.findByPk(userId),
+    TaskType.findOne({ where: { alias: data.type_alias } }),
+    TaskStatus.findOne({ where: { alias: 'PENDING' } }),
+  ]);
+  if (!user) throw new ServiceError('user_not_found', 404);
+  if (!type) throw new ServiceError('task_type_not_found', 404);
+  if (!status) throw new ServiceError('task_status_not_found', 404);
+  const task = await Task.create({
+    user_id: userId,
+    type_id: type.id,
+    status_id: status.id,
+    title: data.title,
+    description: data.description,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return Task.findByPk(task.id, { include: [TaskType, TaskStatus] });
+}
+
+async function updateForUser(userId, taskId, data, actorId) {
+  const task = await Task.findOne({
+    where: { id: taskId, user_id: userId },
+  });
+  if (!task) throw new ServiceError('task_not_found', 404);
+
+  let typeId = task.type_id;
+  if (data.type_alias) {
+    const type = await TaskType.findOne({ where: { alias: data.type_alias } });
+    if (!type) throw new ServiceError('task_type_not_found', 404);
+    typeId = type.id;
+  }
+
+  let statusId = task.status_id;
+  if (data.status_alias) {
+    const status = await TaskStatus.findOne({ where: { alias: data.status_alias } });
+    if (!status) throw new ServiceError('task_status_not_found', 404);
+    statusId = status.id;
+  }
+
+  await task.update({
+    title: data.title ?? task.title,
+    description: data.description ?? task.description,
+    type_id: typeId,
+    status_id: statusId,
+    updated_by: actorId,
+  });
+
+  return Task.findByPk(task.id, { include: [TaskType, TaskStatus] });
+}
+
+async function removeForUser(userId, taskId, actorId = null) {
+  const task = await Task.findOne({ where: { id: taskId, user_id: userId } });
+  if (!task) throw new ServiceError('task_not_found', 404);
+  await task.update({ updated_by: actorId });
+  await task.destroy();
+}
+
+export default { listByUser, createForUser, updateForUser, removeForUser };

--- a/src/validators/taskValidators.js
+++ b/src/validators/taskValidators.js
@@ -1,0 +1,14 @@
+import { body } from 'express-validator';
+
+export const createTaskRules = [
+  body('title').isString().notEmpty(),
+  body('description').optional().isString(),
+  body('type_alias').isString().notEmpty(),
+];
+
+export const updateTaskRules = [
+  body('title').optional().isString().notEmpty(),
+  body('description').optional().isString(),
+  body('type_alias').optional().isString().notEmpty(),
+  body('status_alias').optional().isString().notEmpty(),
+];


### PR DESCRIPTION
## Summary
- create `task_types`, `task_statuses` and `tasks` tables
- seed initial task types and statuses
- implement Task models and service
- add admin endpoints to manage user tasks

## Testing
- `npm run lint`
- `npm test` *(fails: passportService.test.js, trainingService.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_686f83f78f28832d91ca7d3e49111a16