### PR TITLE
Improve test coverage

### DIFF
--- a/tests/passportService.test.js
+++ b/tests/passportService.test.js
@@ -3,6 +3,7 @@ import { expect, jest, test } from '@jest/globals';
 const findOneMock = jest.fn();
 const createMock = jest.fn();
 const destroyMock = jest.fn();
+const updateMock = jest.fn();
 const findByPkMock = jest.fn();
 const findTypeMock = jest.fn();
 const findCountryMock = jest.fn();
@@ -10,7 +11,7 @@ const findExtMock = jest.fn();
 const legacyFindMock = jest.fn();
 const cleanPassportMock = jest.fn();
 
-const passportInstance = { destroy: destroyMock };
+const passportInstance = { destroy: destroyMock, update: updateMock };
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,

--- a/tests/pdf.test.js
+++ b/tests/pdf.test.js
@@ -1,0 +1,55 @@
+import { expect, jest, test, beforeEach } from '@jest/globals';
+
+const accessMock = jest.fn();
+const registerFontMock = jest.fn();
+
+jest.unstable_mockModule('fs', () => ({
+  __esModule: true,
+  default: { accessSync: accessMock, constants: { R_OK: 4 } },
+  accessSync: accessMock,
+  constants: { R_OK: 4 },
+}));
+
+jest.unstable_mockModule('../src/config/pdf.js', () => ({
+  __esModule: true,
+  PDF_FONTS: {
+    regular: '/reg.ttf',
+    bold: '/bold.ttf',
+    italic: '/italic.ttf',
+    boldItalic: '/bi.ttf',
+  },
+}));
+
+const { applyFonts } = await import('../src/utils/pdf.js');
+
+beforeEach(() => {
+  accessMock.mockReset();
+  registerFontMock.mockReset();
+});
+
+test('applyFonts registers provided fonts', () => {
+  const doc = { registerFont: registerFontMock };
+  applyFonts(doc);
+  expect(accessMock).toHaveBeenCalledTimes(4);
+  expect(registerFontMock).toHaveBeenCalledWith('SB-Regular', '/reg.ttf');
+  expect(registerFontMock).toHaveBeenCalledWith('SB-Bold', '/bold.ttf');
+  expect(registerFontMock).toHaveBeenCalledWith('SB-Italic', '/italic.ttf');
+  expect(registerFontMock).toHaveBeenCalledWith('SB-BoldItalic', '/bi.ttf');
+});
+
+test('applyFonts falls back when fonts missing', () => {
+  accessMock.mockImplementation(() => {
+    throw new Error('missing');
+  });
+  const doc = { registerFont: registerFontMock };
+  const res = applyFonts(doc);
+  expect(registerFontMock).toHaveBeenCalledWith(
+    'Default-Regular',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf'
+  );
+  expect(registerFontMock).toHaveBeenCalledWith(
+    'Default-Bold',
+    '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf'
+  );
+  expect(res).toEqual({ regular: 'Default-Regular', bold: 'Default-Bold' });
+});

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -44,8 +44,14 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   TrainingRefereeGroup: { destroy: destroyMock, bulkCreate: bulkCreateMock },
   User: { findByPk: findUserMock },
   TrainingRole: {},
+  Role: {},
   TrainingRegistration: { findOne: findRegMock },
   RefereeGroup: { findAll: findAllGroupsMock },
+}));
+
+jest.unstable_mockModule('../src/models/trainingRegistration.js', () => ({
+  __esModule: true,
+  default: { findOne: findRegMock },
 }));
 
 const { default: service } = await import('../src/services/trainingService.js');


### PR DESCRIPTION
## Summary
- fix broken tests for passport and training services
- mock trainingRegistration model for training service tests
- add pdf utility tests for font handling

## Testing
- `npm test -- --coverage --coverageReporters=text-summary`

------
https://chatgpt.com/codex/tasks/task_e_686f8cd3b084832db66d3aec35d5b335