### PR TITLE
Add past trainings section

### DIFF
--- a/src/controllers/trainingSelfController.js
+++ b/src/controllers/trainingSelfController.js
@@ -30,6 +30,19 @@ export default {
     }
   },
 
+  async past(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    try {
+      const { rows, count } = await trainingRegistrationService.listPastByUser(
+        req.user.id,
+        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
+      );
+      return res.json({ trainings: rows.map(mapper.toPublic), total: count });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+
   async register(req, res) {
     try {
       await trainingRegistrationService.register(

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -28,6 +28,7 @@ router.post(
 );
 router.get('/available', auth, authorize('REFEREE'), selfController.available);
 router.get('/me/upcoming', auth, authorize('REFEREE'), selfController.upcoming);
+router.get('/me/past', auth, authorize('REFEREE'), selfController.past);
 router.get('/:id', auth, authorize('ADMIN'), controller.get);
 router.put(
   '/:id',


### PR DESCRIPTION
## Summary
- split `My trainings` into upcoming and past sections
- expose `/camp-trainings/me/past` API for past trainings
- support past trainings lookup in controller and service

## Testing
- `npm test` *(fails: Jest coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_6870f70b524c832db2055f5636519f8c