### PR TITLE
Increase test coverage

### DIFF
--- a/tests/addressService.test.js
+++ b/tests/addressService.test.js
@@ -1,0 +1,276 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const userFindMock = jest.fn();
+const addressTypeFindMock = jest.fn();
+const userAddressFindMock = jest.fn();
+const userAddressCreateMock = jest.fn();
+const addressCreateMock = jest.fn();
+const addressFindMock = jest.fn();
+const cleanAddressMock = jest.fn();
+const findExtMock = jest.fn();
+const findLegacyMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  Address: { create: addressCreateMock, findByPk: addressFindMock },
+  AddressType: { findOne: addressTypeFindMock },
+  UserAddress: { findOne: userAddressFindMock, create: userAddressCreateMock },
+  User: { findByPk: userFindMock },
+  UserExternalId: { findOne: findExtMock },
+}));
+
+jest.unstable_mockModule('../src/services/dadataService.js', () => ({
+  __esModule: true,
+  default: { cleanAddress: cleanAddressMock },
+  cleanAddress: cleanAddressMock,
+}));
+
+jest.unstable_mockModule('../src/services/legacyUserService.js', () => ({
+  __esModule: true,
+  default: { findById: findLegacyMock },
+  findById: findLegacyMock,
+}));
+
+const servicePath = '../src/services/addressService.js';
+
+beforeEach(() => {
+  jest.resetModules();
+  userFindMock.mockReset();
+  addressTypeFindMock.mockReset();
+  userAddressFindMock.mockReset();
+  userAddressCreateMock.mockReset();
+  addressCreateMock.mockReset();
+  addressFindMock.mockReset();
+  cleanAddressMock.mockReset();
+  findExtMock.mockReset();
+  findLegacyMock.mockReset();
+});
+
+test('createForUser throws when user missing', async () => {
+  userFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.createForUser('u1', 'REG', { result: 'x' }, 'a'))
+    .rejects.toThrow('user_not_found');
+});
+
+test('createForUser throws when type missing', async () => {
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.createForUser('u1', 'REG', { result: 'x' }, 'a'))
+    .rejects.toThrow('address_type_not_found');
+});
+
+test('createForUser throws when address exists', async () => {
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue({});
+  const service = (await import(servicePath)).default;
+  await expect(service.createForUser('u1', 'REG', { result: 'x' }, 'a'))
+    .rejects.toThrow('address_exists');
+});
+
+test('createForUser throws on invalid address', async () => {
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue(null);
+  cleanAddressMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.createForUser('u1', 'REG', { result: 'x' }, 'a'))
+    .rejects.toThrow('invalid_address');
+});
+
+test('createForUser returns created address', async () => {
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue(null);
+  cleanAddressMock.mockResolvedValue({ street: 's', result: 'clean' });
+  addressCreateMock.mockResolvedValue({ id: 'a1' });
+  const service = (await import(servicePath)).default;
+  const res = await service.createForUser('u1', 'REG', { result: 'x' }, 'a');
+  expect(addressCreateMock).toHaveBeenCalledWith({
+    street: 's',
+    result: 'clean',
+    created_by: 'a',
+    updated_by: 'a',
+  });
+  expect(userAddressCreateMock).toHaveBeenCalledWith({
+    user_id: 'u1',
+    address_id: 'a1',
+    address_type_id: 't',
+    created_by: 'a',
+    updated_by: 'a',
+  });
+  expect(res).toEqual({ id: 'a1', AddressType: { id: 't' } });
+});
+
+test('fetchFromLegacy returns null when no external id', async () => {
+  findExtMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toBeNull();
+});
+
+test('fetchFromLegacy returns null when legacy missing', async () => {
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toBeNull();
+});
+
+test('fetchFromLegacy returns null when no address parts', async () => {
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue({});
+  const service = (await import(servicePath)).default;
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toBeNull();
+});
+
+test('fetchFromLegacy returns null when cleaning fails', async () => {
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue({ adr_ind: '1', adr_city: 'C', adr_adr: 'S' });
+  cleanAddressMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  const res = await service.fetchFromLegacy('u1');
+  expect(res).toBeNull();
+});
+
+test('fetchFromLegacy returns cleaned result', async () => {
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue({ adr_ind: '1', adr_city: 'C', adr_adr: 'S' });
+  cleanAddressMock.mockResolvedValue({ result: 'ok' });
+  const service = (await import(servicePath)).default;
+  const res = await service.fetchFromLegacy('u1');
+  expect(cleanAddressMock).toHaveBeenCalled();
+  expect(res).toEqual({ result: 'ok' });
+});
+
+test('importFromLegacy returns existing address', async () => {
+  userAddressFindMock.mockResolvedValueOnce({ id: 'ex' });
+  const service = (await import(servicePath)).default;
+  const res = await service.importFromLegacy('u1', 'a');
+  expect(res).toEqual({ id: 'ex' });
+});
+
+test('importFromLegacy returns null when legacy missing', async () => {
+  userAddressFindMock.mockResolvedValueOnce(null);
+  findExtMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  const res = await service.importFromLegacy('u1', 'a');
+  expect(res).toBeNull();
+});
+
+test('importFromLegacy returns null when create fails', async () => {
+  userAddressFindMock.mockResolvedValueOnce(null); // existing check
+  // fetchFromLegacy success path
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue({ adr_ind: '1', adr_city: 'C', adr_adr: 'S' });
+  cleanAddressMock.mockResolvedValue({ result: 'ok' });
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValueOnce(null); // inside createForUser
+  addressCreateMock.mockRejectedValue(new Error('fail'));
+  const service = (await import(servicePath)).default;
+  const res = await service.importFromLegacy('u1', 'a');
+  expect(res).toBeNull();
+});
+
+test('importFromLegacy creates address from legacy', async () => {
+  userAddressFindMock.mockResolvedValueOnce(null); // existing check
+  findExtMock.mockResolvedValue({ external_id: 'e1' });
+  findLegacyMock.mockResolvedValue({ adr_ind: '1', adr_city: 'C', adr_adr: 'S' });
+  cleanAddressMock.mockResolvedValue({ result: 'ok', street: 'S' });
+  userFindMock.mockResolvedValue({});
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValueOnce(null); // inside createForUser
+  addressCreateMock.mockResolvedValue({ id: 'a1' });
+  const service = (await import(servicePath)).default;
+  const res = await service.importFromLegacy('u1', 'a');
+  expect(res).toEqual({ id: 'a1', AddressType: { id: 't' } });
+});
+
+test('getForUser returns null when type missing', async () => {
+  addressTypeFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.getForUser('u1', 'REG')).rejects.toThrow('address_type_not_found');
+});
+
+test('getForUser returns address', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue({ Address: { id: 'a' }, AddressType: { id: 't' } });
+  const service = (await import(servicePath)).default;
+  const res = await service.getForUser('u1', 'REG');
+  expect(res).toEqual({ id: 'a', AddressType: { id: 't' } });
+});
+
+test('updateForUser updates address', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  const addressUpdate = jest.fn();
+  const uaUpdate = jest.fn();
+  userAddressFindMock.mockResolvedValue({ address_id: 'a1', Address: { update: addressUpdate }, update: uaUpdate });
+  cleanAddressMock.mockResolvedValue({ street: 's', result: 'clean' });
+  addressFindMock.mockResolvedValue({ id: 'a1' });
+  const service = (await import(servicePath)).default;
+  const res = await service.updateForUser('u1', 'REG', { result: 'x' }, 'a');
+  expect(addressUpdate).toHaveBeenCalled();
+  expect(uaUpdate).toHaveBeenCalled();
+  expect(res).toEqual({ id: 'a1', AddressType: { id: 't' } });
+});
+
+test('removeForUser deletes address', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  const addrUpdate = jest.fn();
+  const addrDestroy = jest.fn();
+  const uaUpdate = jest.fn();
+  const uaDestroy = jest.fn();
+  userAddressFindMock.mockResolvedValue({ Address: { update: addrUpdate, destroy: addrDestroy }, update: uaUpdate, destroy: uaDestroy });
+  const service = (await import(servicePath)).default;
+  await service.removeForUser('u1', 'REG', 'a');
+  expect(addrUpdate).toHaveBeenCalledWith({ updated_by: 'a' });
+  expect(addrDestroy).toHaveBeenCalled();
+  expect(uaUpdate).toHaveBeenCalledWith({ updated_by: 'a' });
+  expect(uaDestroy).toHaveBeenCalled();
+});
+
+test('getForUser returns null when address not found', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  const res = await service.getForUser('u1', 'REG');
+  expect(res).toBeNull();
+});
+
+test('updateForUser throws when type missing', async () => {
+  addressTypeFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.updateForUser('u1', 'REG', { result: 'x' }, 'a')).rejects.toThrow('address_type_not_found');
+});
+
+test('updateForUser throws when address missing', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.updateForUser('u1', 'REG', { result: 'x' }, 'a')).rejects.toThrow('address_not_found');
+});
+
+test('updateForUser throws on invalid address', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue({ Address: {}, update: jest.fn() });
+  cleanAddressMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.updateForUser('u1', 'REG', { result: 'x' }, 'a')).rejects.toThrow('invalid_address');
+});
+
+test('removeForUser throws when type missing', async () => {
+  addressTypeFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.removeForUser('u1', 'REG', 'a')).rejects.toThrow('address_type_not_found');
+});
+
+test('removeForUser throws when address missing', async () => {
+  addressTypeFindMock.mockResolvedValue({ id: 't' });
+  userAddressFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.removeForUser('u1', 'REG', 'a')).rejects.toThrow('address_not_found');
+});

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -1,0 +1,26 @@
+import { expect, test, jest } from '@jest/globals';
+import { sendError } from '../src/utils/api.js';
+
+test('sendError uses default values when err missing', () => {
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) };
+  sendError(res);
+  expect(res.status).toHaveBeenCalledWith(400);
+  expect(json).toHaveBeenCalledWith({ error: 'internal_error' });
+});
+
+test('sendError takes status and code from error', () => {
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) };
+  sendError(res, { status: 403, code: 'forbidden' });
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(json).toHaveBeenCalledWith({ error: 'forbidden' });
+});
+
+test('sendError falls back to error message', () => {
+  const json = jest.fn();
+  const res = { status: jest.fn(() => ({ json })) };
+  sendError(res, { message: 'bad', status: 401 });
+  expect(res.status).toHaveBeenCalledWith(401);
+  expect(json).toHaveBeenCalledWith({ error: 'bad' });
+});

--- a/tests/emailCodeAttempts.test.js
+++ b/tests/emailCodeAttempts.test.js
@@ -1,0 +1,28 @@
+import { beforeEach, expect, test } from '@jest/globals';
+import { markFailed, get, clear, _reset, WINDOW_MS } from '../src/services/emailCodeAttempts.js';
+
+beforeEach(() => {
+  _reset();
+});
+
+test('markFailed increments and resets after window', () => {
+  const now = Date.now();
+  expect(markFailed('u', now)).toBe(1);
+  expect(markFailed('u', now + 1000)).toBe(2);
+  expect(get('u', now + 1000)).toBe(2);
+  expect(markFailed('u', now + WINDOW_MS + 1)).toBe(1);
+});
+
+test('clear removes entry', () => {
+  const now = Date.now();
+  markFailed('u', now);
+  clear('u');
+  expect(get('u', now)).toBe(0);
+});
+
+test('get returns 0 after window', () => {
+  const now = Date.now();
+  markFailed('u', now);
+  expect(get('u', now + WINDOW_MS + 1)).toBe(0);
+  expect(get('u', now + WINDOW_MS + 2)).toBe(0);
+});

--- a/tests/personal.test.js
+++ b/tests/personal.test.js
@@ -12,3 +12,14 @@ describe('personal utils', () => {
     expect(isValidSnils('689-169-232 66')).toBe(false);
   });
 });
+  test('isValidSnils early return for small number', () => {
+    expect(isValidSnils('001-001-998 00')).toBe(true);
+  });
+
+  test('isValidSnils handles sum equal to 100', () => {
+    expect(isValidSnils('100-018-999 00')).toBe(true);
+  });
+
+  test('isValidSnils handles modulo check equal to 100', () => {
+    expect(isValidSnils('101-998-999 00')).toBe(true);
+  });

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -261,3 +261,9 @@ test('updatePresence rejects when not coach', async () => {
     service.updatePresence('t1', 'u1', false, 'u2')
   ).rejects.toThrow('access_denied');
 });
+
+test('listAvailable returns empty when no referee group', async () => {
+  findGroupUserMock.mockResolvedValue(null);
+  const res = await service.listAvailable('u1');
+  expect(res).toEqual({ rows: [], count: 0 });
+});


### PR DESCRIPTION
## Summary
- add api sendError tests
- implement extensive addressService tests
- add tests for email code attempt tracking
- expand personal utils tests
- cover trainingRegistrationService listAvailable path

## Testing
- `npm test`
- `npm run test:coverage`

------
https://chatgpt.com/codex/tasks/task_e_68710f799824832d8e78ecc6eea434ab