### PR TITLE
Add loading spinner on medical certificate upload

### DIFF
--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -21,6 +21,7 @@ const ticketError = ref('');
 const fileError = ref('');
 const selectedFile = ref(null);
 const uploadSuccess = ref(false);
+const uploading = ref(false);
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ['application/pdf'];
 let ticketModal;
@@ -190,6 +191,7 @@ async function createTicket() {
     fileError.value = 'Недопустимый формат файла';
     return;
   }
+  uploading.value = true;
   try {
     const { ticket } = await apiFetch('/tickets', {
       method: 'POST',
@@ -203,6 +205,8 @@ async function createTicket() {
     selectedFile.value = null;
   } catch (e) {
     ticketError.value = e.message;
+  } finally {
+    uploading.value = false;
   }
 }
 
@@ -397,7 +401,15 @@ function onFileChange(e) {
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" @click="ticketModal.hide()">Отмена</button>
-          <button type="button" class="btn btn-brand" @click="createTicket">Отправить</button>
+          <button
+            type="button"
+            class="btn btn-brand"
+            @click="createTicket"
+            :disabled="uploading"
+          >
+            <span v-if="uploading" class="spinner-border spinner-border-sm me-2"></span>
+            Отправить
+          </button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add `uploading` ref on Medical.vue
- show spinner inside upload button
- disable upload button while request is in progress

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872859f3770832d9f9a2648a25081b4