### PR TITLE
Add default description for medical certificate tickets

### DIFF
--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -23,6 +23,8 @@ const selectedFile = ref(null);
 const uploadSuccess = ref(false);
 const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
 const ALLOWED_TYPES = ['application/pdf'];
+const DEFAULT_DESCRIPTION =
+  'Прошу приобщить к материалам личного дела мое медицинское заключение-допуск к обслуживанию соревнований. Подтверждаю, что направляемый документ является подлинным.';
 let ticketModal;
 const activeExamId = computed(() => {
   const e = exams.value.find(
@@ -193,7 +195,10 @@ async function createTicket() {
   try {
     const { ticket } = await apiFetch('/tickets', {
       method: 'POST',
-      body: JSON.stringify({ type_alias: 'MED_CERT_UPLOAD' }),
+      body: JSON.stringify({
+        type_alias: 'MED_CERT_UPLOAD',
+        description: DEFAULT_DESCRIPTION,
+      }),
     });
     const form = new FormData();
     form.append('file', file);


### PR DESCRIPTION
## Summary
- prefill MED_CERT_UPLOAD tickets with a standard description when uploading a medical certificate

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68728545a740832db1216bcb212cdd25