### PR TITLE
Show alert when no trainings to sign up

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -530,7 +530,7 @@ function dayOpen(day) {
       </div>
 
       <div v-show="activeTab === 'register'">
-        <p v-if="!groupedAllByDay.length" class="text-muted">Нет доступных тренировок</p>
+        <div v-if="!groupedAllByDay.length" class="alert alert-warning" role="alert">Нет доступных тренировок</div>
         <div v-else class="stadium-list">
           <div
               v-for="g in groupedAllByDay"


### PR DESCRIPTION
## Summary
- alert the user if no training sessions are available to register

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687284ccce20832db89db14a47246983