### PR TITLE
Fix training registration visibility

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -156,7 +156,7 @@ const upcoming = computed(() => {
 });
 
 const availableTrainings = computed(() =>
-    upcoming.value.filter((t) => !t.registered && !t.user_registered)
+    upcoming.value.filter((t) => !t.registered)
 );
 
 const groupedAll = computed(() => groupDetailed(availableTrainings.value));

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -156,7 +156,7 @@ const upcoming = computed(() => {
 });
 
 const availableTrainings = computed(() =>
-    upcoming.value.filter((t) => !t.registered)
+    upcoming.value.filter((t) => !t.registered && !t.user_registered)
 );
 
 const groupedAll = computed(() => groupDetailed(availableTrainings.value));
@@ -195,17 +195,21 @@ function groupByDay(list) {
       });
 }
 
-watch(groupedAllByDay, (groups) => {
-  const current = { ...selectedDates.value };
-  let changed = false;
-  groups.forEach((g) => {
-    if (g.days.length && !current[g.stadium.id]) {
-      current[g.stadium.id] = g.days[0].date.toISOString();
-      changed = true;
-    }
-  });
-  if (changed) selectedDates.value = current;
-});
+watch(
+    groupedAllByDay,
+    (groups) => {
+      const current = { ...selectedDates.value };
+      let changed = false;
+      groups.forEach((g) => {
+        if (g.days.length && !current[g.stadium.id]) {
+          current[g.stadium.id] = g.days[0].date.toISOString();
+          changed = true;
+        }
+      });
+      if (changed) selectedDates.value = current;
+    },
+    { immediate: true }
+);
 
 const weekTrainings = computed(() => {
   const now = new Date();

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -39,6 +39,7 @@ async function loadAll() {
   loading.value = true;
   try {
     await Promise.all([loadAvailable(), loadMine()]);
+    initSelectedDates();
     error.value = '';
     await nextTick();
     applyTooltips();
@@ -166,6 +167,16 @@ const groupedAllByDay = computed(() =>
       days: groupByDay(g.trainings),
     }))
 );
+
+function initSelectedDates() {
+  const result = {};
+  groupedAllByDay.value.forEach((g) => {
+    if (g.days.length) {
+      result[g.stadium.id] = g.days[0].date.toISOString();
+    }
+  });
+  selectedDates.value = result;
+}
 
 function groupByDay(list) {
   const map = {};

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {ref, onMounted, computed, nextTick} from 'vue';
+import {ref, onMounted, computed, nextTick, watch} from 'vue';
 import {RouterLink} from 'vue-router';
 import {apiFetch} from '../api.js';
 import TrainingCard from '../components/TrainingCard.vue';
@@ -194,6 +194,18 @@ function groupByDay(list) {
         return g;
       });
 }
+
+watch(groupedAllByDay, (groups) => {
+  const current = { ...selectedDates.value };
+  let changed = false;
+  groups.forEach((g) => {
+    if (g.days.length && !current[g.stadium.id]) {
+      current[g.stadium.id] = g.days[0].date.toISOString();
+      changed = true;
+    }
+  });
+  if (changed) selectedDates.value = current;
+});
 
 const weekTrainings = computed(() => {
   const now = new Date();


### PR DESCRIPTION
## Summary
- auto-select first available training date in Camps view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872d55d37d8832d8c75a9252b5a58dd