### PR TITLE
Remove status dropdown on ticket admin page

### DIFF
--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -43,9 +43,12 @@ async function changeStatus(ticket, alias) {
 async function progress(ticket) {
   ticket._changing = true;
   try {
-    const { ticket: updated } = await apiFetch(`/tickets/${ticket.id}/progress`, {
-      method: 'POST',
-    });
+    const { ticket: updated } = await apiFetch(
+      `/tickets/${ticket.id}/progress`,
+      {
+        method: 'POST',
+      }
+    );
     const idx = tickets.value.findIndex((t) => t.id === ticket.id);
     if (idx !== -1) tickets.value[idx] = { ...updated, _flash: true };
     setTimeout(() => {
@@ -96,45 +99,33 @@ async function progress(ticket) {
                 <td>{{ t.description }}</td>
                 <td>
                   <div v-for="f in t.files" :key="f.id">
-                    <a :href="f.url" target="_blank" rel="noopener">{{ f.name }}</a>
+                    <a :href="f.url" target="_blank" rel="noopener">{{
+                      f.name
+                    }}</a>
                   </div>
                 </td>
                 <td>{{ t.status.name }}</td>
                 <td class="text-end">
-                  <div class="btn-group">
-                    <button
-                      type="button"
-                      class="btn btn-sm btn-outline-secondary dropdown-toggle"
-                      data-bs-toggle="dropdown"
-                      aria-expanded="false"
-                    >
-                      Статус
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-end">
-                      <li>
-                        <button class="dropdown-item" @click="changeStatus(t, 'CREATED')">
-                          Создан
-                        </button>
-                      </li>
-                      <li>
-                        <button class="dropdown-item" @click="changeStatus(t, 'IN_PROGRESS')">
-                          В работе
-                        </button>
-                      </li>
-                      <li>
-                        <button class="dropdown-item" @click="changeStatus(t, 'CONFIRMED')">
-                          Подтвержден
-                        </button>
-                      </li>
-                      <li>
-                        <button class="dropdown-item" @click="changeStatus(t, 'REJECTED')">
-                          Отклонен
-                        </button>
-                      </li>
-                    </ul>
-                  </div>
                   <button
-                    class="btn btn-sm btn-brand ms-2"
+                    class="btn btn-sm btn-outline-secondary me-2"
+                    @click="changeStatus(t, 'IN_PROGRESS')"
+                  >
+                    В работу
+                  </button>
+                  <button
+                    class="btn btn-sm btn-success me-2"
+                    @click="changeStatus(t, 'CONFIRMED')"
+                  >
+                    Подтвердить
+                  </button>
+                  <button
+                    class="btn btn-sm btn-danger me-2"
+                    @click="changeStatus(t, 'REJECTED')"
+                  >
+                    Отклонить
+                  </button>
+                  <button
+                    class="btn btn-sm btn-brand"
                     @click="progress(t)"
                     :disabled="t._changing"
                   >

--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -40,27 +40,6 @@ async function changeStatus(ticket, alias) {
   }
 }
 
-async function progress(ticket) {
-  ticket._changing = true;
-  try {
-    const { ticket: updated } = await apiFetch(
-      `/tickets/${ticket.id}/progress`,
-      {
-        method: 'POST',
-      }
-    );
-    const idx = tickets.value.findIndex((t) => t.id === ticket.id);
-    if (idx !== -1) tickets.value[idx] = { ...updated, _flash: true };
-    setTimeout(() => {
-      const t = tickets.value.find((tt) => tt.id === ticket.id);
-      if (t) t._flash = false;
-    }, 1000);
-  } catch (e) {
-    alert(e.message);
-  } finally {
-    ticket._changing = false;
-  }
-}
 </script>
 
 <template>
@@ -130,17 +109,6 @@ async function progress(ticket) {
                       <i class="bi bi-x-lg"></i>
                     </button>
                   </template>
-                  <button
-                    class="btn btn-sm btn-brand"
-                    @click="progress(t)"
-                    :disabled="t._changing"
-                  >
-                    <span
-                      v-if="t._changing"
-                      class="spinner-border spinner-border-sm me-1"
-                    ></span>
-                    Далее
-                  </button>
                 </td>
               </tr>
             </tbody>

--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -106,24 +106,30 @@ async function progress(ticket) {
                 </td>
                 <td>{{ t.status.name }}</td>
                 <td class="text-end">
-                  <button
-                    class="btn btn-sm btn-outline-secondary me-2"
-                    @click="changeStatus(t, 'IN_PROGRESS')"
-                  >
-                    В работу
-                  </button>
-                  <button
-                    class="btn btn-sm btn-success me-2"
-                    @click="changeStatus(t, 'CONFIRMED')"
-                  >
-                    Подтвердить
-                  </button>
-                  <button
-                    class="btn btn-sm btn-danger me-2"
-                    @click="changeStatus(t, 'REJECTED')"
-                  >
-                    Отклонить
-                  </button>
+                  <template v-if="t.status.alias === 'CREATED'">
+                    <button
+                      class="btn btn-sm btn-outline-secondary me-2"
+                      @click="changeStatus(t, 'IN_PROGRESS')"
+                    >
+                      В работу
+                    </button>
+                  </template>
+                  <template v-else-if="t.status.alias === 'IN_PROGRESS'">
+                    <button
+                      class="btn btn-sm btn-success me-2"
+                      @click="changeStatus(t, 'CONFIRMED')"
+                      title="Подтвердить"
+                    >
+                      <i class="bi bi-check-lg"></i>
+                    </button>
+                    <button
+                      class="btn btn-sm btn-danger me-2"
+                      @click="changeStatus(t, 'REJECTED')"
+                      title="Отклонить"
+                    >
+                      <i class="bi bi-x-lg"></i>
+                    </button>
+                  </template>
                   <button
                     class="btn btn-sm btn-brand"
                     @click="progress(t)"


### PR DESCRIPTION
## Summary
- simplify ticket status management in admin panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872d899b344832dab4b2d06b02a1182