### PR TITLE
Add ticket type to status update email

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ DADATA_SECRET=your_dadata_secret
 `src/templates/verificationEmail.js` и `src/templates/passwordResetEmail.js`.
 Письма о создании и смене статуса обращения формируются в
 `src/templates/ticketCreatedEmail.js` и `src/templates/ticketStatusChangedEmail.js`.
+Письмо об изменении статуса дополнительно включает тип обращения для удобства пользователя.
 
 `PASSWORD_MIN_LENGTH` and `PASSWORD_PATTERN` allow customizing the
 password policy for user registration. By default passwords must be at

--- a/src/templates/ticketStatusChangedEmail.js
+++ b/src/templates/ticketStatusChangedEmail.js
@@ -1,12 +1,13 @@
 export function renderTicketStatusChangedEmail(ticket) {
   const status = ticket.TicketStatus?.name || '';
+  const type = ticket.TicketType?.name || '';
   const subject = 'Статус обращения обновлён';
-  const text = `Статус вашего обращения изменён на: ${status}.`;
+  const text = `Статус вашего обращения (${type}) изменён на: ${status}.`;
   const html = `
     <div style="font-family: Arial, sans-serif; color: #333;">
       <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
       <p style="font-size:16px;margin:0 0 16px;">
-        Статус вашего обращения изменён на: ${status}.
+        Статус вашего обращения (${type}) изменён на: ${status}.
       </p>
     </div>`;
   return { subject, text, html };


### PR DESCRIPTION
## Summary
- show ticket type in status update notification
- note this behaviour in the README

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872d8b763c8832d90bba350b0021547