### PR TITLE
Fix training registration tab

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -25,6 +25,15 @@ const toastRef = ref(null);
 const toastMessage = ref('');
 let toast;
 
+watch(activeTab, async (tab) => {
+  if (tab === 'register' && !trainings.value.length && !loading.value) {
+    await loadAvailable();
+    initSelectedDates();
+    await nextTick();
+    applyTooltips();
+  }
+});
+
 function shortName(u) {
   const initials = [u.first_name, u.patronymic]
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- load training schedule when switching to the "Запись на тренировки" tab

## Testing
- `npm run lint`
- `npm test`
- `npm run build` in `client`

------
https://chatgpt.com/codex/tasks/task_e_6872e5b6fbcc832d929839c47ff08ffa