### PR TITLE
Fix camp training list refresh

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -39,13 +39,13 @@ async function loadAll() {
   loading.value = true;
   try {
     await Promise.all([loadAvailable(), loadMine()]);
-    initSelectedDates();
     error.value = '';
-    await nextTick();
-    applyTooltips();
   } catch (e) {
     error.value = e.message;
   } finally {
+    initSelectedDates();
+    await nextTick();
+    applyTooltips();
     loading.value = false;
   }
 }
@@ -58,6 +58,9 @@ async function loadAvailable() {
     );
     trainings.value = data.trainings || [];
     error.value = '';
+    initSelectedDates();
+    await nextTick();
+    applyTooltips();
   } catch (e) {
     error.value = e.message;
   } finally {


### PR DESCRIPTION
## Summary
- ensure available camp trainings are selected and tooltips applied even when requests fail
- initialize training date selection after loading individual camps

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872e5b6fbcc832d929839c47ff08ffa