### PR TITLE
Fix training tab display

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -118,6 +118,12 @@ function cancelTooltip(t) {
   return 'Отменить можно не позднее чем за 48 часов';
 }
 
+watch(activeTab, (tab) => {
+  if (tab === 'register' && !trainings.value.length) {
+    loadAvailable();
+  }
+});
+
 const myTrainings = computed(() => mineUpcoming.value);
 
 function groupDetailed(list) {


### PR DESCRIPTION
## Summary
- ensure available trainings load when switching to the registration tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e5b6fbcc832d929839c47ff08ffa