### PR TITLE
Fix training registration tab not loading

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -211,6 +211,13 @@ watch(
     { immediate: true }
 );
 
+watch(activeTab, async (tab) => {
+  if (tab === 'register' && !trainings.value.length) {
+    await loadAvailable();
+    initSelectedDates();
+  }
+});
+
 const weekTrainings = computed(() => {
   const now = new Date();
   const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);


### PR DESCRIPTION
## Summary
- reload training list when user opens the registration tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872e5b6fbcc832d929839c47ff08ffa