### PR TITLE
Fix trainings tab

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -365,7 +365,7 @@ function dayOpen(day) {
       <div v-else>
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
 
-        <div v-show="activeTab === 'mine'">
+        <div v-if="activeTab === 'mine'">
           <div class="card section-card tile fade-in shadow-sm mb-3">
             <div class="card-body p-2">
               <ul class="nav nav-pills nav-fill mb-0 tab-selector" role="tablist">
@@ -560,7 +560,7 @@ function dayOpen(day) {
 
           </div>
 
-          <div v-show="activeTab === 'register'">
+          <div v-if="activeTab === 'register'">
             <div v-if="!groupedAllByDay.length" class="alert alert-warning" role="alert">Нет доступных тренировок</div>
             <div v-else class="stadium-list">
               <div

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -25,6 +25,10 @@ const toastRef = ref(null);
 const toastMessage = ref('');
 let toast;
 
+watch(activeTab, (val) => {
+  if (val === 'register') loadAvailable();
+});
+
 function shortName(u) {
   const initials = [u.first_name, u.patronymic]
       .filter(Boolean)


### PR DESCRIPTION
## Summary
- reload training data when switching to the "register" tab so slots show up

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872ea64f7ac832d8a4d7ab1bfa8bd2b