### PR TITLE
Fix camp tabs visibility

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -333,6 +333,7 @@ function dayOpen(day) {
           <ul class="nav nav-pills nav-fill mb-0 tab-selector">
             <li class="nav-item">
               <button
+                  type="button"
                   class="nav-link"
                   :class="{ active: activeTab === 'mine' }"
                   @click="activeTab = 'mine'"
@@ -342,6 +343,7 @@ function dayOpen(day) {
             </li>
             <li class="nav-item">
               <button
+                  type="button"
                   class="nav-link"
                   :class="{ active: activeTab === 'register' }"
                   @click="activeTab = 'register'"
@@ -412,6 +414,7 @@ function dayOpen(day) {
               <div v-if="!groupedMine.length" class="alert alert-warning">
                 У вас нет тренировок. Перейдите во вкладку
                 <button
+                    type="button"
                     class="btn btn-link p-0"
                     @click="activeTab = 'register'"
                 >


### PR DESCRIPTION
## Summary
- ensure camp tab buttons don't submit forms by setting `type="button"`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872f103085c832db15bfae33c10106f