### PR TITLE
Improve camps registration loading

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -35,14 +35,16 @@ function shortName(u) {
 
 onMounted(loadAll);
 
+watch(activeTab, (tab) => {
+  if (tab === 'register') loadAvailable();
+  else loadMine();
+});
+
 async function loadAll() {
   loading.value = true;
   try {
     await Promise.all([loadAvailable(), loadMine()]);
-    initSelectedDates();
     error.value = '';
-    await nextTick();
-    applyTooltips();
   } catch (e) {
     error.value = e.message;
   } finally {
@@ -57,7 +59,10 @@ async function loadAvailable() {
         `/camp-trainings/available?page=${page.value}&limit=${pageSize}`
     );
     trainings.value = data.trainings || [];
+    initSelectedDates();
     error.value = '';
+    await nextTick();
+    applyTooltips();
   } catch (e) {
     error.value = e.message;
   } finally {
@@ -73,6 +78,8 @@ async function loadMine() {
     ]);
     mineUpcoming.value = upcomingData.trainings || [];
     minePast.value = pastData.trainings || [];
+    await nextTick();
+    applyTooltips();
   } catch (e) {
     // ignore, handled by caller
   }
@@ -361,7 +368,7 @@ function dayOpen(day) {
       <div v-else>
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
 
-        <div v-show="activeTab === 'mine'">
+        <div v-if="activeTab === 'mine'">
           <div class="card section-card tile fade-in shadow-sm mb-3">
             <div class="card-body p-2">
               <ul class="nav nav-pills nav-fill mb-0 tab-selector" role="tablist">
@@ -556,7 +563,7 @@ function dayOpen(day) {
 
           </div>
 
-          <div v-show="activeTab === 'register'">
+          <div v-if="activeTab === 'register'" :key="'register'">
             <div v-if="!groupedAllByDay.length" class="alert alert-warning" role="alert">Нет доступных тренировок</div>
             <div v-else class="stadium-list">
               <div


### PR DESCRIPTION
## Summary
- reload data when switching between "My trainings" and "Registration" tabs
- reinit dates and tooltips after loading available trainings
- apply tooltips after loading personal trainings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872f4581464832d91743255500e23e7