### PR TITLE
Improve personal data notice position

### DIFF
--- a/client/src/components/CookieNotice.vue
+++ b/client/src/components/CookieNotice.vue
@@ -1,13 +1,13 @@
 <template>
   <div
     v-if="visible"
-    class="cookie-notice alert alert-info d-flex align-items-center position-fixed bottom-0 start-50 translate-middle-x mb-3 fade show"
+    class="cookie-notice alert alert-info d-flex flex-column flex-sm-row align-items-center position-fixed bottom-0 start-50 translate-middle-x mb-3 fade show"
     role="alert"
   >
-    <span class="me-3">
+    <span class="me-sm-3 mb-2 mb-sm-0 text-center text-sm-start flex-fill">
       Продолжая работу с сайтом, вы соглашаетесь с использованием файлов cookie и обработкой персональных данных в соответствии с законодательством.
     </span>
-    <button type="button" class="btn btn-brand btn-sm" @click="accept">Принять</button>
+    <button type="button" class="btn btn-brand btn-sm cookie-btn" @click="accept">Принять</button>
   </div>
 </template>
 
@@ -40,6 +40,10 @@ onMounted(() => {
     left: auto !important;
     bottom: auto !important;
     margin-bottom: 0 !important;
+    text-align: center;
+  }
+  .cookie-btn {
+    width: 100%;
   }
 }
 </style>

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -80,7 +80,7 @@ async function login() {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center min-vh-100">
+  <div class="d-flex flex-column align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
       <h2 class="mb-3 text-center">Авторизация</h2>

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -4,6 +4,7 @@ import { useRouter, RouterLink } from 'vue-router'
 import { apiFetch } from '../api.js'
 import { auth, setAuthToken } from '../auth.js'
 import PasswordStrengthMeter from '../components/PasswordStrengthMeter.vue'
+import CookieNotice from '../components/CookieNotice.vue'
 
 const router = useRouter()
 const step = ref(1)
@@ -68,7 +69,7 @@ async function finish() {
 </script>
 
 <template>
-  <div class="d-flex align-items-center justify-content-center min-vh-100">
+  <div class="d-flex flex-column align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <h1 class="mb-3 text-center">Регистрация</h1>
       <p class="text-center mb-3">с использованием существующей учетной записи в личном кабинете судьи</p>
@@ -140,6 +141,7 @@ async function finish() {
         </button>
       </form>
     </div>
+    <CookieNotice />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- show cookie notice under registration form
- use column layout on auth pages to keep notice beneath form on small screens

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872ebe6ba48832d82639c7a7648cedb