### PR TITLE
Add referee search, filters and attendance stats

### DIFF
--- a/src/controllers/refereeGroupAdminController.js
+++ b/src/controllers/refereeGroupAdminController.js
@@ -6,11 +6,12 @@ import { sendError } from '../utils/api.js';
 
 export default {
   async list(req, res) {
-    const { page = '1', limit = '20', season_id } = req.query;
+    const { page = '1', limit = '20', season_id, camp_stadium_id } = req.query;
     const { rows, count } = await refereeGroupService.listAll({
       page: parseInt(page, 10),
       limit: parseInt(limit, 10),
       season_id,
+      camp_stadium_id,
     });
     return res.json({ groups: rows.map(mapper.toPublic), total: count });
   },

--- a/src/mappers/refereeGroupMapper.js
+++ b/src/mappers/refereeGroupMapper.js
@@ -1,8 +1,11 @@
 function sanitize(obj) {
-  const { id, name, season_id, Season } = obj;
-  const res = { id, name, season_id };
+  const { id, name, season_id, camp_stadium_id, Season, CampStadium } = obj;
+  const res = { id, name, season_id, camp_stadium_id };
   if (Season) {
     res.season = { id: Season.id, name: Season.name, alias: Season.alias };
+  }
+  if (CampStadium) {
+    res.stadium = { id: CampStadium.id, name: CampStadium.name };
   }
   return res;
 }

--- a/src/migrations/20250907007000-add-camp-stadium-id-to-referee-groups.js
+++ b/src/migrations/20250907007000-add-camp-stadium-id-to-referee-groups.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('referee_groups', 'camp_stadium_id', {
+      type: Sequelize.UUID,
+      references: { model: 'camp_stadiums', key: 'id' },
+      onUpdate: 'CASCADE',
+      onDelete: 'SET NULL',
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('referee_groups', 'camp_stadium_id');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -144,6 +144,8 @@ RefereeGroup.hasMany(TrainingRefereeGroup, { foreignKey: 'group_id' });
 TrainingRefereeGroup.belongsTo(RefereeGroup, { foreignKey: 'group_id' });
 Season.hasMany(RefereeGroup, { foreignKey: 'season_id' });
 RefereeGroup.belongsTo(Season, { foreignKey: 'season_id' });
+CampStadium.hasMany(RefereeGroup, { foreignKey: 'camp_stadium_id' });
+RefereeGroup.belongsTo(CampStadium, { foreignKey: 'camp_stadium_id' });
 Training.hasMany(TrainingRegistration, { foreignKey: 'training_id' });
 TrainingRegistration.belongsTo(Training, { foreignKey: 'training_id' });
 User.hasMany(TrainingRegistration, { foreignKey: 'user_id' });

--- a/src/models/refereeGroup.js
+++ b/src/models/refereeGroup.js
@@ -12,6 +12,7 @@ RefereeGroup.init(
       primaryKey: true,
     },
     season_id: { type: DataTypes.UUID, allowNull: false },
+    camp_stadium_id: { type: DataTypes.UUID },
     name: { type: DataTypes.STRING(100), allowNull: false },
   },
   {

--- a/src/validators/refereeGroupValidators.js
+++ b/src/validators/refereeGroupValidators.js
@@ -2,10 +2,12 @@ import { body } from 'express-validator';
 
 export const refereeGroupCreateRules = [
   body('season_id').isUUID(),
+  body('camp_stadium_id').optional().isUUID(),
   body('name').isString().notEmpty(),
 ];
 
 export const refereeGroupUpdateRules = [
   body('season_id').optional().isUUID(),
+  body('camp_stadium_id').optional().isUUID(),
   body('name').optional().isString().notEmpty(),
 ];

--- a/tests/refereeGroupService.test.js
+++ b/tests/refereeGroupService.test.js
@@ -25,6 +25,9 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Season: {},
   User: { findByPk: findUserMock },
   Role: {},
+  CampStadium: {},
+  Training: {},
+  TrainingRegistration: {},
 }));
 
 const { default: service } = await import('../src/services/refereeGroupService.js');


### PR DESCRIPTION
## Summary
- enhance referee group service with search, filter and stats helpers
- expose stats via referee group users controller
- extend judges admin tab with search, group/season filters and training stats

## Testing
- `npm run lint`
- `npm test` *(fails: Module jest-circus/build/runner.js in the testRunner option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b4a3d08cc832da50313694886d658