### PR TITLE
Fix pagination visibility and add tax status modal

### DIFF
--- a/client/src/components/TaxationInfo.vue
+++ b/client/src/components/TaxationInfo.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, watch } from 'vue';
 import Modal from 'bootstrap/js/dist/modal';
 import { apiFetch } from '../api.js';
 
@@ -7,6 +7,7 @@ const props = defineProps({
   userId: String,
   editable: { type: Boolean, default: true },
   showOkved: { type: Boolean, default: true },
+  modalOnly: { type: Boolean, default: false },
 });
 
 const taxation = ref(null);
@@ -103,10 +104,19 @@ onMounted(() => {
   }
   load();
 });
+
+watch(
+  () => props.userId,
+  () => {
+    load();
+  }
+);
+
+defineExpose({ openModal });
 </script>
 
 <template>
-  <div class="card section-card tile fade-in shadow-sm mt-4">
+  <div v-if="!props.modalOnly" class="card section-card tile fade-in shadow-sm mt-4">
     <div class="card-body">
       <div class="d-flex justify-content-between mb-3">
         <h5 class="card-title mb-0">Налоговый статус</h5>


### PR DESCRIPTION
## Summary
- expose modal functions on `TaxationInfo.vue`
- add `modalOnly` prop for reuse without card
- reload tax info when `userId` changes
- add hidden `TaxationInfo` modal in AdminUsers
- show update icon when tax status missing

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b4af7fd38832d9261e25f1ca69d06