### PR TITLE
Implement coach attendance verification

### DIFF
--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -220,6 +220,7 @@ async function updateRole(trainingId, userId, roleId, actorId) {
 async function updatePresence(trainingId, userId, present, actorId) {
   const registration = await TrainingRegistration.findOne({
     where: { training_id: trainingId, user_id: userId },
+    include: [TrainingRole],
   });
   if (!registration) throw new ServiceError('registration_not_found', 404);
 
@@ -236,6 +237,9 @@ async function updatePresence(trainingId, userId, present, actorId) {
       include: [TrainingRole],
     });
     if (coachReg?.TrainingRole?.alias !== 'COACH') {
+      throw new ServiceError('access_denied');
+    }
+    if (registration.TrainingRole?.alias === 'COACH') {
       throw new ServiceError('access_denied');
     }
   }

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -262,6 +262,15 @@ test('updatePresence rejects when not coach', async () => {
   ).rejects.toThrow('access_denied');
 });
 
+test('updatePresence rejects when updating coach presence', async () => {
+  findRegMock.mockResolvedValueOnce({ TrainingRole: { alias: 'COACH' } });
+  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'REFEREE' }] });
+  findRegMock.mockResolvedValueOnce({ TrainingRole: { alias: 'COACH' } });
+  await expect(
+    service.updatePresence('t1', 'u1', true, 'u1')
+  ).rejects.toThrow('access_denied');
+});
+
 test('listAvailable returns empty when no referee group', async () => {
   findGroupUserMock.mockResolvedValue(null);
   const res = await service.listAvailable('u1');

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -203,6 +203,16 @@ test('setAttendanceMarked updates for admin', async () => {
   expect(updateMock).toHaveBeenCalledWith({ attendance_marked: true, updated_by: 'admin' });
 });
 
+test('setAttendanceMarked marks coach present', async () => {
+  const updateRegMock = jest.fn();
+  findByPkMock.mockResolvedValue({ update: updateMock });
+  findUserMock.mockResolvedValue({ Roles: [{ alias: 'REFEREE' }] });
+  findRegMock.mockResolvedValue({ TrainingRole: { alias: 'COACH' }, update: updateRegMock });
+  await service.setAttendanceMarked('t1', true, 'u1');
+  expect(updateMock).toHaveBeenCalledWith({ attendance_marked: true, updated_by: 'u1' });
+  expect(updateRegMock).toHaveBeenCalledWith({ present: true, updated_by: 'u1' });
+});
+
 test('setAttendanceMarked rejects when not coach', async () => {
   findByPkMock.mockResolvedValue({ update: updateMock });
   findUserMock.mockResolvedValue({ Roles: [{ alias: 'REFEREE' }] });


### PR DESCRIPTION
## Summary
- prevent marking presence for coaches directly
- mark coach present when attendance is verified
- test coach presence restrictions
- test automatic coach presence update

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b6b5c393c832d8214cdffc95cd9e4