### PR TITLE
Add status filter to admin ticket list

### DIFF
--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -8,11 +8,13 @@ const loading = ref(true);
 const error = ref('');
 const userFilter = ref('');
 const typeFilter = ref('');
+const statusFilter = ref('active');
 const ticketTypes = ref([]);
 
 onMounted(loadTickets);
 
 watch(typeFilter, loadTickets);
+watch(statusFilter, loadTickets);
 let searchTimeout;
 watch(userFilter, () => {
   clearTimeout(searchTimeout);
@@ -34,6 +36,7 @@ async function loadTickets() {
     const params = new URLSearchParams();
     if (userFilter.value) params.set('user', userFilter.value);
     if (typeFilter.value) params.set('type', typeFilter.value);
+    if (statusFilter.value) params.set('status', statusFilter.value);
     const query = params.toString();
     const data = await apiFetch(`/tickets${query ? `?${query}` : ''}`);
     tickets.value = data.tickets || [];
@@ -100,6 +103,12 @@ async function changeStatus(ticket, alias) {
               <option v-for="t in ticketTypes" :key="t.alias" :value="t.alias">
                 {{ t.name }}
               </option>
+            </select>
+          </div>
+          <div class="col-6 col-sm-auto">
+            <select v-model="statusFilter" class="form-select">
+              <option value="active">Активные</option>
+              <option value="completed">Завершенные</option>
             </select>
           </div>
         </div>

--- a/src/controllers/ticketAdminController.js
+++ b/src/controllers/ticketAdminController.js
@@ -8,13 +8,14 @@ import { sendError } from '../utils/api.js';
 
 export default {
   async listAll(req, res) {
-    const { page = '1', limit = '20', user = '', type = '' } = req.query;
+    const { page = '1', limit = '20', user = '', type = '', status = '' } = req.query;
     try {
       const { rows, count } = await ticketService.listAll({
         page: parseInt(page, 10),
         limit: parseInt(limit, 10),
         user: user.trim(),
         type: type.trim(),
+        status: status.trim(),
       });
       const result = [];
       for (const t of rows) {

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -118,9 +118,17 @@ async function listAll(options = {}) {
   const page = Math.max(1, parseInt(options.page || 1, 10));
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
   const offset = (page - 1) * limit;
+  const statusInclude = { model: TicketStatus };
+  if (options.status === 'active') {
+    statusInclude.where = { alias: ['CREATED', 'IN_PROGRESS'] };
+    statusInclude.required = true;
+  } else if (options.status === 'completed') {
+    statusInclude.where = { alias: ['CONFIRMED', 'REJECTED'] };
+    statusInclude.required = true;
+  }
   const include = [
     { model: User },
-    TicketStatus,
+    statusInclude,
     { model: TicketFile, include: [File] },
   ];
   if (options.user) {


### PR DESCRIPTION
## Summary
- add status filter on admin tickets page
- support new status filter in backend controller and service

## Testing
- `npm test -- --coverage=false`

------
https://chatgpt.com/codex/tasks/task_e_687b70709ff4832da179ae3ae6721092