### PR TITLE
Improve error handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -11,6 +11,8 @@ import requestLogger from './src/middlewares/requestLogger.js';
 import rateLimiter from './src/middlewares/rateLimiter.js';
 import swaggerSpec from './src/docs/swagger.js';
 import { ALLOWED_ORIGINS } from './src/config/cors.js';
+import { sendError } from './src/utils/api.js';
+import logger from './logger.js';
 
 const app = express();
 app.set('trust proxy', 2);
@@ -42,6 +44,18 @@ app.use(requestLogger);
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/', indexRouter);
+
+// Catch unhandled routes
+app.use((req, res) => {
+  res.status(404).json({ error: 'not_found' });
+});
+
+// Centralized error handler
+// eslint-disable-next-line no-unused-vars
+app.use((err, _req, res, _next) => {
+  logger.error('Unhandled error processing request: %s', err.stack || err);
+  sendError(res, err, 500);
+});
 
 
 export default app;

--- a/bin/www
+++ b/bin/www
@@ -19,6 +19,14 @@ const debug = debugLib('fhmoscow-pulse:server');
 
 validateEnv();
 
+process.on('unhandledRejection', (err) => {
+  console.error('Unhandled rejection:', err);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('Uncaught exception:', err);
+});
+
 /**
  * Get port from environment and store in Express.
  */


### PR DESCRIPTION
## Summary
- add centralized 404 and error handlers
- log unhandled errors and rejections

## Testing
- `npm test` *(fails: Module jest-circus/build/runner.js in the testRunner option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b70cc7180832d8047071b341515b3