### PR TITLE
Add past training attendance status

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -348,6 +348,16 @@ function attendanceAlertType(t) {
 function dayOpen(day) {
   return day.trainings.some((t) => t.registration_open);
 }
+
+function attendanceStatus(t) {
+  if (!t.attendance_marked) {
+    return { icon: 'bi-clock', text: 'Посещаемость тренировки не отмечена', class: 'text-muted' };
+  }
+  if (t.my_presence) {
+    return { icon: 'bi-check-circle-fill', text: 'Вы посетили тренировку', class: 'text-success' };
+  }
+  return { icon: 'bi-x-circle-fill', text: 'Тренер не подтвердил Ваше присутствие', class: 'text-danger' };
+}
 </script>
 
 <template>
@@ -493,9 +503,19 @@ function dayOpen(day) {
                               "
                             >
                               <i class="bi bi-check2-square" aria-hidden="true"></i>
-                              <span class="visually-hidden">Посещаемость</span>
+                            <span class="visually-hidden">Посещаемость</span>
                             </RouterLink>
                           </div>
+                        </div>
+                        <div
+                            v-if="mineView === 'past'"
+                            class="small d-flex align-items-center mb-1"
+                        >
+                          <i
+                              :class="['bi', attendanceStatus(t).icon, attendanceStatus(t).class, 'me-1']"
+                              aria-hidden="true"
+                          ></i>
+                          <span :class="attendanceStatus(t).class">{{ attendanceStatus(t).text }}</span>
                         </div>
                         <div
                             v-if="attendanceAlertType(t)"
@@ -601,8 +621,18 @@ function dayOpen(day) {
                               :title="cancelTooltip(t)"
                           >
                             <i class="bi bi-x-lg" aria-hidden="true"></i>
-                            <span class="visually-hidden">Отменить</span>
+                          <span class="visually-hidden">Отменить</span>
                           </button>
+                        </div>
+                        <div
+                            v-if="mineView === 'past'"
+                            class="small d-flex align-items-center mb-1"
+                        >
+                          <i
+                              :class="['bi', attendanceStatus(t).icon, attendanceStatus(t).class, 'me-1']"
+                              aria-hidden="true"
+                          ></i>
+                          <span :class="attendanceStatus(t).class">{{ attendanceStatus(t).text }}</span>
                         </div>
                       </div>
                       <div

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -351,12 +351,12 @@ function dayOpen(day) {
 
 function attendanceStatus(t) {
   if (!t.attendance_marked) {
-    return { icon: 'bi-clock', text: 'Посещаемость тренировки не отмечена', class: 'text-muted' };
+    return { icon: 'bi-clock', text: 'Уточняется', class: 'text-muted' };
   }
   if (t.my_presence) {
-    return { icon: 'bi-check-circle-fill', text: 'Вы посетили тренировку', class: 'text-success' };
+    return { icon: 'bi-check-circle-fill', text: 'Посещено', class: 'text-success' };
   }
-  return { icon: 'bi-x-circle-fill', text: 'Тренер не подтвердил Ваше присутствие', class: 'text-danger' };
+  return { icon: 'bi-x-circle-fill', text: 'Не посещено', class: 'text-danger' };
 }
 </script>
 

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -508,7 +508,7 @@ function attendanceStatus(t) {
                           </div>
                         </div>
                         <div
-                            v-if="mineView === 'past'"
+                            v-if="mineView === 'past' && t.my_role?.alias !== 'COACH'"
                             class="small d-flex align-items-center mb-1"
                         >
                           <i
@@ -625,7 +625,7 @@ function attendanceStatus(t) {
                           </button>
                         </div>
                         <div
-                            v-if="mineView === 'past'"
+                            v-if="mineView === 'past' && t.my_role?.alias !== 'COACH'"
                             class="small d-flex align-items-center mb-1"
                         >
                           <i

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -62,6 +62,9 @@ function sanitize(obj) {
   if (obj.my_role) {
     res.my_role = { ...obj.my_role };
   }
+  if (Object.prototype.hasOwnProperty.call(obj, 'my_presence')) {
+    res.my_presence = obj.my_presence;
+  }
   return res;
 }
 

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -340,6 +340,7 @@ async function listUpcomingByUser(userId, options = {}) {
             alias: myReg.TrainingRole.alias,
           }
         : null;
+      const myPresence = myReg?.present ?? null;
       return {
         ...plain,
         available,
@@ -349,6 +350,7 @@ async function listUpcomingByUser(userId, options = {}) {
         ),
         user_registered: true,
         my_role: myRole,
+        my_presence: myPresence,
       };
     }),
     count: mine.length,
@@ -373,7 +375,6 @@ async function listPastByUser(userId, options = {}) {
     ],
     where: {
       end_at: { [Op.lt]: now },
-      attendance_marked: true,
     },
     order: [['start_at', 'DESC']],
     limit,
@@ -402,6 +403,7 @@ async function listPastByUser(userId, options = {}) {
             alias: myReg.TrainingRole.alias,
           }
         : null;
+      const myPresence = myReg?.present ?? null;
       return {
         ...plain,
         available,
@@ -411,6 +413,7 @@ async function listPastByUser(userId, options = {}) {
         ),
         user_registered: true,
         my_role: myRole,
+        my_presence: myPresence,
       };
     }),
     count: mine.length,

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -263,6 +263,24 @@ test('listPastByUser includes my presence', async () => {
   expect(res.rows[0].my_presence).toBe(true);
 });
 
+test('listPastByUser returns unmarked trainings', async () => {
+  const trPlain = {
+    ...training,
+    end_at: new Date(Date.now() - 1000).toISOString(),
+    attendance_marked: false,
+    TrainingRegistrations: [
+      {
+        user_id: 'u1',
+        TrainingRole: { id: 'r1', name: 'Участник', alias: 'PARTICIPANT' },
+      },
+    ],
+  };
+  const tr = { ...trPlain, get: () => trPlain };
+  findAndCountAllMock.mockResolvedValueOnce({ rows: [tr], count: 1 });
+  const res = await service.listPastByUser('u1', {});
+  expect(res.rows[0].attendance_marked).toBe(false);
+});
+
 test('updatePresence updates value for admin', async () => {
   const updateMock = jest.fn();
   findRegMock.mockResolvedValueOnce({ update: updateMock });

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -245,6 +245,24 @@ test('listUpcomingByUser includes my role', async () => {
   expect(findAndCountAllMock).toHaveBeenCalled();
 });
 
+test('listPastByUser includes my presence', async () => {
+  const trPlain = {
+    ...training,
+    end_at: new Date(Date.now() - 1000).toISOString(),
+    TrainingRegistrations: [
+      {
+        user_id: 'u1',
+        present: true,
+        TrainingRole: { id: 'r1', name: 'Участник', alias: 'PARTICIPANT' },
+      },
+    ],
+  };
+  const tr = { ...trPlain, get: () => trPlain };
+  findAndCountAllMock.mockResolvedValueOnce({ rows: [tr], count: 1 });
+  const res = await service.listPastByUser('u1', {});
+  expect(res.rows[0].my_presence).toBe(true);
+});
+
 test('updatePresence updates value for admin', async () => {
   const updateMock = jest.fn();
   findRegMock.mockResolvedValueOnce({ update: updateMock });


### PR DESCRIPTION
## Summary
- display visit status for past trainings
- include my_presence field in training API mapper
- return my_presence from listPastByUser
- test past training presence field

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687b8e95c574832d9fc7c136d5993fbd