### PR TITLE
Update referee group page design

### DIFF
--- a/client/src/components/RefereeGroups.vue
+++ b/client/src/components/RefereeGroups.vue
@@ -131,8 +131,8 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div v-if="groups.length" class="table-responsive">
-          <table class="table table-striped align-middle mb-0">
+        <div v-if="groups.length" class="table-responsive d-none d-sm-block">
+          <table class="table admin-table table-striped align-middle mb-0">
             <thead>
               <tr>
                 <th>Сезон</th>
@@ -155,6 +155,24 @@ defineExpose({ refresh });
               </tr>
             </tbody>
           </table>
+        </div>
+        <div v-if="groups.length" class="d-block d-sm-none">
+          <div v-for="g in groups" :key="g.id" class="card training-card mb-2">
+            <div class="card-body p-2 d-flex justify-content-between">
+              <div>
+                <h6 class="mb-1">{{ g.name }}</h6>
+                <p class="mb-1">{{ g.season ? g.season.name : '' }}</p>
+              </div>
+              <div>
+                <button class="btn btn-sm btn-secondary me-2" @click="openEdit(g)">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>


### PR DESCRIPTION
## Summary
- adjust referee groups table design to match other camp tabs
- include mobile-friendly cards

## Testing
- `npm test` *(fails: coverage threshold not met)*
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687b8fa94724832dae27d320152446f5