### PR TITLE
Hide medical exam block when none available

### DIFF
--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -310,7 +310,7 @@ function onFileChange(e) {
         Файл отправлен. После проверки он будет добавлен в список.
       </div>
       <div
-        v-if="showExams"
+        v-if="showExams && (examsLoading || exams.length)"
         class="card section-card tile fade-in shadow-sm mb-3 mt-3"
       >
         <div class="card-body">
@@ -330,9 +330,6 @@ function onFileChange(e) {
               @toggle="toggleExam"
             />
           </div>
-          <p v-else-if="!examsLoading" class="text-muted mb-0">
-            Нет доступных медосмотров
-          </p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- hide "Upcoming medical exams" section when no exams are available

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687b904a6ff4832da08d49a34ce0f19c