### PR TITLE
Improve normative result handling

### DIFF
--- a/client/src/utils/time.js
+++ b/client/src/utils/time.js
@@ -1,0 +1,16 @@
+export function formatMinutesSeconds(total) {
+  if (total == null || isNaN(total)) return '';
+  const minutes = Math.floor(total / 60);
+  const seconds = Math.round(total % 60);
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}
+
+export function parseMinutesSeconds(str) {
+  if (!str) return null;
+  const match = /^(\d{1,2}):(\d{2})$/.exec(str);
+  if (!match) return null;
+  const minutes = parseInt(match[1], 10);
+  const seconds = parseInt(match[2], 10);
+  if (Number.isNaN(minutes) || Number.isNaN(seconds)) return null;
+  return minutes * 60 + seconds;
+}

--- a/src/services/normativeTypeService.js
+++ b/src/services/normativeTypeService.js
@@ -27,6 +27,15 @@ function parseValue(val, unit) {
   return unit.fractional ? num : Math.round(num);
 }
 
+function parseResultValue(val, unit) {
+  const parsed = parseValue(val, unit);
+  if (parsed == null) return null;
+  if (unit.alias === 'SECONDS' && unit.fractional) {
+    return Math.round(parsed * 100) / 100;
+  }
+  return parsed;
+}
+
 function stepForUnit(unit) {
   if (unit.alias === 'SECONDS' && unit.fractional) return 0.01;
   return 1;
@@ -295,5 +304,5 @@ async function remove(id, actorId = null) {
   await type.destroy();
 }
 
-export { parseValue, stepForUnit, determineZone };
+export { parseValue, parseResultValue, stepForUnit, determineZone };
 export default { listAll, getById, create, update, remove };

--- a/src/validators/normativeResultValidators.js
+++ b/src/validators/normativeResultValidators.js
@@ -1,16 +1,30 @@
 import { body } from 'express-validator';
 
+import { NormativeType, MeasurementUnit } from '../models/index.js';
+import { parseResultValue } from '../services/normativeTypeService.js';
+
 export const normativeResultCreateRules = [
   body('user_id').isUUID(),
   body('season_id').isUUID(),
   body('training_id').optional().isUUID(),
   body('type_id').isUUID(),
-  body('value_type_id').isUUID(),
-  body('unit_id').isUUID(),
-  body('value').isFloat(),
+  body('value')
+    .notEmpty()
+    .custom(async (val, { req }) => {
+      const type = await NormativeType.findByPk(req.body.type_id, {
+        include: [MeasurementUnit],
+      });
+      if (!type) throw new Error('normative_type_not_found');
+      const parsed = parseResultValue(val, type.MeasurementUnit);
+      if (parsed == null) throw new Error('invalid_value');
+      req.body.value = parsed;
+      req.body.unit_id = type.unit_id;
+      req.body.value_type_id = type.value_type_id;
+      return true;
+    }),
 ];
 
 export const normativeResultUpdateRules = [
   body('training_id').optional().isUUID(),
-  body('value').optional().isFloat(),
+  body('value').optional().notEmpty(),
 ];

--- a/tests/normativeResultService.test.js
+++ b/tests/normativeResultService.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   Training: {},
   Season: {},
   User: {},
+  MeasurementUnit: {},
 }));
 
 const determineZoneMock = jest.fn((type) => type.NormativeTypeZones[0]);
@@ -21,6 +22,7 @@ const determineZoneMock = jest.fn((type) => type.NormativeTypeZones[0]);
 jest.unstable_mockModule('../src/services/normativeTypeService.js', () => ({
   __esModule: true,
   determineZone: determineZoneMock,
+  parseResultValue: jest.fn((v) => v),
 }));
 
 const { default: service } = await import('../src/services/normativeResultService.js');

--- a/tests/normativeTypeService.test.js
+++ b/tests/normativeTypeService.test.js
@@ -1,6 +1,7 @@
 import { expect, test, describe } from '@jest/globals';
 import {
   parseValue,
+  parseResultValue,
   stepForUnit,
   determineZone,
 } from '../src/services/normativeTypeService.js';
@@ -34,5 +35,15 @@ describe('normativeTypeService helpers', () => {
     };
     const zone = determineZone(type, 7);
     expect(zone.NormativeZone.alias).toBe('YELLOW');
+  });
+
+  test('parseResultValue rounds seconds', () => {
+    const unit = { alias: 'SECONDS', fractional: true };
+    expect(parseResultValue('12.345', unit)).toBe(12.35);
+  });
+
+  test('parseResultValue parses MIN_SEC', () => {
+    const unit = { alias: 'MIN_SEC', fractional: false };
+    expect(parseResultValue('02:05', unit)).toBe(125);
   });
 });


### PR DESCRIPTION
## Summary
- store normative results consistently according to measurement unit
- round seconds and convert minute-second input to total seconds
- validate normative result values by type on backend
- mask minute-second values in admin UI and show formatted values
- add helper utilities and tests

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687be656f4c8832d88629497e78ffe04