### PR TITLE
Fix container scope on camp admin page

### DIFF
--- a/client/src/views/AdminCampStadiums.vue
+++ b/client/src/views/AdminCampStadiums.vue
@@ -738,7 +738,6 @@ async function toggleTrainingGroup(training, groupId, checked) {
         </nav>
       </div>
 
-    </div>
 
     <div v-if="activeTab === 'types'">
       <div v-if="typesError" class="alert alert-danger">{{ typesError }}</div>
@@ -1198,6 +1197,8 @@ async function toggleTrainingGroup(training, groupId, checked) {
       </div>
     </div>
   </div>
+</div>
+</div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- keep the camp administration container open for all tabs

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687be741b590832d8abc3c7b8971b8d0