### PR TITLE
Add creation date to tickets list

### DIFF
--- a/client/src/views/Tickets.vue
+++ b/client/src/views/Tickets.vue
@@ -7,6 +7,15 @@ const tickets = ref([]);
 const loading = ref(true);
 const error = ref('');
 
+function formatDateTime(value) {
+  if (!value) return '';
+  const d = new Date(value);
+  return d.toLocaleString('ru-RU', {
+    dateStyle: 'short',
+    timeStyle: 'short',
+  });
+}
+
 
 
 onMounted(loadTickets);
@@ -63,6 +72,7 @@ async function deleteTicket(ticket) {
                 <h6 class="mb-0">{{ t.type.name }}</h6>
                 <span class="badge bg-secondary">{{ t.status.name }}</span>
               </div>
+              <p class="text-muted small mb-1">{{ formatDateTime(t.created_at) }}</p>
               <p class="mb-2">{{ t.description || '—' }}</p>
               <div v-if="t.files && t.files.length" class="d-flex flex-wrap gap-2">
                 <a


### PR DESCRIPTION
## Summary
- display creation time for user tickets

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c954d92b4832d8ed726316e62377f