### PR TITLE
Fix MIN_SEC value input parsing

### DIFF
--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -199,7 +199,10 @@ function selectUser(u) {
 }
 
 function onValueInput(e) {
-  if (currentUnit.value?.alias !== 'MIN_SEC') return;
+  if (currentUnit.value?.alias !== 'MIN_SEC') {
+    form.value.value = e.target.value;
+    return;
+  }
   let val = e.target.value.replace(/[^0-9:]/g, '');
   const colon = val.indexOf(':');
   if (colon === -1) {
@@ -468,7 +471,7 @@ defineExpose({ refresh });
                   :type="currentUnit?.alias === 'MIN_SEC' ? 'text' : 'number'"
                   :step="currentUnit?.alias === 'SECONDS' && currentUnit.fractional ? '0.01' : '1'"
                   :pattern="currentUnit?.alias === 'MIN_SEC' ? '\\d{1,2}:\\d{2}' : null"
-                  v-model="form.value.value"
+                  :value="form.value.value"
                   @input="onValueInput"
                   class="form-control"
                   placeholder="Значение"

--- a/client/src/utils/time.js
+++ b/client/src/utils/time.js
@@ -7,10 +7,18 @@ export function formatMinutesSeconds(total) {
 
 export function parseMinutesSeconds(str) {
   if (!str) return null;
+  let minutes;
+  let seconds;
   const match = /^(\d{1,2}):(\d{1,2})$/.exec(str);
-  if (!match) return null;
-  const minutes = parseInt(match[1], 10);
-  const seconds = parseInt(match[2], 10);
+  if (match) {
+    minutes = parseInt(match[1], 10);
+    seconds = parseInt(match[2], 10);
+  } else if (/^\d{3,4}$/.test(str)) {
+    minutes = parseInt(str.slice(0, str.length - 2), 10);
+    seconds = parseInt(str.slice(-2), 10);
+  } else {
+    return null;
+  }
   if (
     Number.isNaN(minutes) ||
     Number.isNaN(seconds) ||

--- a/src/services/normativeTypeService.js
+++ b/src/services/normativeTypeService.js
@@ -15,10 +15,18 @@ function parseValue(val, unit) {
   if (val == null || val === '') return null;
   if (unit.alias === 'MIN_SEC') {
     const str = String(val);
+    let minutes;
+    let seconds;
     const match = /^(\d{1,2}):(\d{1,2})$/.exec(str);
-    if (!match) return null;
-    const minutes = parseInt(match[1], 10);
-    const seconds = parseInt(match[2], 10);
+    if (match) {
+      minutes = parseInt(match[1], 10);
+      seconds = parseInt(match[2], 10);
+    } else if (/^\d{3,4}$/.test(str)) {
+      minutes = parseInt(str.slice(0, str.length - 2), 10);
+      seconds = parseInt(str.slice(-2), 10);
+    } else {
+      return null;
+    }
     if (
       Number.isNaN(minutes) ||
       Number.isNaN(seconds) ||

--- a/tests/normativeTypeService.test.js
+++ b/tests/normativeTypeService.test.js
@@ -12,6 +12,12 @@ describe('normativeTypeService helpers', () => {
     expect(parseValue('03:45', unit)).toBe(225);
   });
 
+  test('parseValue parses MIN_SEC without colon', () => {
+    const unit = { alias: 'MIN_SEC', fractional: false };
+    expect(parseValue('0345', unit)).toBe(225);
+    expect(parseValue('345', unit)).toBe(225);
+  });
+
   test('parseValue parses numeric with rounding', () => {
     const unit = { alias: 'REPS', fractional: false };
     expect(parseValue('12.7', unit)).toBe(13);
@@ -45,5 +51,11 @@ describe('normativeTypeService helpers', () => {
   test('parseResultValue parses MIN_SEC', () => {
     const unit = { alias: 'MIN_SEC', fractional: false };
     expect(parseResultValue('02:05', unit)).toBe(125);
+  });
+
+  test('parseResultValue parses MIN_SEC without colon', () => {
+    const unit = { alias: 'MIN_SEC', fractional: false };
+    expect(parseResultValue('0205', unit)).toBe(125);
+    expect(parseResultValue('205', unit)).toBe(125);
   });
 });


### PR DESCRIPTION
## Summary
- support values without colon in parseValue
- allow colonless input on frontend
- test parseValue/parseResultValue with colonless values

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c94efdde4832dae5ae7770d3d15a5