### PR TITLE
Improve Normatives admin UI

### DIFF
--- a/client/src/components/AdminNormativeGroups.vue
+++ b/client/src/components/AdminNormativeGroups.vue
@@ -132,7 +132,7 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div v-if="groups.length" class="table-responsive">
+        <div v-if="groups.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-striped align-middle mb-0">
             <thead>
               <tr>
@@ -166,6 +166,27 @@ defineExpose({ refresh });
               </tr>
             </tbody>
           </table>
+        </div>
+        <div v-if="groups.length" class="d-block d-sm-none">
+          <div v-for="g in groups" :key="g.id" class="card training-card mb-2">
+            <div class="card-body p-2 d-flex justify-content-between">
+              <div>
+                <h6 class="mb-1">{{ g.name }}</h6>
+                <p class="mb-1">
+                  {{ seasons.find((s) => s.id === g.season_id)?.name || g.season_id }}
+                </p>
+                <p class="mb-1">Обязательная: {{ g.required ? 'Да' : 'Нет' }}</p>
+              </div>
+              <div>
+                <button class="btn btn-sm btn-secondary me-2" @click="openEdit(g)">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
@@ -268,3 +289,38 @@ defineExpose({ refresh });
     </div>
   </div>
 </template>
+
+<style scoped>
+.training-card {
+  border-radius: 0.5rem;
+  border: 1px solid #dee2e6;
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}
+
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 575.98px) {
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -318,7 +318,7 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div v-if="results.length" class="table-responsive">
+        <div v-if="results.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-striped align-middle mb-0">
             <thead>
               <tr>
@@ -358,6 +358,27 @@ defineExpose({ refresh });
               </tr>
             </tbody>
           </table>
+        </div>
+        <div v-if="results.length" class="d-block d-sm-none">
+          <div v-for="r in results" :key="r.id" class="card training-card mb-2">
+            <div class="card-body p-2">
+              <h6 class="mb-1">
+                {{ r.user?.last_name }} {{ r.user?.first_name }}
+              </h6>
+              <p class="mb-1">Тип: {{ types.find((t) => t.id === r.type_id)?.name || r.type_id }}</p>
+              <p class="mb-1">Группа: {{ r.group?.name || '-' }}</p>
+              <p class="mb-1">Значение: {{ formatValue(r) }}</p>
+              <p class="mb-1">Зона: {{ r.zone?.name }}</p>
+              <div class="text-end">
+                <button class="btn btn-sm btn-secondary me-2" @click="openEdit(r)">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button class="btn btn-sm btn-danger" @click="removeResult(r)">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
@@ -528,3 +549,38 @@ defineExpose({ refresh });
     </div>
   </div>
 </template>
+
+<style scoped>
+.training-card {
+  border-radius: 0.5rem;
+  border: 1px solid #dee2e6;
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}
+
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 575.98px) {
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/client/src/components/AdminNormativeTypes.vue
+++ b/client/src/components/AdminNormativeTypes.vue
@@ -283,7 +283,7 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div v-if="types.length" class="table-responsive">
+        <div v-if="types.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-striped align-middle mb-0">
             <thead>
               <tr>
@@ -328,6 +328,27 @@ defineExpose({ refresh });
               </tr>
             </tbody>
           </table>
+        </div>
+        <div v-if="types.length" class="d-block d-sm-none">
+          <div v-for="t in types" :key="t.id" class="card training-card mb-2">
+            <div class="card-body p-2 d-flex justify-content-between">
+              <div>
+                <h6 class="mb-1">{{ t.name }}</h6>
+                <p class="mb-1">
+                  {{ seasons.find((s) => s.id === t.season_id)?.name || t.season_id }}
+                </p>
+                <p class="mb-1">Обязательный: {{ t.required ? 'Да' : 'Нет' }}</p>
+              </div>
+              <div>
+                <button class="btn btn-sm btn-secondary me-2" @click="openEdit(t)">
+                  <i class="bi bi-pencil"></i>
+                </button>
+                <button class="btn btn-sm btn-danger" @click="removeType(t)">
+                  <i class="bi bi-trash"></i>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
@@ -504,3 +525,38 @@ defineExpose({ refresh });
     </div>
   </div>
 </template>
+
+<style scoped>
+.training-card {
+  border-radius: 0.5rem;
+  border: 1px solid #dee2e6;
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}
+
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+@media (max-width: 575.98px) {
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -5,12 +5,12 @@ const userSections = [
   { title: 'Пользователи', icon: 'bi-people', to: '/users' },
   { title: 'Документы', icon: 'bi-file-earmark', to: '/documents-admin' },
   { title: 'Медицина', icon: 'bi-file-earmark-medical', to: '/medical-admin' },
-  { title: 'Нормативы', icon: 'bi-speedometer2', to: '/normatives-admin' },
   { title: 'Обращения', icon: 'bi-chat-dots', to: '/tickets-admin' },
 ]
 
 const refereeSections = [
   { title: 'Управление сборами', icon: 'bi-building', to: '/camp-stadiums' },
+  { title: 'Нормативы', icon: 'bi-speedometer2', to: '/normatives-admin' },
 ]
 </script>
 

--- a/client/src/views/AdminNormatives.vue
+++ b/client/src/views/AdminNormatives.vue
@@ -19,6 +19,7 @@ const activeTab = ref('groups');
           <li class="breadcrumb-item active" aria-current="page">Нормативы</li>
         </ol>
       </nav>
+      <h1 class="mb-3">Нормативы</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3">
         <div class="card-body p-2">
           <ul


### PR DESCRIPTION
## Summary
- show Normatives in referee management section
- display section title in Normatives admin page
- add mobile card views for normative groups, types and results

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687cb3cdfc88832d82f75ea05df641a7