### PR TITLE
Add referee normatives section

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -9,6 +9,7 @@ import Profile from './views/Profile.vue';
 import Medical from './views/Medical.vue';
 import Camps from './views/Camps.vue';
 import Tasks from './views/Tasks.vue';
+import Normatives from './views/Normatives.vue';
 import AdminUsers from './views/AdminUsers.vue';
 import AdminHome from './views/AdminHome.vue';
 import AdminUserEdit from './views/AdminUserEdit.vue';
@@ -49,6 +50,11 @@ const routes = [
     path: '/tasks',
     component: Tasks,
     meta: { requiresAuth: true },
+  },
+  {
+    path: '/normatives',
+    component: Normatives,
+    meta: { requiresAuth: true, requiresReferee: true },
   },
   {
     path: '/trainings/:id/attendance',

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -9,6 +9,7 @@ const basePreparationSections = [
   { title: 'Сборы', icon: 'bi-people-fill', to: '/camps', referee: true },
   { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical', referee: true },
   { title: 'Задачи', icon: 'bi-list-check', to: '/tasks' },
+  { title: 'Нормативы', icon: 'bi-stopwatch', to: '/normatives', referee: true },
 ]
 
 const workSections = [

--- a/client/src/views/Normatives.vue
+++ b/client/src/views/Normatives.vue
@@ -1,0 +1,120 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import { RouterLink } from 'vue-router';
+import { apiFetch } from '../api.js';
+import { formatMinutesSeconds } from '../utils/time.js';
+
+const groups = ref([]);
+const loading = ref(true);
+const error = ref('');
+
+onMounted(load);
+
+async function load() {
+  loading.value = true;
+  try {
+    const data = await apiFetch('/normatives');
+    groups.value = data.groups || [];
+    error.value = '';
+  } catch (e) {
+    error.value = e.message;
+    groups.value = [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+function formatValue(result) {
+  if (!result) return '-';
+  if (result.unit?.alias === 'MIN_SEC') return formatMinutesSeconds(result.value);
+  if (result.unit?.alias === 'SECONDS') return Number(result.value).toFixed(2);
+  return result.value;
+}
+</script>
+
+<template>
+  <div class="py-3 normatives-page">
+    <div class="container">
+      <nav aria-label="breadcrumb" class="mb-2">
+        <ol class="breadcrumb mb-0">
+          <li class="breadcrumb-item">
+            <RouterLink to="/">Главная</RouterLink>
+          </li>
+          <li class="breadcrumb-item active" aria-current="page">Нормативы</li>
+        </ol>
+      </nav>
+      <h1 class="mb-3">Нормативы</h1>
+      <div v-if="error" class="alert alert-danger">{{ error }}</div>
+      <div v-if="loading" class="text-center my-3">
+        <div class="spinner-border" role="status"></div>
+      </div>
+      <div v-for="g in groups" :key="g.id" class="card section-card tile fade-in shadow-sm mb-3">
+        <div class="card-header">
+          <h2 class="h6 mb-0">{{ g.name }}</h2>
+        </div>
+        <div class="card-body p-3">
+          <div v-if="g.types && g.types.length" class="table-responsive">
+            <table class="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Норматив</th>
+                  <th class="text-nowrap">Мой результат</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="t in g.types" :key="t.id">
+                  <td>{{ t.name }}</td>
+                  <td>{{ formatValue(t.result) }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p v-else class="text-muted mb-0">Нормативы отсутствуют.</p>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.section-card {
+  border-radius: 1rem;
+  overflow: hidden;
+  border: 0;
+}
+
+.fade-in {
+  animation: fadeIn 0.4s ease-out;
+}
+
+.normatives-page nav[aria-label='breadcrumb'] {
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 575.98px) {
+  .normatives-page {
+    padding-top: 0.5rem !important;
+    padding-bottom: 0.5rem !important;
+  }
+
+  .normatives-page nav[aria-label='breadcrumb'] {
+    margin-bottom: 0.25rem !important;
+  }
+
+  .section-card {
+    margin-left: -1rem;
+    margin-right: -1rem;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+</style>

--- a/src/controllers/normativeSelfController.js
+++ b/src/controllers/normativeSelfController.js
@@ -1,0 +1,50 @@
+import normativeGroupService from '../services/normativeGroupService.js';
+import normativeTypeService from '../services/normativeTypeService.js';
+import normativeResultService from '../services/normativeResultService.js';
+import groupMapper from '../mappers/normativeGroupMapper.js';
+import typeMapper from '../mappers/normativeTypeMapper.js';
+import resultMapper from '../mappers/normativeResultMapper.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async list(req, res) {
+    const { season_id } = req.query;
+    try {
+      const [groupData, typeData, resultData] = await Promise.all([
+        normativeGroupService.listAll({ page: 1, limit: 1000, season_id }),
+        normativeTypeService.listAll({ page: 1, limit: 1000, season_id }),
+        normativeResultService.listAll({
+          page: 1,
+          limit: 1000,
+          season_id,
+          user_id: req.user.id,
+        }),
+      ]);
+      const groups = groupData.rows.map(groupMapper.toPublic);
+      const types = typeData.rows.map(typeMapper.toPublic);
+      const results = resultData.rows.map(resultMapper.toPublic);
+      const resultByType = {};
+      for (const r of results) {
+        if (!resultByType[r.type_id]) {
+          resultByType[r.type_id] = r;
+        }
+      }
+      const groupMap = Object.fromEntries(
+        groups.map((g) => [g.id, { ...g, types: [] }])
+      );
+      for (const t of types) {
+        const res = resultByType[t.id] || null;
+        (t.groups || []).forEach((g) => {
+          const grp = groupMap[g.group_id];
+          if (grp) {
+            grp.types.push({ ...t, result: res });
+          }
+        });
+      }
+      const list = Object.values(groupMap).filter((g) => g.types.length > 0);
+      return res.json({ groups: list });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -38,6 +38,7 @@ import normativeResultsRouter from './normativeResults.js';
 import measurementUnitsRouter from './measurementUnits.js';
 import normativeValueTypesRouter from './normativeValueTypes.js';
 import normativeZonesRouter from './normativeZones.js';
+import normativesRouter from './normatives.js';
 
 const router = express.Router();
 
@@ -73,6 +74,7 @@ router.use('/normative-results', normativeResultsRouter);
 router.use('/measurement-units', measurementUnitsRouter);
 router.use('/normative-value-types', normativeValueTypesRouter);
 router.use('/normative-zones', normativeZonesRouter);
+router.use('/normatives', normativesRouter);
 router.use('/tasks', tasksRouter);
 router.use('/tickets', ticketsRouter);
 

--- a/src/routes/normatives.js
+++ b/src/routes/normatives.js
@@ -1,0 +1,11 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import controller from '../controllers/normativeSelfController.js';
+
+const router = express.Router();
+
+router.get('/', auth, authorize('REFEREE'), controller.list);
+
+export default router;


### PR DESCRIPTION
## Summary
- add new API route `/normatives` returning groups, types and own results
- expose controller to build normative data for current user
- include client page to view normatives and results
- update router and home page menu

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ce3d676c4832db80a8c0df6b3c7e3