### PR TITLE
Add training history modal

### DIFF
--- a/src/controllers/trainingRegistrationAdminController.js
+++ b/src/controllers/trainingRegistrationAdminController.js
@@ -107,6 +107,20 @@ export default {
     }
   },
 
+  async history(req, res) {
+    const { page = '1', limit = '20' } = req.query;
+    try {
+      const { rows, count } = await trainingRegistrationService.listPastByUser(
+        req.params.userId,
+        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
+      );
+      const trainings = rows.map(trainingMapper.toPublic);
+      return res.json({ trainings, total: count });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+
   async remove(req, res) {
     try {
       await trainingRegistrationService.remove(

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -94,4 +94,11 @@ router.delete(
   selfController.unregister
 );
 
+router.get(
+  '/users/:userId/history',
+  auth,
+  authorize('ADMIN'),
+  registrationsController.history
+);
+
 export default router;


### PR DESCRIPTION
## Summary
- provide API to fetch referee training history
- display history icon in referees table
- show modal with past trainings for a referee

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e0c0ac230832dbffacf7317228843