### PR TITLE
Enable attendance editing in admin training view

### DIFF
--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue';
 import { useRoute, RouterLink } from 'vue-router';
+import Modal from 'bootstrap/js/dist/modal';
 import { apiFetch } from '../api.js';
 
 const ROLE_ORDER = ['COACH', 'EQUIPMENT_MANAGER', 'PARTICIPANT'];
@@ -19,6 +20,25 @@ const addLoading = ref(false);
 const judges = ref([]);
 const trainingRoles = ref([]);
 const lastAddedUserId = ref(null);
+const normativeTypes = ref([]);
+const units = ref([]);
+const resultUser = ref(null);
+const resultForm = ref({ type_id: '', value: '', minutes: '', seconds: '' });
+const resultError = ref('');
+const resultModalRef = ref(null);
+let resultModal;
+
+const attendanceMarked = computed(() => training.value?.attendance_marked);
+const allMarked = computed(() =>
+  list.value
+    .filter((r) => showAttendance(r))
+    .every((r) => r.present === true || r.present === false)
+);
+const currentUnit = computed(() => {
+  const t = normativeTypes.value.find((x) => x.id === resultForm.value.type_id);
+  if (!t) return null;
+  return units.value.find((u) => u.id === t.unit_id) || null;
+});
 
 function showAttendance(reg) {
   const alias = reg.role?.alias;
@@ -62,6 +82,7 @@ onMounted(() => {
   loadRegistrations();
   loadJudges();
   loadTrainingRoles();
+  resultModal = new Modal(resultModalRef.value);
 });
 
 function formatDateTimeRange(start, end) {
@@ -80,6 +101,7 @@ async function loadTraining() {
   try {
     const data = await apiFetch(`/camp-trainings/${route.params.id}`);
     training.value = data.training;
+    await loadNormativeData();
     trainingError.value = '';
   } catch (e) {
     training.value = null;
@@ -148,6 +170,21 @@ async function loadTrainingRoles() {
   }
 }
 
+async function loadNormativeData() {
+  if (!training.value) return;
+  try {
+    const [typeData, unitData] = await Promise.all([
+      apiFetch(`/normative-types?limit=100&season_id=${training.value.season_id}`),
+      apiFetch('/measurement-units'),
+    ]);
+    normativeTypes.value = typeData.types || [];
+    units.value = unitData.units || [];
+  } catch (_e) {
+    normativeTypes.value = [];
+    units.value = [];
+  }
+}
+
 async function addRegistration() {
   if (!addForm.value.user_id || !addForm.value.training_role_id) return;
   try {
@@ -196,6 +233,85 @@ async function updateRegistration(reg) {
     }, 1500);
   } catch (e) {
     alert(e.message);
+  }
+}
+
+async function setPresence(reg, value) {
+  try {
+    await apiFetch(
+      `/camp-trainings/${route.params.id}/registrations/${reg.user.id}/presence`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ present: value }),
+      }
+    );
+    reg.present = value;
+  } catch (e) {
+    alert(e.message);
+  }
+}
+
+async function finishAttendance() {
+  if (!allMarked.value) {
+    alert('Отметьте посещаемость для всех участников');
+    return;
+  }
+  try {
+    const data = await apiFetch(`/camp-trainings/${route.params.id}/attendance`, {
+      method: 'PUT',
+      body: JSON.stringify({ attendance_marked: true }),
+    });
+    training.value = data.training;
+  } catch (e) {
+    alert(e.message);
+  }
+}
+
+function openResultModal(reg) {
+  resultUser.value = reg.user;
+  resultForm.value = { type_id: '', value: '', minutes: '', seconds: '' };
+  resultError.value = '';
+  resultModal.show();
+}
+
+async function saveResult() {
+  const type = normativeTypes.value.find((t) => t.id === resultForm.value.type_id);
+  if (!type) {
+    resultError.value = 'Выберите норматив';
+    return;
+  }
+  const unit = units.value.find((u) => u.id === type.unit_id);
+  let val;
+  if (unit?.alias === 'MIN_SEC') {
+    const m = parseInt(resultForm.value.minutes || '0', 10);
+    const s = parseInt(resultForm.value.seconds || '0', 10);
+    if (Number.isNaN(m) || Number.isNaN(s) || s < 0 || s > 59) {
+      resultError.value = 'Неверное значение';
+      return;
+    }
+    val = `${m}:${String(s).padStart(2, '0')}`;
+  } else {
+    val = resultForm.value.value;
+    if (val === '' || val == null) {
+      resultError.value = 'Неверное значение';
+      return;
+    }
+  }
+  const payload = {
+    user_id: resultUser.value.id,
+    season_id: training.value.season_id,
+    training_id: training.value.id,
+    type_id: type.id,
+    value: val,
+  };
+  try {
+    await apiFetch('/normative-results', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    resultModal.hide();
+  } catch (e) {
+    resultError.value = e.message;
   }
 }
 </script>
@@ -279,12 +395,55 @@ async function updateRegistration(reg) {
                     </select>
                   </td>
                   <td class="text-center">
-                    <template v-if="showAttendance(r)">
-                      <i :class="attendanceIcon(r)" :title="attendanceTitle(r)" aria-hidden="true"></i>
-                      <span class="visually-hidden">{{ attendanceTitle(r) }}</span>
-                    </template>
+                    <div
+                      v-if="showAttendance(r)"
+                      class="btn-group btn-group-sm presence-group"
+                      role="group"
+                    >
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        :id="`present-yes-${r.user.id}`"
+                        :name="`present-${r.user.id}`"
+                        autocomplete="off"
+                        :checked="r.present === true"
+                        @change="setPresence(r, true)"
+                        :disabled="attendanceMarked"
+                      />
+                      <label
+                        class="btn btn-outline-success presence-btn"
+                        :for="`present-yes-${r.user.id}`"
+                      >
+                        <i class="bi bi-check-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Да</span>
+                      </label>
+                      <input
+                        type="radio"
+                        class="btn-check"
+                        :id="`present-no-${r.user.id}`"
+                        :name="`present-${r.user.id}`"
+                        autocomplete="off"
+                        :checked="r.present === false"
+                        @change="setPresence(r, false)"
+                        :disabled="attendanceMarked"
+                      />
+                      <label
+                        class="btn btn-outline-danger presence-btn"
+                        :for="`present-no-${r.user.id}`"
+                      >
+                        <i class="bi bi-x-lg" aria-hidden="true"></i>
+                        <span class="visually-hidden">Нет</span>
+                      </label>
+                    </div>
                   </td>
                   <td class="text-end">
+                    <button
+                      v-if="showAttendance(r)"
+                      class="btn btn-sm btn-secondary me-2"
+                      @click="openResultModal(r)"
+                    >
+                      <i class="bi bi-plus-lg" aria-hidden="true"></i>
+                    </button>
                     <button class="btn btn-sm btn-danger" @click="removeRegistration(r.user.id)">
                       <i class="bi bi-x-lg" aria-hidden="true"></i>
                       <span class="visually-hidden">Удалить</span>
@@ -296,7 +455,107 @@ async function updateRegistration(reg) {
           </div>
         </div>
       </div>
-      <p v-else-if="!loading && !loadingTraining" class="text-muted mb-0">Нет записей.</p>
+      <button
+        v-if="list.length && !attendanceMarked"
+        class="btn btn-brand mt-3"
+        @click="finishAttendance"
+        :disabled="!allMarked"
+      >
+        Завершить
+      </button>
+      <p v-else-if="attendanceMarked" class="alert alert-success mt-3">
+        Посещаемость отмечена
+      </p>
+      <p v-else-if="!loading && !loadingTraining" class="text-muted mb-0">
+        Нет записей.
+      </p>
+      <div ref="resultModalRef" class="modal fade" tabindex="-1">
+        <div class="modal-dialog">
+          <div class="modal-content">
+            <form @submit.prevent="saveResult">
+              <div class="modal-header">
+                <h5 class="modal-title">Результат норматива</h5>
+                <button
+                  type="button"
+                  class="btn-close"
+                  @click="resultModal.hide()"
+                ></button>
+              </div>
+              <div class="modal-body">
+                <div v-if="resultError" class="alert alert-danger mb-2">
+                  {{ resultError }}
+                </div>
+                <div class="form-floating mb-3">
+                  <select
+                    id="resType"
+                    v-model="resultForm.type_id"
+                    class="form-select"
+                    required
+                  >
+                    <option value="" disabled>Тип норматива</option>
+                    <option v-for="t in normativeTypes" :key="t.id" :value="t.id">
+                      {{ t.name }}
+                    </option>
+                  </select>
+                  <label for="resType">Тип норматива</label>
+                </div>
+                <div v-if="currentUnit?.alias === 'MIN_SEC'" class="row g-2 mb-3">
+                  <div class="col">
+                    <div class="form-floating">
+                      <input
+                        id="resMin"
+                        type="number"
+                        min="0"
+                        v-model.number="resultForm.minutes"
+                        class="form-control"
+                        placeholder="Минуты"
+                        required
+                      />
+                      <label for="resMin">Минуты</label>
+                    </div>
+                  </div>
+                  <div class="col">
+                    <div class="form-floating">
+                      <input
+                        id="resSec"
+                        type="number"
+                        min="0"
+                        max="59"
+                        v-model.number="resultForm.seconds"
+                        class="form-control"
+                        placeholder="Секунды"
+                        required
+                      />
+                      <label for="resSec">Секунды</label>
+                    </div>
+                  </div>
+                </div>
+                <div v-else class="form-floating mb-3">
+                  <input
+                    id="resValue"
+                    type="number"
+                    v-model="resultForm.value"
+                    class="form-control"
+                    placeholder="Значение"
+                    required
+                  />
+                  <label for="resValue">Значение</label>
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button
+                  type="button"
+                  class="btn btn-secondary"
+                  @click="resultModal.hide()"
+                >
+                  Отмена
+                </button>
+                <button type="submit" class="btn btn-primary">Сохранить</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
@@ -319,6 +578,14 @@ async function updateRegistration(reg) {
   border-radius: 1rem;
   overflow: hidden;
   border: 0;
+}
+
+.presence-group .presence-btn {
+  width: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem 0;
 }
 
 @media (max-width: 575.98px) {

--- a/src/controllers/normativeResultAdminController.js
+++ b/src/controllers/normativeResultAdminController.js
@@ -6,11 +6,19 @@ import { sendError } from '../utils/api.js';
 
 export default {
   async list(req, res) {
-    const { page = '1', limit = '20', season_id } = req.query;
+    const {
+      page = '1',
+      limit = '20',
+      season_id,
+      training_id,
+      user_id,
+    } = req.query;
     const { rows, count } = await normativeResultService.listAll({
       page: parseInt(page, 10),
       limit: parseInt(limit, 10),
       season_id,
+      training_id,
+      user_id,
     });
     return res.json({ results: rows.map(mapper.toPublic), total: count });
   },

--- a/src/services/normativeResultService.js
+++ b/src/services/normativeResultService.js
@@ -22,6 +22,7 @@ async function listAll(options = {}) {
   const where = {};
   if (options.season_id) where.season_id = options.season_id;
   if (options.user_id) where.user_id = options.user_id;
+  if (options.training_id) where.training_id = options.training_id;
   const { rows, count } = await NormativeResult.findAndCountAll({
     order: [['created_at', 'DESC']],
     limit,


### PR DESCRIPTION
## Summary
- allow admins to mark attendance and add normative results on the training participants page

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687e311f53b4832db84f9d3e8202f71e