### PR TITLE
Fix preparation section order

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -7,9 +7,9 @@ import UpcomingEventCard from '../components/UpcomingEventCard.vue'
 
 const basePreparationSections = [
   { title: 'Сборы', icon: 'bi-people-fill', to: '/camps', referee: true },
+  { title: 'Нормативы', icon: 'bi-stopwatch', to: '/normatives', referee: true },
   { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical', referee: true },
   { title: 'Задачи', icon: 'bi-list-check', to: '/tasks' },
-  { title: 'Нормативы', icon: 'bi-stopwatch', to: '/normatives', referee: true },
 ]
 
 const workSections = [


### PR DESCRIPTION
## Summary
- reorder tiles in the "Preparation for the season" section

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687e80215ed4832d8eea8875ee37d351