### PR TITLE
Adjust admin normative layout

### DIFF
--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -137,6 +137,13 @@ body {
   white-space: nowrap;
 }
 
+.ledger-col {
+  width: 4.5rem;
+  max-width: 4.5rem;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
 .zone-cell {
   font-weight: 600;
   text-align: center;

--- a/client/src/components/AdminNormativeGroups.vue
+++ b/client/src/components/AdminNormativeGroups.vue
@@ -46,6 +46,10 @@ async function load() {
     const data = await apiFetch(`/normative-groups?${params}`);
     groups.value = data.groups;
     total.value = data.total;
+    const pages = Math.max(1, Math.ceil(total.value / pageSize.value));
+    if (currentPage.value > pages) {
+      currentPage.value = pages;
+    }
     error.value = '';
   } catch (e) {
     error.value = e.message;
@@ -140,15 +144,6 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div class="row g-2 justify-content-end align-items-end mb-3">
-          <div class="col-6 col-sm-auto">
-            <select v-model.number="pageSize" class="form-select">
-              <option :value="15">15</option>
-              <option :value="30">30</option>
-              <option :value="50">50</option>
-            </select>
-          </div>
-        </div>
         <div v-if="groups.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-striped align-middle mb-0">
             <thead>
@@ -216,8 +211,16 @@ defineExpose({ refresh });
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
     </div>
-    <nav class="mt-3" v-if="totalPages > 1">
-      <ul class="pagination justify-content-center">
+    <nav
+      class="mt-3 d-flex align-items-center justify-content-between"
+      v-if="groups.length"
+    >
+      <select v-model.number="pageSize" class="form-select form-select-sm w-auto">
+        <option :value="15">15</option>
+        <option :value="30">30</option>
+        <option :value="50">50</option>
+      </select>
+      <ul class="pagination mb-0">
         <li class="page-item" :class="{ disabled: currentPage === 1 }">
           <button
             class="page-link"

--- a/client/src/components/AdminNormativeLedger.vue
+++ b/client/src/components/AdminNormativeLedger.vue
@@ -84,8 +84,8 @@ watch(search, () => {
       </div>
       <div v-if="error" class="alert alert-danger mb-0">{{ error }}</div>
       <div v-else-if="isLoading" class="text-center py-3">Загрузка...</div>
-      <div v-else class="table-responsive">
-        <table class="table table-bordered align-middle mb-0">
+      <div v-else class="table-responsive d-none d-sm-block">
+        <table class="table table-bordered align-middle mb-0 admin-table auto-cols ledger-table">
           <thead>
             <tr>
               <th rowspan="2">Судья</th>
@@ -96,7 +96,7 @@ watch(search, () => {
             <tr>
               <template v-for="g in ledger.groups" :key="g.id">
                 <template v-for="t in g.types" :key="t.id">
-                  <th class="text-center">{{ t.name }}</th>
+                  <th class="text-center ledger-col">{{ t.name }}</th>
                 </template>
               </template>
             </tr>
@@ -116,6 +116,7 @@ watch(search, () => {
                         ? `zone-${j.results[t.id].zone.alias}`
                         : ''
                     ]"
+                    class="ledger-col"
                   >
                     {{ formatValue(t, j.results[t.id]) }}
                   </td>
@@ -124,6 +125,35 @@ watch(search, () => {
             </tr>
           </tbody>
         </table>
+      </div>
+      <div v-else-if="ledger.judges.length" class="d-block d-sm-none">
+        <div v-for="j in ledger.judges" :key="j.user.id" class="card training-card mb-2">
+          <div class="card-body p-2">
+            <h6 class="mb-2">
+              {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic || '' }}
+            </h6>
+            <div v-for="g in ledger.groups" :key="g.id" class="mb-2">
+              <strong class="d-block mb-1">{{ g.name }}</strong>
+              <div
+                v-for="t in g.types"
+                :key="t.id"
+                class="d-flex justify-content-between small"
+              >
+                <span class="me-2">{{ t.name }}</span>
+                <span
+                  :class="[
+                    'zone-cell',
+                    j.results[t.id]?.zone?.alias
+                      ? `zone-${j.results[t.id].zone.alias}`
+                      : ''
+                  ]"
+                  >
+                  {{ formatValue(t, j.results[t.id]) }}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>
@@ -170,6 +200,12 @@ watch(search, () => {
 <style scoped>
 .table-bordered {
   min-width: max-content;
+}
+.ledger-col {
+  width: 4.5rem;
+  max-width: 4.5rem;
+  white-space: normal;
+  word-wrap: break-word;
 }
 .fade-in {
   animation: fadeIn 0.4s ease-out;

--- a/client/src/components/AdminNormativeLedger.vue
+++ b/client/src/components/AdminNormativeLedger.vue
@@ -87,7 +87,15 @@ watch(pageSize, (val) => {
               </td>
               <template v-for="g in ledger.groups" :key="g.id">
                 <template v-for="t in g.types" :key="t.id">
-                  <td class="text-center">
+                  <td
+                    :class="[
+                      'text-center',
+                      'zone-cell',
+                      j.results[t.id]?.zone?.alias
+                        ? `zone-${j.results[t.id].zone.alias}`
+                        : ''
+                    ]"
+                  >
                     {{ formatValue(t, j.results[t.id]) }}
                   </td>
                 </template>

--- a/client/src/components/AdminNormativeLedger.vue
+++ b/client/src/components/AdminNormativeLedger.vue
@@ -9,6 +9,7 @@ const currentPage = ref(1);
 const pageSize = ref(
   parseInt(localStorage.getItem('normativeLedgerPageSize') || '15', 10)
 );
+const search = ref('');
 const isLoading = ref(false);
 const error = ref('');
 
@@ -22,6 +23,7 @@ async function load() {
     const params = new URLSearchParams({
       page: currentPage.value,
       limit: pageSize.value,
+      search: search.value,
     });
     const data = await apiFetch(`/normative-ledger?${params}`);
     ledger.value = data.ledger;
@@ -56,11 +58,30 @@ watch(pageSize, (val) => {
   currentPage.value = 1;
   load();
 });
+
+let searchTimeout;
+watch(search, () => {
+  clearTimeout(searchTimeout);
+  searchTimeout = setTimeout(() => {
+    currentPage.value = 1;
+    load();
+  }, 300);
+});
 </script>
 
 <template>
   <div class="card section-card tile fade-in shadow-sm mb-3">
     <div class="card-body p-2">
+      <div class="row g-2 align-items-end mb-3">
+        <div class="col">
+          <input
+            type="text"
+            class="form-control"
+            placeholder="ФИО судьи"
+            v-model="search"
+          />
+        </div>
+      </div>
       <div v-if="error" class="alert alert-danger mb-0">{{ error }}</div>
       <div v-else-if="isLoading" class="text-center py-3">Загрузка...</div>
       <div v-else class="table-responsive">
@@ -148,7 +169,7 @@ watch(pageSize, (val) => {
 
 <style scoped>
 .table-bordered {
-  min-width: 600px;
+  min-width: max-content;
 }
 .fade-in {
   animation: fadeIn 0.4s ease-out;

--- a/client/src/components/AdminNormativeLedger.vue
+++ b/client/src/components/AdminNormativeLedger.vue
@@ -84,29 +84,30 @@ watch(search, () => {
       </div>
       <div v-if="error" class="alert alert-danger mb-0">{{ error }}</div>
       <div v-else-if="isLoading" class="text-center py-3">Загрузка...</div>
-      <div v-else class="table-responsive d-none d-sm-block">
-        <table class="table table-bordered align-middle mb-0 admin-table auto-cols ledger-table">
-          <thead>
-            <tr>
-              <th rowspan="2">Судья</th>
-              <template v-for="g in ledger.groups" :key="g.id">
-                <th :colspan="g.types.length" class="text-center">{{ g.name }}</th>
-              </template>
-            </tr>
-            <tr>
-              <template v-for="g in ledger.groups" :key="g.id">
-                <template v-for="t in g.types" :key="t.id">
-                  <th class="text-center ledger-col">{{ t.name }}</th>
+      <div v-else>
+        <div class="table-responsive d-none d-sm-block">
+          <table class="table table-bordered align-middle mb-0 admin-table auto-cols ledger-table">
+            <thead>
+              <tr>
+                <th rowspan="2">Судья</th>
+                <template v-for="g in ledger.groups" :key="g.id">
+                  <th :colspan="g.types.length" class="text-center">{{ g.name }}</th>
                 </template>
-              </template>
-            </tr>
-          </thead>
-          <tbody>
-            <tr v-for="j in ledger.judges" :key="j.user.id">
-              <td>
-                {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic || '' }}
-              </td>
-              <template v-for="g in ledger.groups" :key="g.id">
+              </tr>
+              <tr>
+                <template v-for="g in ledger.groups" :key="g.id">
+                  <template v-for="t in g.types" :key="t.id">
+                    <th class="text-center ledger-col">{{ t.name }}</th>
+                  </template>
+                </template>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="j in ledger.judges" :key="j.user.id">
+                <td>
+                  {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic || '' }}
+                </td>
+                <template v-for="g in ledger.groups" :key="g.id">
                 <template v-for="t in g.types" :key="t.id">
                   <td
                     :class="[
@@ -123,15 +124,15 @@ watch(search, () => {
                 </template>
               </template>
             </tr>
-          </tbody>
-        </table>
-      </div>
-      <div v-else-if="ledger.judges.length" class="d-block d-sm-none">
-        <div v-for="j in ledger.judges" :key="j.user.id" class="card training-card mb-2">
-          <div class="card-body p-2">
-            <h6 class="mb-2">
-              {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic || '' }}
-            </h6>
+            </tbody>
+          </table>
+        </div>
+        <div v-if="ledger.judges.length" class="d-block d-sm-none">
+          <div v-for="j in ledger.judges" :key="j.user.id" class="card training-card mb-2">
+            <div class="card-body p-2">
+              <h6 class="mb-2">
+                {{ j.user.last_name }} {{ j.user.first_name }} {{ j.user.patronymic || '' }}
+              </h6>
             <div v-for="g in ledger.groups" :key="g.id" class="mb-2">
               <strong class="d-block mb-1">{{ g.name }}</strong>
               <div

--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -380,13 +380,6 @@ defineExpose({ refresh });
               <option v-for="g in groups" :key="g.id" :value="g.id">{{ g.name }}</option>
             </select>
           </div>
-          <div class="col-6 col-sm-auto">
-            <select v-model.number="pageSize" class="form-select">
-              <option :value="15">15</option>
-              <option :value="30">30</option>
-              <option :value="50">50</option>
-            </select>
-          </div>
         </div>
         <div v-if="error" class="alert alert-danger mb-3">{{ error }}</div>
         <div v-if="isLoading" class="text-center my-3">
@@ -444,8 +437,16 @@ defineExpose({ refresh });
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
     </div>
-    <nav class="mt-3" v-if="totalPages > 1">
-      <ul class="pagination justify-content-center">
+    <nav
+      class="mt-3 d-flex align-items-center justify-content-between"
+      v-if="results.length"
+    >
+      <select v-model.number="pageSize" class="form-select form-select-sm w-auto">
+        <option :value="15">15</option>
+        <option :value="30">30</option>
+        <option :value="50">50</option>
+      </select>
+      <ul class="pagination mb-0">
         <li class="page-item" :class="{ disabled: currentPage === 1 }">
           <button
             class="page-link"

--- a/client/src/components/AdminNormativeTypes.vue
+++ b/client/src/components/AdminNormativeTypes.vue
@@ -105,6 +105,10 @@ async function load() {
     const data = await apiFetch(`/normative-types?${params}`);
     types.value = data.types;
     total.value = data.total;
+    const pages = Math.max(1, Math.ceil(total.value / pageSize.value));
+    if (currentPage.value > pages) {
+      currentPage.value = pages;
+    }
     error.value = '';
   } catch (e) {
     error.value = e.message;
@@ -291,15 +295,6 @@ defineExpose({ refresh });
         <div v-if="isLoading" class="text-center my-3">
           <div class="spinner-border" role="status"></div>
         </div>
-        <div class="row g-2 justify-content-end align-items-end mb-3">
-          <div class="col-6 col-sm-auto">
-            <select v-model.number="pageSize" class="form-select">
-              <option :value="15">15</option>
-              <option :value="30">30</option>
-              <option :value="50">50</option>
-            </select>
-          </div>
-        </div>
         <div v-if="types.length" class="table-responsive d-none d-sm-block">
           <table class="table admin-table table-striped align-middle mb-0">
             <thead>
@@ -378,8 +373,16 @@ defineExpose({ refresh });
         <p v-else-if="!isLoading" class="text-muted mb-0">Записей нет.</p>
       </div>
     </div>
-    <nav class="mt-3" v-if="totalPages > 1">
-      <ul class="pagination justify-content-center">
+    <nav
+      class="mt-3 d-flex align-items-center justify-content-between"
+      v-if="types.length"
+    >
+      <select v-model.number="pageSize" class="form-select form-select-sm w-auto">
+        <option :value="15">15</option>
+        <option :value="30">30</option>
+        <option :value="50">50</option>
+      </select>
+      <ul class="pagination mb-0">
         <li class="page-item" :class="{ disabled: currentPage === 1 }">
           <button
             class="page-link"

--- a/client/src/views/AdminNormatives.vue
+++ b/client/src/views/AdminNormatives.vue
@@ -6,7 +6,7 @@ import AdminNormativeTypes from '../components/AdminNormativeTypes.vue';
 import AdminNormativeResults from '../components/AdminNormativeResults.vue';
 import AdminNormativeLedger from '../components/AdminNormativeLedger.vue';
 
-const activeTab = ref('groups');
+const activeTab = ref('results');
 </script>
 
 <template>
@@ -29,24 +29,6 @@ const activeTab = ref('groups');
             <li class="nav-item">
               <button
                 class="nav-link"
-                :class="{ active: activeTab === 'groups' }"
-                @click="activeTab = 'groups'"
-              >
-                Группы
-              </button>
-            </li>
-            <li class="nav-item">
-              <button
-                class="nav-link"
-                :class="{ active: activeTab === 'types' }"
-                @click="activeTab = 'types'"
-              >
-                Типы
-              </button>
-            </li>
-            <li class="nav-item">
-              <button
-                class="nav-link"
                 :class="{ active: activeTab === 'results' }"
                 @click="activeTab = 'results'"
               >
@@ -62,20 +44,38 @@ const activeTab = ref('groups');
                 Ведомость
               </button>
             </li>
+            <li class="nav-item">
+              <button
+                class="nav-link"
+                :class="{ active: activeTab === 'types' }"
+                @click="activeTab = 'types'"
+              >
+                Типы
+              </button>
+            </li>
+            <li class="nav-item">
+              <button
+                class="nav-link"
+                :class="{ active: activeTab === 'groups' }"
+                @click="activeTab = 'groups'"
+              >
+                Группы
+              </button>
+            </li>
           </ul>
         </div>
       </div>
-      <div v-if="activeTab === 'groups'">
-        <AdminNormativeGroups />
+      <div v-if="activeTab === 'results'">
+        <AdminNormativeResults />
+      </div>
+      <div v-else-if="activeTab === 'ledger'">
+        <AdminNormativeLedger />
       </div>
       <div v-else-if="activeTab === 'types'">
         <AdminNormativeTypes />
       </div>
-      <div v-else-if="activeTab === 'results'">
-        <AdminNormativeResults />
-      </div>
       <div v-else>
-        <AdminNormativeLedger />
+        <AdminNormativeGroups />
       </div>
     </div>
   </div>

--- a/src/controllers/normativeLedgerAdminController.js
+++ b/src/controllers/normativeLedgerAdminController.js
@@ -2,11 +2,12 @@ import normativeLedgerService from '../services/normativeLedgerService.js';
 
 export default {
   async list(req, res) {
-    const { season_id, page = '1', limit = '20' } = req.query;
+    const { season_id, page = '1', limit = '20', search = '' } = req.query;
     const { judges, groups, total } = await normativeLedgerService.list({
       season_id,
       page: parseInt(page, 10),
       limit: parseInt(limit, 10),
+      search: search.trim(),
     });
     res.json({ ledger: { judges, groups }, total });
   },

--- a/src/controllers/normativeLedgerAdminController.js
+++ b/src/controllers/normativeLedgerAdminController.js
@@ -2,8 +2,12 @@ import normativeLedgerService from '../services/normativeLedgerService.js';
 
 export default {
   async list(req, res) {
-    const { season_id } = req.query;
-    const data = await normativeLedgerService.list({ season_id });
-    res.json({ ledger: data });
+    const { season_id, page = '1', limit = '20' } = req.query;
+    const { judges, groups, total } = await normativeLedgerService.list({
+      season_id,
+      page: parseInt(page, 10),
+      limit: parseInt(limit, 10),
+    });
+    res.json({ ledger: { judges, groups }, total });
   },
 };

--- a/src/services/normativeLedgerService.js
+++ b/src/services/normativeLedgerService.js
@@ -1,3 +1,5 @@
+import { Op } from 'sequelize';
+
 import {
   User,
   Role,
@@ -27,6 +29,16 @@ async function list(options = {}) {
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
   const offset = (page - 1) * limit;
 
+  const userWhere = {};
+  if (options.search) {
+    const term = `%${options.search}%`;
+    userWhere[Op.or] = [
+      { last_name: { [Op.iLike]: term } },
+      { first_name: { [Op.iLike]: term } },
+      { patronymic: { [Op.iLike]: term } },
+    ];
+  }
+
   const [{ rows: judges, count }, types] = await Promise.all([
     User.findAndCountAll({
       include: [
@@ -37,6 +49,7 @@ async function list(options = {}) {
           required: true,
         },
       ],
+      where: userWhere,
       order: [
         ['last_name', 'ASC'],
         ['first_name', 'ASC'],

--- a/src/services/normativeResultService.js
+++ b/src/services/normativeResultService.js
@@ -144,7 +144,7 @@ async function create(data, actorId) {
   }
   const value = parseResultValue(data.value, type.MeasurementUnit);
   if (value == null) throw new ServiceError('invalid_value');
-  const zone = determineZone(type, value);
+  const zone = determineZone(type, value, user.sex_id);
   const res = await NormativeResult.create({
     user_id: data.user_id,
     season_id: data.season_id,
@@ -167,6 +167,7 @@ async function update(id, data, actorId) {
         model: NormativeType,
         include: [MeasurementUnit, NormativeTypeZone],
       },
+      { model: User },
     ],
   });
   if (!res) throw new ServiceError('normative_result_not_found', 404);
@@ -175,7 +176,7 @@ async function update(id, data, actorId) {
     newValue = parseResultValue(data.value, res.NormativeType.MeasurementUnit);
     if (newValue == null) throw new ServiceError('invalid_value');
   }
-  const zone = determineZone(res.NormativeType, newValue);
+  const zone = determineZone(res.NormativeType, newValue, res.User?.sex_id);
   await res.update(
     {
       training_id: data.training_id ?? res.training_id,

--- a/src/services/normativeTypeService.js
+++ b/src/services/normativeTypeService.js
@@ -188,6 +188,7 @@ async function listAll(options = {}) {
   return NormativeType.findAndCountAll({
     include: [NormativeTypeZone, NormativeGroupType],
     order: [['name', 'ASC']],
+    distinct: true,
     limit,
     offset,
     where,

--- a/tests/normativeLedgerService.test.js
+++ b/tests/normativeLedgerService.test.js
@@ -93,3 +93,10 @@ test('list returns best results and total', async () => {
   expect(judges[0].results.t1.value).toBe(7);
   expect(judges[0].results.t2.value).toBe(8);
 });
+
+test('list applies search filter', async () => {
+  await service.list({ search: 'Pet' });
+  expect(findAndCountAllUsersMock).toHaveBeenCalledWith(
+    expect.objectContaining({ where: expect.any(Object) })
+  );
+});

--- a/tests/normativeLedgerService.test.js
+++ b/tests/normativeLedgerService.test.js
@@ -1,12 +1,12 @@
 import { jest, expect, test } from '@jest/globals';
 
-const findAllUsersMock = jest.fn();
+const findAndCountAllUsersMock = jest.fn();
 const findAllTypesMock = jest.fn();
 const findAllResultsMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
-  User: { findAll: findAllUsersMock },
+  User: { findAndCountAll: findAndCountAllUsersMock },
   Role: {},
   NormativeType: { findAll: findAllTypesMock },
   NormativeGroupType: {},
@@ -35,7 +35,7 @@ jest.unstable_mockModule('../src/mappers/normativeZoneMapper.js', () => ({
 
 const { default: service } = await import('../src/services/normativeLedgerService.js');
 
-findAllUsersMock.mockResolvedValue([{ id: 'u1' }]);
+findAndCountAllUsersMock.mockResolvedValue({ rows: [{ id: 'u1' }], count: 1 });
 findAllTypesMock.mockResolvedValue([
   {
     id: 't1',
@@ -81,8 +81,12 @@ findAllResultsMock.mockResolvedValue([
   },
 ]);
 
-test('list returns best results', async () => {
-  const { judges, groups } = await service.list();
+test('list returns best results and total', async () => {
+  const { judges, groups, total } = await service.list({ page: 2, limit: 5 });
+  expect(total).toBe(1);
+  expect(findAndCountAllUsersMock).toHaveBeenCalledWith(
+    expect.objectContaining({ limit: 5, offset: 5 })
+  );
   expect(judges).toHaveLength(1);
   expect(groups[0].types).toHaveLength(2);
   expect(groups[0].types[0].unit_alias).toBe('MIN_SEC');

--- a/tests/normativeResultService.test.js
+++ b/tests/normativeResultService.test.js
@@ -69,7 +69,7 @@ findTypeMock.mockResolvedValue({
   NormativeTypeZone: [],
 });
 findSeasonMock.mockResolvedValue({ id: 's1' });
-findUserMock.mockResolvedValue({ id: 'u1' });
+findUserMock.mockResolvedValue({ id: 'u1', sex_id: 'sx1' });
 findRegMock.mockResolvedValue(null);
 createRegMock.mockResolvedValue({});
 findRoleMock.mockResolvedValue({ id: 'role1' });
@@ -103,4 +103,15 @@ test('create ensures registration', async () => {
     expect.objectContaining({ training_id: 'tr1', user_id: 'u1', present: true })
   );
   expect(createResultMock).toHaveBeenCalled();
+});
+
+test('create passes user sex to zone determination', async () => {
+  await service.create({
+    user_id: 'u1',
+    season_id: 's1',
+    training_id: 'tr1',
+    type_id: 't1',
+    value: 5,
+  });
+  expect(determineZoneMock).toHaveBeenCalledWith(expect.any(Object), 5, 'sx1');
 });

--- a/tests/normativeResultService.test.js
+++ b/tests/normativeResultService.test.js
@@ -1,20 +1,37 @@
 import { jest, expect, test } from '@jest/globals';
 
 const findAndCountAllMock = jest.fn();
+const createResultMock = jest.fn();
+const findTypeMock = jest.fn();
+const findSeasonMock = jest.fn();
+const findUserMock = jest.fn();
+const findRegMock = jest.fn();
+const createRegMock = jest.fn();
+const findRoleMock = jest.fn();
+const findResultByPkMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
-  NormativeResult: { findAndCountAll: findAndCountAllMock },
-  NormativeType: {},
+  NormativeResult: {
+    findAndCountAll: findAndCountAllMock,
+    create: createResultMock,
+    findByPk: findResultByPkMock,
+  },
+  NormativeType: { findByPk: findTypeMock },
   NormativeTypeZone: {},
   NormativeGroupType: {},
   NormativeGroup: {},
   NormativeZone: {},
   CampStadium: {},
   Training: {},
-  Season: {},
-  User: {},
+  Season: { findByPk: findSeasonMock },
+  User: { findByPk: findUserMock },
   MeasurementUnit: {},
+  TrainingRegistration: {
+    findOne: findRegMock,
+    create: createRegMock,
+  },
+  TrainingRole: { findOne: findRoleMock },
 }));
 
 const determineZoneMock = jest.fn();
@@ -41,6 +58,21 @@ const dataRow = {
 };
 
 findAndCountAllMock.mockResolvedValue({ rows: [dataRow], count: 1 });
+createResultMock.mockResolvedValue({ id: 'nr1' });
+findResultByPkMock.mockResolvedValue({ id: 'nr1' });
+findTypeMock.mockResolvedValue({
+  id: 't1',
+  unit_id: 'u1',
+  value_type_id: 'vt1',
+  season_id: 's1',
+  MeasurementUnit: {},
+  NormativeTypeZone: [],
+});
+findSeasonMock.mockResolvedValue({ id: 's1' });
+findUserMock.mockResolvedValue({ id: 'u1' });
+findRegMock.mockResolvedValue(null);
+createRegMock.mockResolvedValue({});
+findRoleMock.mockResolvedValue({ id: 'role1' });
 
 test('listAll filters by user and maps zone and group', async () => {
   const { rows, count } = await service.listAll({ user_id: 'u1' });
@@ -53,4 +85,22 @@ test('listAll filters by user and maps zone and group', async () => {
   );
   expect(rows[0].zone.alias).toBe('YELLOW');
   expect(rows[0].group.name).toBe('G1');
+});
+
+test('create ensures registration', async () => {
+  await service.create({
+    user_id: 'u1',
+    season_id: 's1',
+    training_id: 'tr1',
+    type_id: 't1',
+    value: 5,
+  });
+  expect(findRegMock).toHaveBeenCalledWith({
+    where: { training_id: 'tr1', user_id: 'u1' },
+    paranoid: false,
+  });
+  expect(createRegMock).toHaveBeenCalledWith(
+    expect.objectContaining({ training_id: 'tr1', user_id: 'u1', present: true })
+  );
+  expect(createResultMock).toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- reorder tabs in admin normative section
- make normative types and groups page size configurable

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e80ad5f24832d9753b4252d9a6cfc