### PR TITLE
Move past training logic

### DIFF
--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -218,10 +218,7 @@ const upcomingWeekTrainings = computed(() => {
   return mineUpcoming.value.filter((t) => {
     const start = new Date(t.start_at);
     const finish = new Date(t.end_at);
-    if (!t.attendance_marked && t.my_role?.alias === 'COACH') {
-      return true;
-    }
-    // show only trainings that have not finished yet
+    // show trainings that have not finished yet
     // and start within the next week
     return finish > now && start < end;
   });

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -308,8 +308,8 @@ async function listUpcomingByUser(userId, options = {}) {
       [Op.or]: [
         { start_at: { [Op.between]: [now, end] } },
         {
-          attendance_marked: false,
           start_at: { [Op.lt]: now },
+          end_at: { [Op.gt]: now },
         },
       ],
     },

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -245,6 +245,15 @@ test('listUpcomingByUser includes my role', async () => {
   expect(findAndCountAllMock).toHaveBeenCalled();
 });
 
+test('listUpcomingByUser excludes finished unmarked trainings', async () => {
+  findAndCountAllMock.mockResolvedValueOnce({ rows: [], count: 0 });
+  await service.listUpcomingByUser('u1', {});
+  const where = findAndCountAllMock.mock.calls[0][0].where;
+  const cond = where[Object.getOwnPropertySymbols(where)[0]][1];
+  expect(cond).not.toHaveProperty('attendance_marked');
+  expect(cond).toHaveProperty('end_at');
+});
+
 test('listPastByUser includes my presence', async () => {
   const trPlain = {
     ...training,


### PR DESCRIPTION
## Summary
- don't keep finished trainings in upcoming list
- keep warning but in past list
- update service test to check query

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e9ed8655c832d9ea2d942b06bde0d