### PR TITLE
Improve trainingTypeService tests

### DIFF
--- a/tests/trainingTypeService.test.js
+++ b/tests/trainingTypeService.test.js
@@ -25,7 +25,9 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   },
 }));
 
-const { default: service } = await import('../src/services/trainingTypeService.js');
+const { default: service } = await import(
+  '../src/services/trainingTypeService.js'
+);
 
 test('update modifies name and capacity', async () => {
   findByPkMock.mockResolvedValue({ ...instance, name: 'Old', alias: 'old' });
@@ -61,6 +63,52 @@ test('remove deletes training type', async () => {
 test('remove throws when not found', async () => {
   findByPkMock.mockResolvedValue(null);
   await expect(service.remove('t1', 'admin')).rejects.toThrow(
+    'training_type_not_found'
+  );
+});
+
+test('listAll forwards pagination params', async () => {
+  findAndCountAllMock.mockResolvedValue({ rows: [], count: 0 });
+  const result = await service.listAll({ page: 2, limit: 5 });
+  expect(result).toEqual({ rows: [], count: 0 });
+  expect(findAndCountAllMock).toHaveBeenCalledWith({
+    order: [['name', 'ASC']],
+    limit: 5,
+    offset: 5,
+  });
+});
+
+test('getById returns type when found', async () => {
+  const type = { id: 't1' };
+  findByPkMock.mockResolvedValue(type);
+  const result = await service.getById('t1');
+  expect(result).toBe(type);
+});
+
+test('getById throws when not found', async () => {
+  findByPkMock.mockResolvedValue(null);
+  await expect(service.getById('bad')).rejects.toThrow(
+    'training_type_not_found'
+  );
+});
+
+test('update keeps existing name when not provided', async () => {
+  findByPkMock.mockResolvedValue({ ...instance, name: 'Old', alias: 'OLD' });
+  await service.update('t1', { default_capacity: 15 }, 'admin');
+  expect(updateMock).toHaveBeenCalledWith(
+    {
+      name: 'Old',
+      alias: 'OLD',
+      default_capacity: 15,
+      updated_by: 'admin',
+    },
+    { returning: false }
+  );
+});
+
+test('update throws when not found', async () => {
+  findByPkMock.mockResolvedValue(null);
+  await expect(service.update('t1', { name: 'X' }, 'admin')).rejects.toThrow(
     'training_type_not_found'
   );
 });


### PR DESCRIPTION
## Summary
- expand unit tests for `trainingTypeService`
- cover list retrieval and getById
- check update branches and not-found cases

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ea49220cc832d97490fe3d30510cc