### PR TITLE
Fix missing error translations

### DIFF
--- a/client/src/errors.js
+++ b/client/src/errors.js
@@ -41,6 +41,12 @@ export const ERROR_MESSAGES = {
   user_not_found: 'Пользователь не найден',
   file_too_large: 'Файл слишком большой',
   invalid_file_type: 'Недопустимый тип файла',
+  address_not_found: 'Адрес не найден',
+  awaiting_confirmation: 'Ожидается подтверждение',
+  email_unconfirmed: 'Электронная почта не подтверждена',
+  file_required: 'Не выбран файл',
+  registration_incomplete: 'Регистрация не завершена',
+  status_unknown: 'Неизвестный статус',
   not_found: 'Не найдено'
 };
 


### PR DESCRIPTION
## Summary
- add translations for missing backend error codes

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ea44cc408832da8e2820da3aa8167