### PR TITLE
Enhance training registration mobile UI

### DIFF
--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -612,8 +612,8 @@ function openNormatives(reg) {
   }
 
   .registration-card {
-    margin-left: -1rem;
-    margin-right: -1rem;
+    margin-left: -0.5rem;
+    margin-right: -0.5rem;
   }
 }
 

--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -321,7 +321,7 @@ function openNormatives(reg) {
             :key="group.role ? group.role.id : 'none'"
             class="mb-4"
           >
-            <h5 class="mb-2">
+            <h5 class="group-heading mb-2 px-2 py-1">
               {{ group.role ? group.role.name : 'Без роли' }}
             </h5>
             <div class="table-responsive d-none d-sm-block">
@@ -584,6 +584,12 @@ function openNormatives(reg) {
 .registration-card {
   border-radius: 0.5rem;
   border: 1px solid #dee2e6;
+}
+
+.group-heading {
+  background-color: #f8f9fa;
+  border-radius: 0.25rem;
+  font-weight: 600;
 }
 
 @media (max-width: 575.98px) {


### PR DESCRIPTION
## Summary
- emphasize role group headings in AdminTrainingRegistrations view for better mobile readability

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ea6f4fa8c832db0a5fc6d34fc71b7