### PR TITLE
Fix email error when deleting normative result

### DIFF
--- a/src/services/normativeResultService.js
+++ b/src/services/normativeResultService.js
@@ -206,8 +206,11 @@ async function remove(id, actorId = null) {
   if (!res) throw new ServiceError('normative_result_not_found', 404);
   await res.update({ updated_by: actorId });
   await res.destroy();
-  const user = res.User || (await User.findByPk(res.user_id));
-  if (user) {
+  let user = res.User;
+  if (!user || !user.email) {
+    user = await User.findByPk(res.user_id);
+  }
+  if (user && user.email) {
     await emailService.sendNormativeResultRemovedEmail(user, res);
   }
 }

--- a/tests/normativeResultService.test.js
+++ b/tests/normativeResultService.test.js
@@ -134,3 +134,23 @@ test('create passes user sex to zone determination', async () => {
   });
   expect(determineZoneMock).toHaveBeenCalledWith(expect.any(Object), 5, 'sx1');
 });
+
+test('remove fetches user when email missing', async () => {
+  const updateMock = jest.fn();
+  const destroyMock = jest.fn();
+  findResultByPkMock.mockResolvedValueOnce({
+    id: 'nr1',
+    user_id: 'u1',
+    update: updateMock,
+    destroy: destroyMock,
+    User: { id: 'u1' },
+  });
+  findUserMock.mockResolvedValueOnce({ id: 'u1', email: 'test@ex.com' });
+
+  await service.remove('nr1', 'adm');
+
+  expect(updateMock).toHaveBeenCalledWith({ updated_by: 'adm' });
+  expect(destroyMock).toHaveBeenCalled();
+  expect(findUserMock).toHaveBeenCalledWith('u1');
+  expect(sendRemoveEmailMock).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- handle missing email when removing normative result
- test user fetch logic in removal

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687eb97c3b4c832d91c73e68eeed25fc