### PR TITLE
Fix normative modal caching

### DIFF
--- a/client/src/components/TrainingNormativeResultsModal.vue
+++ b/client/src/components/TrainingNormativeResultsModal.vue
@@ -79,9 +79,14 @@ function open() {
   minutes.value = '';
   seconds.value = '';
   formError.value = '';
+  results.value = [];
+  types.value = [];
+  units.value = [];
+  error.value = '';
+  loading.value = true;
   if (!modal) modal = new Modal(modalRef.value);
-  load();
   modal.show();
+  load();
 }
 
 defineExpose({ open });


### PR DESCRIPTION
## Summary
- clear normative results state when opening the modal

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ebc89ef84832daef475c6a96934e7