### PR TITLE
Potential fix for code scanning alert no. 19: Prototype-polluting assignment

### DIFF
--- a/src/services/normativeTypeService.js
+++ b/src/services/normativeTypeService.js
@@ -85,15 +85,15 @@ async function buildZones({
   const redZone = dict.find((z) => z.alias === 'RED');
   if (!greenZone || !yellowZone || !redZone) return [];
   const step = stepForUnit(unit);
-  const bySex = {};
+  const bySex = new Map();
   for (const z of zones) {
     const zn = zoneById[z.zone_id];
     if (!zn || (zn.alias !== 'GREEN' && zn.alias !== 'YELLOW')) continue;
-    if (!bySex[z.sex_id]) bySex[z.sex_id] = {};
-    bySex[z.sex_id][zn.alias] = z;
+    if (!bySex.has(z.sex_id)) bySex.set(z.sex_id, {});
+    bySex.get(z.sex_id)[zn.alias] = z;
   }
   const result = [];
-  for (const [sexId, data] of Object.entries(bySex)) {
+  for (const [sexId, data] of bySex.entries()) {
     if (valueType.alias === 'MORE_BETTER') {
       const g = data.GREEN;
       const y = data.YELLOW;


### PR DESCRIPTION
Potential fix for [https://github.com/r0kko/fhmoscow-pulse/security/code-scanning/19](https://github.com/r0kko/fhmoscow-pulse/security/code-scanning/19)

The best fix is to use a `Map` object instead of a plain object as the dictionary for `bySex`. `Map` allows any string or value as a key, but does not interact with the prototype chain, so even if a user submits `"sex_id": "__proto__"` it will be stored as a normal entry and not pollute the prototype.  

Specifically:
- In `buildZones`, change `const bySex = {};` to `const bySex = new Map();`.
- Replace all assignments and accesses of `bySex[z.sex_id]` and `bySex[z.sex_id][...]` with `Map` methods: `get`, `set`, and so on.
- When iterating with `Object.entries(bySex)` change to `bySex.entries()`, since `Map` provides an iterator of `[key, value]` pairs.

No external dependencies are needed; `Map` is built-in.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
