### PR TITLE
Handle MIN_SEC values in email templates

### DIFF
--- a/src/services/normativeResultService.js
+++ b/src/services/normativeResultService.js
@@ -87,7 +87,10 @@ async function getById(id) {
       { model: Training, include: [CampStadium] },
       {
         model: NormativeType,
-        include: [{ model: NormativeGroupType, include: [NormativeGroup] }],
+        include: [
+          { model: MeasurementUnit },
+          { model: NormativeGroupType, include: [NormativeGroup] },
+        ],
       },
       { model: NormativeZone },
     ],

--- a/src/templates/normativeResultAddedEmail.js
+++ b/src/templates/normativeResultAddedEmail.js
@@ -1,3 +1,5 @@
+import { formatMinutesSeconds } from '../utils/time.js';
+
 export function renderNormativeResultAddedEmail(result) {
   const typeName = result.NormativeType?.name || result.type?.name || '';
   const groupName =
@@ -5,7 +7,10 @@ export function renderNormativeResultAddedEmail(result) {
     result.NormativeType?.NormativeGroupTypes?.[0]?.NormativeGroup?.name ||
     '';
   const zoneName = result.zone?.name || result.NormativeZone?.name || '';
-  const value = result.value;
+  let value = result.value;
+  if (result.NormativeType?.MeasurementUnit?.alias === 'MIN_SEC') {
+    value = formatMinutesSeconds(result.value);
+  }
   const training = result.Training || result.training || {};
   const date = training.start_at
     ? new Date(training.start_at)

--- a/src/templates/normativeResultUpdatedEmail.js
+++ b/src/templates/normativeResultUpdatedEmail.js
@@ -1,3 +1,5 @@
+import { formatMinutesSeconds } from '../utils/time.js';
+
 export function renderNormativeResultUpdatedEmail(result) {
   const typeName = result.NormativeType?.name || result.type?.name || '';
   const groupName =
@@ -5,7 +7,10 @@ export function renderNormativeResultUpdatedEmail(result) {
     result.NormativeType?.NormativeGroupTypes?.[0]?.NormativeGroup?.name ||
     '';
   const zoneName = result.zone?.name || result.NormativeZone?.name || '';
-  const value = result.value;
+  let value = result.value;
+  if (result.NormativeType?.MeasurementUnit?.alias === 'MIN_SEC') {
+    value = formatMinutesSeconds(result.value);
+  }
   const training = result.Training || result.training || {};
   const date = training.start_at
     ? new Date(training.start_at)

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,6 @@
+export function formatMinutesSeconds(total) {
+  if (total == null || isNaN(total)) return '';
+  const minutes = Math.floor(total / 60);
+  const seconds = Math.round(total % 60);
+  return `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+}


### PR DESCRIPTION
## Summary
- include `MeasurementUnit` when fetching normative results
- add helper to format minutes and seconds
- show values in `mm:ss` when unit is `MIN_SEC`

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ec518c548832d9ae151b1259c2a42