### PR TITLE
Fix dictionary loading order

### DIFF
--- a/client/src/components/AdminNormativeGroups.vue
+++ b/client/src/components/AdminNormativeGroups.vue
@@ -22,10 +22,10 @@ const totalPages = computed(() =>
   Math.max(1, Math.ceil(total.value / pageSize.value))
 );
 
-onMounted(() => {
+onMounted(async () => {
   modal = new Modal(modalRef.value);
-  load();
-  loadSeasons();
+  await loadSeasons();
+  await load();
 });
 
 watch(currentPage, load);

--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -55,10 +55,10 @@ const filteredTrainings = computed(() => {
   return trainings.value.filter((t) => t.season_id === form.value.season_id);
 });
 
-onMounted(() => {
+onMounted(async () => {
   modal = new Modal(modalRef.value);
-  load();
-  loadAux();
+  await loadAux();
+  await load();
 });
 
 watch(currentPage, load);

--- a/client/src/components/AdminNormativeTypes.vue
+++ b/client/src/components/AdminNormativeTypes.vue
@@ -48,10 +48,10 @@ const totalPages = computed(() =>
   Math.max(1, Math.ceil(total.value / pageSize.value))
 );
 
-onMounted(() => {
+onMounted(async () => {
   modal = new Modal(modalRef.value);
-  load();
-  loadDictionaries();
+  await loadDictionaries();
+  await load();
 });
 
 watch(


### PR DESCRIPTION
## Summary
- ensure dictionary data loads before rendering normative tables

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687f8515974c832db2f8783fd6b9aa15