### PR TITLE
Enable online normative submissions

### DIFF
--- a/src/controllers/normativeTicketAdminController.js
+++ b/src/controllers/normativeTicketAdminController.js
@@ -1,0 +1,24 @@
+import normativeTicketService from '../services/normativeTicketService.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async approve(req, res) {
+    try {
+      const result = await normativeTicketService.approve(
+        req.params.id,
+        req.user.id
+      );
+      return res.json({ result_id: result.id });
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+  async reject(req, res) {
+    try {
+      await normativeTicketService.reject(req.params.id, req.user.id);
+      return res.status(204).end();
+    } catch (err) {
+      return sendError(res, err, 404);
+    }
+  },
+};

--- a/src/controllers/normativeTicketSelfController.js
+++ b/src/controllers/normativeTicketSelfController.js
@@ -1,0 +1,27 @@
+import { validationResult } from 'express-validator';
+
+import normativeTicketService from '../services/normativeTicketService.js';
+import { sendError } from '../utils/api.js';
+
+export default {
+  async create(req, res) {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    if (!req.file) {
+      return res.status(400).json({ error: 'file_required' });
+    }
+    try {
+      const ticket = await normativeTicketService.createForUser(
+        req.user.id,
+        req.body,
+        req.file,
+        req.user.id
+      );
+      return res.status(201).json({ ticket_id: ticket.ticket_id });
+    } catch (err) {
+      return sendError(res, err);
+    }
+  },
+};

--- a/src/migrations/20250917023000-create-normative-tickets.js
+++ b/src/migrations/20250917023000-create-normative-tickets.js
@@ -1,0 +1,74 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('normative_tickets', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      season_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'seasons', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      type_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'normative_types', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      value: { type: Sequelize.FLOAT, allowNull: false },
+      ticket_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'tickets', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      normative_result_id: {
+        type: Sequelize.UUID,
+        references: { model: 'normative_results', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+    await queryInterface.addIndex('normative_tickets', ['user_id']);
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('normative_tickets');
+  },
+};

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -49,6 +49,7 @@ import NormativeType from './normativeType.js';
 import NormativeTypeZone from './normativeTypeZone.js';
 import NormativeGroupType from './normativeGroupType.js';
 import NormativeResult from './normativeResult.js';
+import NormativeTicket from './normativeTicket.js';
 import TaskType from './taskType.js';
 import TaskStatus from './taskStatus.js';
 import Task from './task.js';
@@ -272,6 +273,20 @@ NormativeResult.belongsTo(MeasurementUnit, { foreignKey: 'unit_id' });
 NormativeZone.hasMany(NormativeResult, { foreignKey: 'zone_id' });
 NormativeResult.belongsTo(NormativeZone, { foreignKey: 'zone_id' });
 
+/* normative tickets */
+NormativeType.hasMany(NormativeTicket, { foreignKey: 'type_id' });
+NormativeTicket.belongsTo(NormativeType, { foreignKey: 'type_id' });
+User.hasMany(NormativeTicket, { foreignKey: 'user_id' });
+NormativeTicket.belongsTo(User, { foreignKey: 'user_id' });
+Season.hasMany(NormativeTicket, { foreignKey: 'season_id' });
+NormativeTicket.belongsTo(Season, { foreignKey: 'season_id' });
+Ticket.hasOne(NormativeTicket, { foreignKey: 'ticket_id' });
+NormativeTicket.belongsTo(Ticket, { foreignKey: 'ticket_id' });
+NormativeResult.hasOne(NormativeTicket, { foreignKey: 'normative_result_id' });
+NormativeTicket.belongsTo(NormativeResult, {
+  foreignKey: 'normative_result_id',
+});
+
 // models that don't have standard audit columns
 const auditExclude = ['Log', 'EmailCode'];
 for (const model of Object.values(sequelize.models)) {
@@ -337,4 +352,5 @@ export {
   NormativeTypeZone,
   NormativeGroupType,
   NormativeResult,
+  NormativeTicket,
 };

--- a/src/models/normativeTicket.js
+++ b/src/models/normativeTicket.js
@@ -1,0 +1,30 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class NormativeTicket extends Model {}
+
+NormativeTicket.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    user_id: { type: DataTypes.UUID, allowNull: false },
+    season_id: { type: DataTypes.UUID, allowNull: false },
+    type_id: { type: DataTypes.UUID, allowNull: false },
+    value: { type: DataTypes.FLOAT, allowNull: false },
+    ticket_id: { type: DataTypes.UUID, allowNull: false },
+    normative_result_id: { type: DataTypes.UUID },
+  },
+  {
+    sequelize,
+    modelName: 'NormativeTicket',
+    tableName: 'normative_tickets',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default NormativeTicket;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -40,6 +40,7 @@ import measurementUnitsRouter from './measurementUnits.js';
 import normativeValueTypesRouter from './normativeValueTypes.js';
 import normativeZonesRouter from './normativeZones.js';
 import normativesRouter from './normatives.js';
+import normativeTicketsRouter from './normativeTickets.js';
 import seasonsRouter from './seasons.js';
 
 const router = express.Router();
@@ -79,6 +80,7 @@ router.use('/measurement-units', measurementUnitsRouter);
 router.use('/normative-value-types', normativeValueTypesRouter);
 router.use('/normative-zones', normativeZonesRouter);
 router.use('/normatives', normativesRouter);
+router.use('/normative-tickets', normativeTicketsRouter);
 router.use('/tasks', tasksRouter);
 router.use('/tickets', ticketsRouter);
 

--- a/src/routes/normativeTickets.js
+++ b/src/routes/normativeTickets.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import multer from 'multer';
+
+import auth from '../middlewares/auth.js';
+import authorize from '../middlewares/authorize.js';
+import selfController from '../controllers/normativeTicketSelfController.js';
+import adminController from '../controllers/normativeTicketAdminController.js';
+import { normativeTicketCreateRules } from '../validators/normativeTicketValidators.js';
+
+const router = express.Router();
+const upload = multer();
+
+router.post(
+  '/',
+  auth,
+  authorize('REFEREE'),
+  upload.single('file'),
+  normativeTicketCreateRules,
+  selfController.create
+);
+
+router.post('/:id/approve', auth, authorize('ADMIN'), adminController.approve);
+
+router.post('/:id/reject', auth, authorize('ADMIN'), adminController.reject);
+
+export default router;

--- a/src/seeders/20250917023000-add-normative-ticket-type.js
+++ b/src/seeders/20250917023000-add-normative-ticket-type.js
@@ -1,0 +1,32 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      "SELECT COUNT(*) AS cnt FROM ticket_types WHERE alias = 'NORMATIVE_ONLINE';"
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'ticket_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Сдача норматива онлайн',
+          alias: 'NORMATIVE_ONLINE',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('ticket_types', {
+      alias: ['NORMATIVE_ONLINE'],
+    });
+  },
+};

--- a/src/services/normativeResultService.js
+++ b/src/services/normativeResultService.js
@@ -157,7 +157,7 @@ async function create(data, actorId) {
     value_type_id: type.value_type_id,
     unit_id: type.unit_id,
     zone_id: zone?.zone_id || null,
-    online: false,
+    online: Boolean(data.online),
     retake: false,
     value,
     created_by: actorId,

--- a/src/services/normativeTicketService.js
+++ b/src/services/normativeTicketService.js
@@ -1,0 +1,82 @@
+import {
+  NormativeTicket,
+  NormativeType,
+  User,
+  Season,
+} from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+import ticketService from './ticketService.js';
+import fileService from './fileService.js';
+import normativeResultService from './normativeResultService.js';
+
+async function createForUser(userId, data, file, actorId) {
+  const [user, type] = await Promise.all([
+    User.findByPk(userId),
+    NormativeType.findByPk(data.type_id),
+  ]);
+  if (!user) throw new ServiceError('user_not_found', 404);
+  if (!type) throw new ServiceError('normative_type_not_found', 404);
+  if (!type.online_available)
+    throw new ServiceError('online_not_available', 400);
+  const season = await Season.findByPk(type.season_id);
+  if (!season) throw new ServiceError('season_not_found', 404);
+
+  const ticket = await ticketService.createForUser(
+    userId,
+    {
+      type_alias: 'NORMATIVE_ONLINE',
+      description: type.name,
+    },
+    actorId
+  );
+  if (file) {
+    await fileService.uploadForNormativeTicket(ticket.id, file, actorId);
+  }
+
+  return NormativeTicket.create({
+    user_id: userId,
+    season_id: season.id,
+    type_id: type.id,
+    value: data.value,
+    ticket_id: ticket.id,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+}
+
+async function approve(id, actorId) {
+  const nt = await NormativeTicket.findByPk(id);
+  if (!nt) throw new ServiceError('normative_ticket_not_found', 404);
+  if (nt.normative_result_id) return nt;
+  const result = await normativeResultService.create(
+    {
+      user_id: nt.user_id,
+      season_id: nt.season_id,
+      type_id: nt.type_id,
+      value: nt.value,
+      online: true,
+    },
+    actorId
+  );
+  await nt.update({ normative_result_id: result.id, updated_by: actorId });
+  await ticketService.update(
+    nt.ticket_id,
+    { status_alias: 'CONFIRMED' },
+    actorId
+  );
+  return result;
+}
+
+async function reject(id, actorId) {
+  const nt = await NormativeTicket.findByPk(id);
+  if (!nt) throw new ServiceError('normative_ticket_not_found', 404);
+  await ticketService.update(
+    nt.ticket_id,
+    { status_alias: 'REJECTED' },
+    actorId
+  );
+  await nt.destroy();
+}
+
+export default { createForUser, approve, reject };

--- a/src/validators/normativeTicketValidators.js
+++ b/src/validators/normativeTicketValidators.js
@@ -1,0 +1,6 @@
+import { body } from 'express-validator';
+
+export const normativeTicketCreateRules = [
+  body('type_id').isUUID(),
+  body('value').isFloat({ min: 0 }),
+];


### PR DESCRIPTION
## Summary
- create NormativeTicket model and migrations
- allow normative results to be submitted online
- upload large video files for normative tickets
- add normative ticket service and controllers
- expose `/normative-tickets` API endpoints
- update frontend normatives page with online submission modal
- support progress tracking via `apiUpload`

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_687f87276d90832d923ac2a64b5f3a9b