### PR TITLE
Update profile table after tax change

### DIFF
--- a/client/src/components/TaxationInfo.vue
+++ b/client/src/components/TaxationInfo.vue
@@ -20,6 +20,8 @@ const checkStatus = ref('');
 const checkError = ref('');
 const statuses = ref({ dadata: null, fns: null });
 
+const emit = defineEmits(['saved']);
+
 function statusIcon(code) {
   if (code === 200) return 'bi-check-circle text-success';
   if (code) return 'bi-exclamation-circle text-danger';
@@ -92,6 +94,7 @@ async function save() {
   try {
     const data = await apiFetch(path, { method: 'POST' });
     taxation.value = data.taxation;
+    emit('saved', data.taxation);
     modal.hide();
   } catch (e) {
     checkError.value = e.message;

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -149,6 +149,10 @@ function openTaxStatus(id) {
   })
 }
 
+async function onTaxSaved() {
+  await loadCompletion()
+}
+
 
 async function blockUser(id) {
   if (!confirm('Заблокировать пользователя?')) return
@@ -496,7 +500,7 @@ async function copy(text) {
             <div class="card-body p-2">
               <h6 class="mb-1">{{ p.last_name }} {{ p.first_name }} {{ p.patronymic }}</h6>
               <p class="mb-1 small">{{ formatDate(p.birth_date) }}</p>
-              <div class="d-flex flex-wrap gap-2">
+              <div class="d-flex flex-wrap gap-1">
                 <span><i :class="p.passport ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> Паспорт</span>
                 <span><i :class="p.inn ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> ИНН</span>
                 <span><i :class="p.snils ? 'bi bi-check-lg text-success' : 'bi bi-x-lg text-danger'"></i> СНИЛС</span>
@@ -523,7 +527,12 @@ async function copy(text) {
     </div>
     </div>
   </div>
-  <TaxationInfo ref="taxModal" :userId="taxUserId" modalOnly />
+  <TaxationInfo
+    ref="taxModal"
+    :userId="taxUserId"
+    modalOnly
+    @saved="onTaxSaved"
+  />
 </template>
 
 <style scoped>


### PR DESCRIPTION
## Summary
- emit `saved` event from `TaxationInfo` component when tax status is saved
- reload profile completion table when tax status is updated
- tighten spacing between check icons on small screens

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b2d024d0c832d8b138d69ff8dc044