### PR TITLE
Add sequential ticket numbers

### DIFF
--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -122,6 +122,7 @@ async function changeStatus(ticket, alias) {
               <tr>
                 <th>Пользователь</th>
                 <th class="d-none d-md-table-cell">Дата</th>
+                <th>Номер</th>
                 <th>Тип</th>
                 <th>Описание</th>
                 <th>Файлы</th>
@@ -133,6 +134,7 @@ async function changeStatus(ticket, alias) {
               <tr v-for="t in tickets" :key="t.id" :class="{ flash: t._flash }">
                 <td>{{ t.user.last_name }} {{ t.user.first_name }}</td>
                 <td class="d-none d-md-table-cell">{{ formatDateTime(t.created_at) }}</td>
+                <td>{{ t.number }}</td>
                 <td>{{ t.type.name }}</td>
                 <td>{{ t.description }}</td>
                 <td>
@@ -179,7 +181,9 @@ async function changeStatus(ticket, alias) {
               <p class="mb-1 fw-semibold">
                 {{ t.user.last_name }} {{ t.user.first_name }}
               </p>
-              <p class="mb-1 text-muted small">{{ formatDateTime(t.created_at) }}</p>
+              <p class="mb-1 text-muted small">
+                № {{ t.number }} · {{ formatDateTime(t.created_at) }}
+              </p>
               <p class="mb-1">{{ t.type.name }}</p>
               <p class="mb-1">{{ t.description }}</p>
               <div v-if="t.files && t.files.length" class="mb-1">

--- a/client/src/views/Tickets.vue
+++ b/client/src/views/Tickets.vue
@@ -111,7 +111,9 @@ async function deleteTicket(ticket) {
                 <h6 class="mb-0">{{ t.type.name }}</h6>
                 <span class="badge bg-secondary">{{ t.status.name }}</span>
               </div>
-              <p class="text-muted small mb-1">{{ formatDateTime(t.created_at) }}</p>
+              <p class="text-muted small mb-1">
+                № {{ t.number }} · {{ formatDateTime(t.created_at) }}
+              </p>
               <p class="mb-2">{{ t.description || '—' }}</p>
               <div v-if="t.files && t.files.length" class="d-flex flex-wrap gap-2">
                 <a

--- a/src/mappers/ticketMapper.js
+++ b/src/mappers/ticketMapper.js
@@ -1,7 +1,14 @@
 function sanitize(obj) {
-  const { id, description, created_at, createdAt, TicketType, TicketStatus } =
-    obj;
-  const res = { id, description };
+  const {
+    id,
+    number,
+    description,
+    created_at,
+    createdAt,
+    TicketType,
+    TicketStatus,
+  } = obj;
+  const res = { id, number, description };
   if (created_at || createdAt) {
     res.created_at = created_at ?? createdAt;
   }

--- a/src/migrations/20250917024000-add-ticket-number.js
+++ b/src/migrations/20250917024000-add-ticket-number.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('tickets', 'number', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+    await queryInterface.sequelize.query(`
+      UPDATE tickets t
+      SET number = numbers.number
+      FROM (
+        SELECT id,
+               to_char(created_at, 'YYMM') || '-' ||
+               lpad(row_number() OVER (PARTITION BY to_char(created_at, 'YYMM') ORDER BY created_at)::text, 6, '0') AS number
+        FROM tickets
+      ) numbers
+      WHERE t.id = numbers.id;
+    `);
+    await queryInterface.changeColumn('tickets', 'number', {
+      type: Sequelize.STRING,
+      allowNull: false,
+    });
+    await queryInterface.addIndex('tickets', ['number'], { unique: true });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeIndex('tickets', ['number']);
+    await queryInterface.removeColumn('tickets', 'number');
+  },
+};

--- a/src/models/ticket.js
+++ b/src/models/ticket.js
@@ -11,6 +11,7 @@ Ticket.init(
       defaultValue: DataTypes.UUIDV4,
       primaryKey: true,
     },
+    number: { type: DataTypes.STRING, allowNull: false, unique: true },
     user_id: { type: DataTypes.UUID, allowNull: false },
     type_id: { type: DataTypes.UUID, allowNull: false },
     status_id: { type: DataTypes.UUID, allowNull: false },

--- a/src/templates/ticketCreatedEmail.js
+++ b/src/templates/ticketCreatedEmail.js
@@ -1,12 +1,12 @@
 export function renderTicketCreatedEmail(ticket) {
   const status = ticket.TicketStatus?.name || '';
   const subject = 'Обращение создано';
-  const text = `Ваше обращение успешно создано. Текущий статус: ${status}.`;
+  const text = `Ваше обращение ${ticket.number} успешно создано. Текущий статус: ${status}.`;
   const html = `
     <div style="font-family: Arial, sans-serif; color: #333;">
       <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
       <p style="font-size:16px;margin:0 0 16px;">
-        Ваше обращение успешно создано. Текущий статус: ${status}.
+        Ваше обращение <strong>${ticket.number}</strong> успешно создано. Текущий статус: ${status}.
       </p>
     </div>`;
   return { subject, text, html };

--- a/src/templates/ticketStatusChangedEmail.js
+++ b/src/templates/ticketStatusChangedEmail.js
@@ -2,12 +2,12 @@ export function renderTicketStatusChangedEmail(ticket) {
   const status = ticket.TicketStatus?.name || '';
   const type = ticket.TicketType?.name || '';
   const subject = 'Статус обращения обновлён';
-  const text = `Статус вашего обращения (${type}) изменён на: ${status}.`;
+  const text = `Статус вашего обращения ${ticket.number} (${type}) изменён на: ${status}.`;
   const html = `
     <div style="font-family: Arial, sans-serif; color: #333;">
       <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
       <p style="font-size:16px;margin:0 0 16px;">
-        Статус вашего обращения (${type}) изменён на: ${status}.
+        Статус вашего обращения <strong>${ticket.number}</strong> (${type}) изменён на: ${status}.
       </p>
     </div>`;
   return { subject, text, html };

--- a/tests/ticketService.test.js
+++ b/tests/ticketService.test.js
@@ -4,6 +4,7 @@ const findAndCountAllMock = jest.fn();
 const findByPkMock = jest.fn();
 const findAllMock = jest.fn();
 const createMock = jest.fn();
+const maxMock = jest.fn();
 const updateMock = jest.fn();
 const destroyMock = jest.fn();
 const ticketFindOneMock = jest.fn();
@@ -18,6 +19,7 @@ beforeEach(() => {
   findByPkMock.mockReset();
   findAllMock.mockReset();
   createMock.mockReset();
+  maxMock.mockReset();
   updateMock.mockReset();
   destroyMock.mockReset();
   ticketFindOneMock.mockReset();
@@ -36,6 +38,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     findOne: ticketFindOneMock,
     findAll: findAllMock,
     create: createMock,
+    max: maxMock,
   },
   TicketType: { findOne: findOneTypeMock },
   TicketStatus: { findOne: findOneStatusMock },
@@ -91,6 +94,7 @@ test('createForUser creates ticket', async () => {
   userFindByPkMock.mockResolvedValue({ id: 'u1' });
   findOneTypeMock.mockResolvedValue({ id: 'type1' });
   findOneStatusMock.mockResolvedValue({ id: 'status1' });
+  maxMock.mockResolvedValue(null);
   createMock.mockResolvedValue({ id: 't1' });
   findByPkMock.mockResolvedValue({ id: 't1' });
   const ticket = await service.createForUser('u1', { type_alias: 'A' }, 'admin');


### PR DESCRIPTION
## Summary
- add migration to assign sequential ticket numbers
- include `number` in ticket model and mapper
- generate numbers when creating tickets
- display number in emails and UI
- update tests for new logic

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688b899d1444832daa97e2dca1d5875a