### PR TITLE
Clear ticket number on deletion

### DIFF
--- a/src/migrations/20250917025000-allow-null-ticket-number.js
+++ b/src/migrations/20250917025000-allow-null-ticket-number.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn('tickets', 'number', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface, Sequelize) {
+    await queryInterface.sequelize.transaction(async (transaction) => {
+      // prettier-ignore
+      await queryInterface.sequelize.query(
+          'UPDATE tickets SET number = CONCAT(\'restored-\', id) WHERE number IS NULL',
+          { transaction }
+        );
+      await queryInterface.changeColumn(
+        'tickets',
+        'number',
+        { type: Sequelize.STRING, allowNull: false },
+        { transaction }
+      );
+    });
+  },
+};

--- a/src/models/ticket.js
+++ b/src/models/ticket.js
@@ -11,7 +11,7 @@ Ticket.init(
       defaultValue: DataTypes.UUIDV4,
       primaryKey: true,
     },
-    number: { type: DataTypes.STRING, allowNull: false, unique: true },
+    number: { type: DataTypes.STRING, allowNull: true, unique: true },
     user_id: { type: DataTypes.UUID, allowNull: false },
     type_id: { type: DataTypes.UUID, allowNull: false },
     status_id: { type: DataTypes.UUID, allowNull: false },
@@ -25,5 +25,12 @@ Ticket.init(
     underscored: true,
   }
 );
+
+Ticket.addHook('beforeDestroy', async (ticket, options) => {
+  await Ticket.update(
+    { number: null },
+    { where: { id: ticket.id }, transaction: options.transaction, hooks: false }
+  );
+});
 
 export default Ticket;

--- a/src/services/ticketService.js
+++ b/src/services/ticketService.js
@@ -160,8 +160,8 @@ async function removeForUser(userId, ticketId, actorId = null) {
   if (statusAlias && statusAlias !== 'CREATED') {
     throw new ServiceError('ticket_locked');
   }
-  await ticket.update({ updated_by: actorId });
-  await ticket.destroy();
+  await ticket.update({ updated_by: actorId, number: null });
+  await ticket.destroy({ hooks: false });
 }
 
 async function listAll(options = {}) {

--- a/tests/ticketService.test.js
+++ b/tests/ticketService.test.js
@@ -127,8 +127,8 @@ test('removeForUser deletes ticket', async () => {
     TicketStatus: { alias: 'CREATED' },
   });
   await service.removeForUser('u1', 't1', 'adm');
-  expect(updateMock).toHaveBeenCalledWith({ updated_by: 'adm' });
-  expect(destroyMock).toHaveBeenCalled();
+  expect(updateMock).toHaveBeenCalledWith({ updated_by: 'adm', number: null });
+  expect(destroyMock).toHaveBeenCalledWith({ hooks: false });
 });
 
 test('removeForUser rejects when not created', async () => {


### PR DESCRIPTION
## Summary
- allow ticket numbers to become nullable and automatically clear them before soft deletion
- update ticket removal logic and tests to reset numbers and skip hooks
- add migration to permit null ticket numbers and handle rollback

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892aa8d04e4832d892f21966a39bf34