### PR TITLE
Add retake option for normative results

### DIFF
--- a/client/src/views/Normatives.vue
+++ b/client/src/views/Normatives.vue
@@ -298,14 +298,18 @@ function thresholdText(t, zone) {
                   </td>
                   <td class="text-center text-nowrap">
                     {{
-                      t.result?.online
+                      t.result?.retake
+                        ? 'Перезачет'
+                        : t.result?.online
                         ? 'Онлайн'
                         : formatDate(t.result?.training?.start_at)
                     }}
                   </td>
                   <td class="text-center d-none d-md-table-cell">
                     {{
-                      t.result?.online
+                      t.result?.retake
+                        ? 'Перезачет'
+                        : t.result?.online
                         ? 'Онлайн'
                         : t.result?.training?.stadium?.name || '-'
                     }}
@@ -396,7 +400,9 @@ function thresholdText(t, zone) {
                 </p>
                 <p class="mb-1 small text-start">
                   {{
-                    t.result?.online
+                    t.result?.retake
+                      ? 'Перезачет'
+                      : t.result?.online
                       ? 'Онлайн'
                       : `${formatDate(t.result?.training?.start_at)}, ${
                           t.result?.training?.stadium?.name || '-'
@@ -447,11 +453,23 @@ function thresholdText(t, zone) {
                   >
                     <span>{{ formatValue(r) }}</span>
                     <span class="small text-nowrap">
-                      {{ r.online ? 'Онлайн' : formatDateTime(r.training?.start_at) }}
+                      {{
+                        r.retake
+                          ? 'Перезачет'
+                          : r.online
+                          ? 'Онлайн'
+                          : formatDateTime(r.training?.start_at)
+                      }}
                     </span>
                   </div>
                   <div class="small text-muted">
-                    {{ r.online ? 'Онлайн' : r.training?.stadium?.name || '-' }}
+                    {{
+                      r.retake
+                        ? 'Перезачет'
+                        : r.online
+                        ? 'Онлайн'
+                        : r.training?.stadium?.name || '-'
+                    }}
                   </div>
                 </li>
               </ul>

--- a/src/validators/normativeResultValidators.js
+++ b/src/validators/normativeResultValidators.js
@@ -8,6 +8,8 @@ export const normativeResultCreateRules = [
   body('season_id').isUUID(),
   body('training_id').optional().isUUID(),
   body('type_id').isUUID(),
+  body('online').optional().isBoolean(),
+  body('retake').optional().isBoolean(),
   body('value')
     .notEmpty()
     .custom(async (val, { req }) => {
@@ -27,4 +29,6 @@ export const normativeResultCreateRules = [
 export const normativeResultUpdateRules = [
   body('training_id').optional().isUUID(),
   body('value').optional().notEmpty(),
+  body('online').optional().isBoolean(),
+  body('retake').optional().isBoolean(),
 ];


### PR DESCRIPTION
## Summary
- allow marking normative results as retake or online with training optional
- show retake results in admin list and client normatives view
- validate retake/online flags in API service and validators

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689330819fc4832d8f0da5b101cf0be2