### PR TITLE
Add new user roles and enhance authorization

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -28,6 +28,9 @@ import NotFound from './views/NotFound.vue';
 import Forbidden from './views/Forbidden.vue';
 import ServerError from './views/ServerError.vue';
 
+const adminRoles = ['ADMIN', 'FIELD_REFEREE_SPECIALIST', 'BRIGADE_REFEREE_SPECIALIST'];
+const refereeRoles = ['REFEREE', 'BRIGADE_REFEREE'];
+
 const routes = [
   { path: '/', component: Home, meta: { requiresAuth: true, fluid: true } },
   { path: '/profile', component: Profile, meta: { requiresAuth: true } },
@@ -173,9 +176,9 @@ router.beforeEach(async (to, _from, next) => {
   }
   if (to.meta.requiresAuth && !isAuthenticated) {
     next('/login');
-  } else if (to.meta.requiresAdmin && !roles.includes('ADMIN')) {
+  } else if (to.meta.requiresAdmin && !roles.some((r) => adminRoles.includes(r))) {
     next('/forbidden');
-  } else if (to.meta.requiresReferee && !roles.includes('REFEREE')) {
+  } else if (to.meta.requiresReferee && !roles.some((r) => refereeRoles.includes(r))) {
     next('/forbidden');
   } else if (
     isAuthenticated &&

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -25,9 +25,11 @@ const docsSections = [
   { title: 'Персональные данные', icon: 'bi-person-circle', to: '/profile' }
 ]
 
+const adminRoles = ['ADMIN', 'FIELD_REFEREE_SPECIALIST', 'BRIGADE_REFEREE_SPECIALIST']
+const refereeRoles = ['REFEREE', 'BRIGADE_REFEREE']
 
-const isAdmin = computed(() => auth.roles.includes('ADMIN'))
-const isReferee = computed(() => auth.roles.includes('REFEREE'))
+const isAdmin = computed(() => auth.roles.some((r) => adminRoles.includes(r)))
+const isReferee = computed(() => auth.roles.some((r) => refereeRoles.includes(r)))
 const preparationSections = computed(() =>
   basePreparationSections.filter((s) => !s.referee || isReferee.value)
 )

--- a/src/controllers/medicalCertificateFileController.js
+++ b/src/controllers/medicalCertificateFileController.js
@@ -2,10 +2,11 @@ import fileService from '../services/fileService.js';
 import fileMapper from '../mappers/fileMapper.js';
 import medicalCertificateService from '../services/medicalCertificateService.js';
 import { sendError } from '../utils/api.js';
+import { hasAdminRole } from '../utils/roles.js';
 
 async function isAdmin(user) {
-  const roles = await user.getRoles({ where: { alias: 'ADMIN' } });
-  return roles && roles.length > 0;
+  const roles = await user.getRoles();
+  return hasAdminRole(roles);
 }
 
 async function list(req, res) {

--- a/src/controllers/profileCompletionAdminController.js
+++ b/src/controllers/profileCompletionAdminController.js
@@ -1,11 +1,12 @@
 import profileService from '../services/profileCompletionService.js';
 import mapper from '../mappers/profileCompletionMapper.js';
 import { sendError } from '../utils/api.js';
+import { REFEREE_ROLES } from '../utils/roles.js';
 
 export default {
   async list(req, res) {
     try {
-      const users = await profileService.listByRole('REFEREE');
+      const users = await profileService.listByRole(REFEREE_ROLES);
       return res.json({ profiles: mapper.toPublicArray(users) });
     } catch (err) {
       return sendError(res, err);

--- a/src/controllers/ticketFileController.js
+++ b/src/controllers/ticketFileController.js
@@ -2,10 +2,11 @@ import fileService from '../services/fileService.js';
 import ticketService from '../services/ticketService.js';
 import fileMapper from '../mappers/fileMapper.js';
 import { sendError } from '../utils/api.js';
+import { hasAdminRole } from '../utils/roles.js';
 
 async function isAdmin(user) {
-  const roles = await user.getRoles({ where: { alias: 'ADMIN' } });
-  return roles && roles.length > 0;
+  const roles = await user.getRoles();
+  return hasAdminRole(roles);
 }
 
 export default {

--- a/src/middlewares/authorize.js
+++ b/src/middlewares/authorize.js
@@ -1,9 +1,25 @@
-export default function authorize(roleAlias) {
+import { ADMIN_ROLES, REFEREE_ROLES } from '../utils/roles.js';
+
+const ROLE_GROUPS = {
+  ADMIN: ADMIN_ROLES,
+  REFEREE: REFEREE_ROLES,
+};
+
+export default function authorize(...aliases) {
+  const allowed = aliases.flatMap((a) => ROLE_GROUPS[a] || [a]);
   return async function (req, res, next) {
-    const roles = await req.user.getRoles({ where: { alias: roleAlias } });
-    if (!roles || roles.length === 0) {
-      return res.status(403).json({ error: 'Доступ запрещён' });
+    try {
+      if (!req.user) {
+        return res.status(401).json({ error: 'Не авторизовано' });
+      }
+      const roles = await req.user.getRoles({ where: { alias: allowed } });
+      if (!roles || roles.length === 0) {
+        return res.status(403).json({ error: 'Доступ запрещён' });
+      }
+      return next();
+    } catch (err) {
+      console.error(err);
+      return res.status(500).json({ error: 'Server error' });
     }
-    next();
   };
 }

--- a/src/seeders/20250607132026-create-user-roles.js
+++ b/src/seeders/20250607132026-create-user-roles.js
@@ -6,38 +6,66 @@ const { v4: uuidv4 } = require('uuid');
 module.exports = {
   async up(queryInterface) {
     const now = new Date();
+    const roles = [
+      {
+        id: uuidv4(),
+        name: 'Admin',
+        alias: 'ADMIN',
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: uuidv4(),
+        name: 'Referee',
+        alias: 'REFEREE',
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: uuidv4(),
+        name: 'Судья в бригаде',
+        alias: 'BRIGADE_REFEREE',
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: uuidv4(),
+        name: 'Специалист по судейству (судьи в поле)',
+        alias: 'FIELD_REFEREE_SPECIALIST',
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: uuidv4(),
+        name: 'Специалист по судейству (судьи в бригаде)',
+        alias: 'BRIGADE_REFEREE_SPECIALIST',
+        created_at: now,
+        updated_at: now,
+      },
+      {
+        id: uuidv4(),
+        name: 'Сотрудник спортивной школы',
+        alias: 'SPORT_SCHOOL_STAFF',
+        created_at: now,
+        updated_at: now,
+      },
+    ];
 
-    // already seeded? (проверяем по alias)
-    const [existing] = await queryInterface.sequelize.query(
-      `SELECT COUNT(*) AS cnt
-             FROM roles
-             WHERE alias IN ('ADMIN', 'REFEREE');`
-    );
-    if (Number(existing[0].cnt) > 0) return;
-
-    await queryInterface.bulkInsert(
-      'roles',
-      [
-        {
-          id: uuidv4(),
-          name: 'Admin',
-          alias: 'ADMIN',
-          created_at: now,
-          updated_at: now,
-        },
-        {
-          id: uuidv4(),
-          name: 'Referee',
-          alias: 'REFEREE',
-          created_at: now,
-          updated_at: now,
-        },
-      ],
-      { ignoreDuplicates: true } // PG → ON CONFLICT DO NOTHING
-    );
+    await queryInterface.bulkInsert('roles', roles, {
+      ignoreDuplicates: true, // PG → ON CONFLICT DO NOTHING
+    });
   },
 
   async down(queryInterface) {
-    await queryInterface.bulkDelete('roles', { alias: ['ADMIN', 'REFEREE'] });
+    await queryInterface.bulkDelete('roles', {
+      alias: [
+        'ADMIN',
+        'REFEREE',
+        'BRIGADE_REFEREE',
+        'FIELD_REFEREE_SPECIALIST',
+        'BRIGADE_REFEREE_SPECIALIST',
+        'SPORT_SCHOOL_STAFF',
+      ],
+    });
   },
 };

--- a/src/services/medicalCertificateService.js
+++ b/src/services/medicalCertificateService.js
@@ -68,12 +68,16 @@ async function listAll(options = {}) {
     },
   ];
 
-  if (options.role) {
+  if (
+    options.role &&
+    (Array.isArray(options.role) ? options.role.length : true)
+  ) {
     const { Role } = await import('../models/index.js');
+    const aliases = Array.isArray(options.role) ? options.role : [options.role];
     include[0].include = [
       {
         model: Role,
-        where: { alias: options.role },
+        where: { alias: aliases },
         through: { attributes: [] },
         required: true,
       },

--- a/src/services/normativeLedgerService.js
+++ b/src/services/normativeLedgerService.js
@@ -12,6 +12,7 @@ import {
   MeasurementUnit,
   Season,
 } from '../models/index.js';
+import { REFEREE_ROLES } from '../utils/roles.js';
 import userMapper from '../mappers/userMapper.js';
 import normativeGroupMapper from '../mappers/normativeGroupMapper.js';
 import normativeZoneMapper from '../mappers/normativeZoneMapper.js';
@@ -44,7 +45,7 @@ async function list(options = {}) {
       include: [
         {
           model: Role,
-          where: { alias: 'REFEREE' },
+          where: { alias: REFEREE_ROLES },
           through: { attributes: [] },
           required: true,
         },

--- a/src/services/profileCompletionService.js
+++ b/src/services/profileCompletionService.js
@@ -10,12 +10,13 @@ import {
   TaxationType,
 } from '../models/index.js';
 
-async function listByRole(alias) {
+async function listByRole(aliases) {
+  const where = { alias: Array.isArray(aliases) ? aliases : [aliases] };
   return User.findAll({
     include: [
       {
         model: Role,
-        where: { alias },
+        where,
         through: { attributes: [] },
         required: true,
       },

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -8,6 +8,7 @@ import {
   TrainingRegistration,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
+import { REFEREE_ROLES } from '../utils/roles.js';
 
 import seasonService from './seasonService.js';
 
@@ -99,7 +100,7 @@ async function listReferees(options = {}) {
     include: [
       {
         model: Role,
-        where: { alias: 'REFEREE' },
+        where: { alias: REFEREE_ROLES },
         through: { attributes: [] },
         required: true,
       },
@@ -153,7 +154,7 @@ async function getReferee(id) {
     include: [
       {
         model: Role,
-        where: { alias: 'REFEREE' },
+        where: { alias: REFEREE_ROLES },
         through: { attributes: [] },
         required: true,
       },

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -12,6 +12,7 @@ import {
   Address,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
+import { hasAdminRole, hasRefereeRole } from '../utils/roles.js';
 
 import trainingService from './trainingService.js';
 import emailService from './emailService.js';
@@ -189,7 +190,7 @@ async function add(trainingId, userId, roleId, actorId) {
   if (!training) throw new ServiceError('training_not_found', 404);
   if (!user) throw new ServiceError('user_not_found', 404);
   if (!role) throw new ServiceError('training_role_not_found', 404);
-  if (!user.Roles.some((r) => r.alias === 'REFEREE')) {
+  if (!hasRefereeRole(user.Roles)) {
     throw new ServiceError('user_not_referee');
   }
 
@@ -226,10 +227,10 @@ async function updatePresence(trainingId, userId, present, actorId) {
 
   const actor = await User.findByPk(actorId, { include: [Role] });
   if (!actor) throw new ServiceError('user_not_found', 404);
-  const isAdmin = actor.Roles.some((r) => r.alias === 'ADMIN');
+  const isAdmin = hasAdminRole(actor.Roles);
 
   if (!isAdmin) {
-    if (!actor.Roles.some((r) => r.alias === 'REFEREE')) {
+    if (!hasRefereeRole(actor.Roles)) {
       throw new ServiceError('access_denied');
     }
     const coachReg = await TrainingRegistration.findOne({
@@ -250,10 +251,10 @@ async function updatePresence(trainingId, userId, present, actorId) {
 async function listForAttendance(trainingId, actorId) {
   const actor = await User.findByPk(actorId, { include: [Role] });
   if (!actor) throw new ServiceError('user_not_found', 404);
-  const isAdmin = actor.Roles.some((r) => r.alias === 'ADMIN');
+  const isAdmin = hasAdminRole(actor.Roles);
 
   if (!isAdmin) {
-    if (!actor.Roles.some((r) => r.alias === 'REFEREE')) {
+    if (!hasRefereeRole(actor.Roles)) {
       throw new ServiceError('access_denied');
     }
     const coachReg = await TrainingRegistration.findOne({

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -12,6 +12,7 @@ import {
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 import TrainingRegistration from '../models/trainingRegistration.js';
+import { hasAdminRole, hasRefereeRole } from '../utils/roles.js';
 
 function isRegistrationOpen(training, registeredCount = 0) {
   const start = new Date(training.start_at);
@@ -260,10 +261,10 @@ async function setAttendanceMarked(id, marked, actorId) {
   if (!training) throw new ServiceError('training_not_found', 404);
   const actor = await User.findByPk(actorId, { include: [Role] });
   if (!actor) throw new ServiceError('user_not_found', 404);
-  const isAdmin = actor.Roles.some((r) => r.alias === 'ADMIN');
+  const isAdmin = hasAdminRole(actor.Roles);
   let coachReg = null;
   if (!isAdmin) {
-    if (!actor.Roles.some((r) => r.alias === 'REFEREE')) {
+    if (!hasRefereeRole(actor.Roles)) {
       throw new ServiceError('access_denied');
     }
     coachReg = await TrainingRegistration.findOne({

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -74,10 +74,14 @@ async function listUsers(options = {}) {
     ];
   }
   const include = [];
-  if (options.role) {
+  if (
+    options.role &&
+    (Array.isArray(options.role) ? options.role.length : true)
+  ) {
+    const aliases = Array.isArray(options.role) ? options.role : [options.role];
     include.push({
       model: Role,
-      where: { alias: options.role },
+      where: { alias: aliases },
       required: true,
     });
   } else {

--- a/src/utils/roles.js
+++ b/src/utils/roles.js
@@ -1,0 +1,18 @@
+export const ADMIN_ROLES = [
+  'ADMIN',
+  'FIELD_REFEREE_SPECIALIST',
+  'BRIGADE_REFEREE_SPECIALIST',
+];
+export const REFEREE_ROLES = ['REFEREE', 'BRIGADE_REFEREE'];
+
+export function hasRole(roles, allowed) {
+  return roles.some((r) => allowed.includes(r.alias ?? r));
+}
+
+export function hasAdminRole(roles) {
+  return hasRole(roles, ADMIN_ROLES);
+}
+
+export function hasRefereeRole(roles) {
+  return hasRole(roles, REFEREE_ROLES);
+}

--- a/tests/authorizeMiddleware.test.js
+++ b/tests/authorizeMiddleware.test.js
@@ -16,6 +16,15 @@ test('allows request when user has role', async () => {
   expect(next).toHaveBeenCalled();
 });
 
+test('allows request when user has one of multiple roles', async () => {
+  const req = makeReq(true);
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  const mw = authorize('ADMIN', 'REFEREE');
+  await mw(req, res, next);
+  expect(next).toHaveBeenCalled();
+});
+
 test('forbids request when user lacks role', async () => {
   const req = makeReq(false);
   const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
@@ -23,5 +32,15 @@ test('forbids request when user lacks role', async () => {
   const mw = authorize('ADMIN');
   await mw(req, res, next);
   expect(res.status).toHaveBeenCalledWith(403);
+  expect(next).not.toHaveBeenCalled();
+});
+
+test('returns 401 when user missing', async () => {
+  const req = {};
+  const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+  const next = jest.fn();
+  const mw = authorize('ADMIN');
+  await mw(req, res, next);
+  expect(res.status).toHaveBeenCalledWith(401);
   expect(next).not.toHaveBeenCalled();
 });

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -127,7 +127,7 @@ test('remove sends cancellation email', async () => {
 test('add creates registration for referee', async () => {
   const tr = { ...training, TrainingRegistrations: [] };
   findTrainingMock.mockResolvedValue(tr);
-  findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   await service.add('t1', 'u2', 'role2', 'admin');
   expect(createRegMock).toHaveBeenCalledWith({
     training_id: 't1',
@@ -137,7 +137,7 @@ test('add creates registration for referee', async () => {
     updated_by: 'admin',
   });
   expect(sendRegEmailMock).toHaveBeenCalledWith(
-    { id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] },
+    { id: 'u2', email: 'e2', Roles: [{ alias: 'BRIGADE_REFEREE' }] },
     tr,
     { id: 'role1' }
   );
@@ -148,7 +148,7 @@ test('add restores deleted registration', async () => {
   const restoreMock = jest.fn();
   const updateMock = jest.fn();
   findTrainingMock.mockResolvedValue(tr);
-  findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValue({ id: 'u2', email: 'e2', Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   findRegMock.mockResolvedValue({
     deletedAt: new Date(),
     restore: restoreMock,
@@ -159,7 +159,7 @@ test('add restores deleted registration', async () => {
   expect(updateMock).toHaveBeenCalledWith({ training_role_id: 'role2', updated_by: 'admin' });
   expect(createRegMock).not.toHaveBeenCalled();
   expect(sendRegEmailMock).toHaveBeenCalledWith(
-    { id: 'u2', email: 'e2', Roles: [{ alias: 'REFEREE' }] },
+    { id: 'u2', email: 'e2', Roles: [{ alias: 'BRIGADE_REFEREE' }] },
     tr,
     { id: 'role1' }
   );
@@ -300,7 +300,7 @@ test('updatePresence updates value for admin', async () => {
 
 test('updatePresence rejects when not coach', async () => {
   findRegMock.mockResolvedValueOnce({});
-  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   findRegMock.mockResolvedValueOnce(null);
   await expect(
     service.updatePresence('t1', 'u1', false, 'u2')
@@ -309,7 +309,7 @@ test('updatePresence rejects when not coach', async () => {
 
 test('updatePresence rejects when updating coach presence', async () => {
   findRegMock.mockResolvedValueOnce({ TrainingRole: { alias: 'COACH' } });
-  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValueOnce({ Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   findRegMock.mockResolvedValueOnce({ TrainingRole: { alias: 'COACH' } });
   await expect(
     service.updatePresence('t1', 'u1', true, 'u1')

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -206,7 +206,7 @@ test('setAttendanceMarked updates for admin', async () => {
 test('setAttendanceMarked marks coach present', async () => {
   const updateRegMock = jest.fn();
   findByPkMock.mockResolvedValue({ update: updateMock });
-  findUserMock.mockResolvedValue({ Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValue({ Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   findRegMock.mockResolvedValue({ TrainingRole: { alias: 'COACH' }, update: updateRegMock });
   await service.setAttendanceMarked('t1', true, 'u1');
   expect(updateMock).toHaveBeenCalledWith({ attendance_marked: true, updated_by: 'u1' });
@@ -215,7 +215,7 @@ test('setAttendanceMarked marks coach present', async () => {
 
 test('setAttendanceMarked rejects when not coach', async () => {
   findByPkMock.mockResolvedValue({ update: updateMock });
-  findUserMock.mockResolvedValue({ Roles: [{ alias: 'REFEREE' }] });
+  findUserMock.mockResolvedValue({ Roles: [{ alias: 'BRIGADE_REFEREE' }] });
   findRegMock.mockResolvedValue(null);
   await expect(service.setAttendanceMarked('t1', true, 'u1')).rejects.toThrow('access_denied');
 });

--- a/tests/userService.test.js
+++ b/tests/userService.test.js
@@ -103,13 +103,13 @@ test('listUsers applies status filter', async () => {
 
 test('listUsers applies role filter', async () => {
   findAndCountAllMock.mockResolvedValue({ rows: [], count: 0 });
-  await service.listUsers({ role: 'ADMIN' });
+  await service.listUsers({ role: ['ADMIN', 'REFEREE'] });
   expect(findAndCountAllMock).toHaveBeenCalledWith(
     expect.objectContaining({
       include: expect.arrayContaining([
         expect.objectContaining({
           model: expect.anything(),
-          where: { alias: 'ADMIN' },
+          where: { alias: ['ADMIN', 'REFEREE'] },
           required: true,
         }),
       ]),


### PR DESCRIPTION
## Summary
- add brigade referee and specialist roles
- centralize role constants and expand auth checks
- expose new roles on frontend and allow multi-role filtering

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689333477fdc832dbcfe0ffd9be53995