### PR TITLE
Standardize header and breadcrumb styles

### DIFF
--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -135,6 +135,28 @@ nav[aria-label='breadcrumb'] {
   nav[aria-label='breadcrumb'] {
     margin-bottom: 0.25rem;
   }
+
+  .breadcrumb {
+    font-size: 0.75rem;
+  }
+
+  h1,
+  .h1 {
+    font-size: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  h2,
+  .h2 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+  }
+
+  h3,
+  .h3 {
+    font-size: 1.125rem;
+    margin-bottom: 0.375rem;
+  }
 }
 
 .skip-link {

--- a/client/src/brand.css
+++ b/client/src/brand.css
@@ -103,6 +103,40 @@
   text-decoration: underline;
 }
 
+/* standardized heading sizes */
+h1,
+.h1 {
+  font-size: 1.75rem;
+  margin-bottom: 1rem;
+}
+
+h2,
+.h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.75rem;
+}
+
+h3,
+.h3 {
+  font-size: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+
+/* standardized breadcrumb spacing */
+nav[aria-label='breadcrumb'] {
+  margin-bottom: 1rem;
+}
+
+.breadcrumb {
+  font-size: 0.875rem;
+}
+
+@media (max-width: 575.98px) {
+  nav[aria-label='breadcrumb'] {
+    margin-bottom: 0.25rem;
+  }
+}
+
 .skip-link {
   position: absolute;
   top: -40px;

--- a/client/src/components/AdminNormativeGroups.vue
+++ b/client/src/components/AdminNormativeGroups.vue
@@ -135,7 +135,7 @@ defineExpose({ refresh });
       <div
         class="card-header d-flex justify-content-between align-items-center"
       >
-        <h2 class="h5 mb-0">Группы нормативов</h2>
+        <h2 class="h5">Группы нормативов</h2>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>

--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -365,7 +365,7 @@ defineExpose({ refresh });
       <div
         class="card-header d-flex justify-content-between align-items-center"
       >
-        <h2 class="h5 mb-0">Результаты нормативов</h2>
+        <h2 class="h5">Результаты нормативов</h2>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>

--- a/client/src/components/AdminNormativeTypes.vue
+++ b/client/src/components/AdminNormativeTypes.vue
@@ -299,7 +299,7 @@ defineExpose({ refresh });
       <div
         class="card-header d-flex justify-content-between align-items-center"
       >
-        <h2 class="h5 mb-0">Типы нормативов</h2>
+        <h2 class="h5">Типы нормативов</h2>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>

--- a/client/src/components/RefereeGroupAssignments.vue
+++ b/client/src/components/RefereeGroupAssignments.vue
@@ -166,7 +166,7 @@ defineExpose({ refresh });
     </div>
     <div class="card section-card ground-card tile fade-in shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
-        <h2 class="h5 mb-0">Назначение судей</h2>
+        <h2 class="h5">Назначение судей</h2>
       </div>
       <div class="card-body p-3">
         <div class="row g-2 mb-3">

--- a/client/src/components/RefereeGroups.vue
+++ b/client/src/components/RefereeGroups.vue
@@ -111,7 +111,7 @@ defineExpose({ refresh });
   <div>
     <div class="card section-card ground-card tile fade-in shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
-        <h2 class="h5 mb-0">Группы судей</h2>
+        <h2 class="h5">Группы судей</h2>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>

--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -55,7 +55,7 @@ async function downloadConsent() {
 
 <template>
   <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item">
           <RouterLink to="/admin">Администрирование</RouterLink>

--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -63,7 +63,7 @@ async function downloadConsent() {
         <li class="breadcrumb-item active" aria-current="page">Документы</li>
       </ol>
     </nav>
-    <h1 class="mb-3">Документы</h1>
+    <h1>Документы</h1>
     <div class="card section-card tile fade-in shadow-sm">
       <div class="card-body">
         <div class="mb-3 position-relative">

--- a/client/src/views/AdminExamRegistrations.vue
+++ b/client/src/views/AdminExamRegistrations.vue
@@ -147,7 +147,7 @@ async function exportPdf() {
 <template>
   <div class="py-3 admin-exam-registrations-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-3">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/admin">Администрирование</RouterLink>
@@ -300,9 +300,6 @@ async function exportPdf() {
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-exam-registrations-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminExamRegistrations.vue
+++ b/client/src/views/AdminExamRegistrations.vue
@@ -158,7 +158,7 @@ async function exportPdf() {
           <li class="breadcrumb-item active" aria-current="page">Заявки</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Заявки на медосмотр</h1>
+      <h1>Заявки на медосмотр</h1>
       <p v-if="exam" class="mb-3">
         <strong>{{ exam.center?.name }}</strong>,
         {{ formatDateTime(exam.start_at) }} - {{ formatDateTime(exam.end_at) }}

--- a/client/src/views/AdminGrounds.vue
+++ b/client/src/views/AdminGrounds.vue
@@ -574,7 +574,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
 <template>
   <div class="py-3 admin-camps-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-3">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/admin">Администрирование</RouterLink>
@@ -1194,9 +1194,6 @@ async function toggleTrainingGroup(training, groupId, checked) {
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-camps-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminGrounds.vue
+++ b/client/src/views/AdminGrounds.vue
@@ -582,7 +582,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
           <li class="breadcrumb-item active" aria-current="page">Сборы</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Сборы</h1>
+      <h1>Сборы</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3 ground-card">
         <div class="card-body p-2">
           <ul class="nav nav-pills nav-fill justify-content-between mb-0 tab-selector">
@@ -621,7 +621,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
         </div>
         <div class="card section-card tile fade-in shadow-sm">
           <div class="card-header d-flex justify-content-between align-items-center">
-            <h2 class="h5 mb-0">Площадки</h2>
+            <h2 class="h5">Площадки</h2>
             <button class="btn btn-brand" @click="openCreate">
               <i class="bi bi-plus-lg me-1"></i>Добавить
             </button>
@@ -708,7 +708,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
       </div>
       <div class="card section-card tile fade-in shadow-sm">
         <div class="card-header d-flex justify-content-between align-items-center">
-          <h2 class="h5 mb-0">Типы тренировок</h2>
+            <h2 class="h5">Типы тренировок</h2>
           <button class="btn btn-brand" @click="openCreateType">
             <i class="bi bi-plus-lg me-1"></i>Добавить
           </button>
@@ -815,7 +815,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
     </div>
     <div class="card section-card tile fade-in shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
-        <h2 class="h5 mb-0">Тренировки</h2>
+        <h2 class="h5">Тренировки</h2>
         <div>
           <button class="btn btn-light me-2" @click="openTrainingFilters" title="Фильтры">
             <i class="bi bi-funnel"></i>

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -17,7 +17,7 @@ const refereeSections = [
 <template>
   <div class="py-4">
     <div class="container">
-      <h1 class="mb-3 text-center">Администрирование</h1>
+      <h1 class="text-center">Администрирование</h1>
 
       <div class="card section-card mb-2">
         <div class="card-body">

--- a/client/src/views/AdminMedicalManagement.vue
+++ b/client/src/views/AdminMedicalManagement.vue
@@ -11,7 +11,7 @@ const activeTab = ref('certificates');
 <template>
   <div class="py-3 admin-medical-management-page">
     <div class="container">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item">
           <RouterLink to="/admin">Администрирование</RouterLink>
@@ -90,9 +90,6 @@ const activeTab = ref('certificates');
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-medical-management-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminNormatives.vue
+++ b/client/src/views/AdminNormatives.vue
@@ -20,7 +20,7 @@ const activeTab = ref('results');
           <li class="breadcrumb-item active" aria-current="page">Нормативы</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Нормативы</h1>
+      <h1>Нормативы</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3">
         <div class="card-body p-2">
           <ul

--- a/client/src/views/AdminNormatives.vue
+++ b/client/src/views/AdminNormatives.vue
@@ -12,7 +12,7 @@ const activeTab = ref('results');
 <template>
   <div class="py-3 admin-normatives-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-3">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/admin">Администрирование</RouterLink>
@@ -106,9 +106,6 @@ const activeTab = ref('results');
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-normatives-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -78,7 +78,7 @@ async function changeStatus(ticket, alias) {
 
 <template>
   <div class="container mt-4 admin-tickets-page">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item">
           <RouterLink to="/admin">Администрирование</RouterLink>
@@ -239,9 +239,6 @@ async function changeStatus(ticket, alias) {
   animation: fadeIn 0.4s ease-out;
 }
 
-.admin-tickets-page nav[aria-label='breadcrumb'] {
-  margin-bottom: 1rem;
-}
 
 .flash {
   animation: flash-bg 1s ease-out;
@@ -258,9 +255,6 @@ async function changeStatus(ticket, alias) {
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-tickets-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminTickets.vue
+++ b/client/src/views/AdminTickets.vue
@@ -86,7 +86,7 @@ async function changeStatus(ticket, alias) {
         <li class="breadcrumb-item active" aria-current="page">Обращения</li>
       </ol>
     </nav>
-    <h1 class="mb-3">Обращения</h1>
+    <h1>Обращения</h1>
     <div class="card section-card tile fade-in shadow-sm mb-3">
       <div class="card-body">
         <div class="row g-2 align-items-end mb-3">

--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -258,7 +258,7 @@ function openNormatives(reg) {
 <template>
   <div class="py-3 admin-training-registrations-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-3">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/admin">Администрирование</RouterLink>
@@ -600,9 +600,6 @@ function openNormatives(reg) {
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-training-registrations-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -269,7 +269,7 @@ function openNormatives(reg) {
           <li class="breadcrumb-item active" aria-current="page">Участники</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Участники тренировки</h1>
+      <h1>Участники тренировки</h1>
       <p v-if="training" class="mb-3">
         <strong>{{ training.type?.name }}</strong
         >,

--- a/client/src/views/AdminUserCreate.vue
+++ b/client/src/views/AdminUserCreate.vue
@@ -107,7 +107,7 @@ async function copyToClipboard(text) {
         <li class="breadcrumb-item active" aria-current="page">Создание</li>
       </ol>
     </nav>
-    <h1 class="mb-3">Новый пользователь</h1>
+    <h1>Новый пользователь</h1>
     <form @submit.prevent="save">
       <UserForm ref="formRef" v-model="user" :isNew="true" :sexes="sexes" />
       <div class="mt-3">

--- a/client/src/views/AdminUserCreate.vue
+++ b/client/src/views/AdminUserCreate.vue
@@ -100,7 +100,7 @@ async function copyToClipboard(text) {
 
 <template>
   <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
         <li class="breadcrumb-item"><RouterLink to="/admin/users">Пользователи</RouterLink></li>

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -147,7 +147,7 @@ async function save() {
 
 <template>
   <div class="container mt-4">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item">
           <RouterLink to="/admin">Администрирование</RouterLink>

--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -160,7 +160,7 @@ async function save() {
         </li>
       </ol>
     </nav>
-    <h1 class="mb-3">Редактирование пользователя</h1>
+    <h1>Редактирование пользователя</h1>
     <div v-if="error" class="alert alert-danger">{{ error }}</div>
 
     <ul v-if="user" class="nav nav-pills nav-fill justify-content-between mb-4">

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -238,7 +238,7 @@ async function copy(text) {
         <li class="breadcrumb-item active" aria-current="page">Пользователи</li>
       </ol>
     </nav>
-    <h1 class="mb-3">Пользователи</h1>
+    <h1>Пользователи</h1>
     <div class="card tile mb-3">
       <div class="card-body p-2">
         <ul class="nav nav-pills nav-fill mb-0 tab-selector">
@@ -253,7 +253,7 @@ async function copy(text) {
     </div>
     <div v-show="activeTab === 'users'" class="card section-card tile fade-in shadow-sm">
       <div class="card-header d-flex justify-content-between align-items-center">
-        <h2 class="h5 mb-0">Пользователи</h2>
+        <h2 class="h5">Пользователи</h2>
         <button class="btn btn-brand" @click="openCreate">
           <i class="bi bi-plus-lg me-1"></i>Добавить
         </button>
@@ -451,7 +451,7 @@ async function copy(text) {
     </div>
     <div v-show="activeTab === 'profiles'" class="card section-card tile fade-in shadow-sm mt-3">
       <div class="card-header">
-        <h2 class="h5 mb-0">Заполнение профиля</h2>
+        <h2 class="h5">Заполнение профиля</h2>
       </div>
       <div class="card-body p-3">
         <div v-if="completionError" class="alert alert-danger mb-3">{{ completionError }}</div>

--- a/client/src/views/AdminUsers.vue
+++ b/client/src/views/AdminUsers.vue
@@ -232,7 +232,7 @@ async function copy(text) {
 <template>
   <div class="py-3 admin-users-page">
     <div class="container">
-    <nav aria-label="breadcrumb" class="mb-3">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item"><RouterLink to="/admin">Администрирование</RouterLink></li>
         <li class="breadcrumb-item active" aria-current="page">Пользователи</li>
@@ -568,9 +568,6 @@ async function copy(text) {
     padding-bottom: 0.5rem !important;
   }
 
-  .admin-users-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/AwaitingConfirmation.vue
+++ b/client/src/views/AwaitingConfirmation.vue
@@ -45,7 +45,7 @@ onUnmounted(() => {
   <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100 text-center" style="max-width: 420px;">
       <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
-      <h2 class="mb-3">Заявка отправлена</h2>
+      <h2>Заявка отправлена</h2>
       <p class="mb-3">Ваша регистрация завершена и ожидает проверки администратором.</p>
       <p class="mb-4">После подтверждения вам станет доступен портал.</p>
       <div class="d-flex justify-content-center gap-2">

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -363,7 +363,7 @@ function attendanceStatus(t) {
 <template>
   <div class="py-3 camps-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/">Главная</RouterLink>
@@ -860,9 +860,6 @@ function attendanceStatus(t) {
     padding-bottom: 0.5rem !important;
   }
 
-  .camps-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .camps-page h1 {
     margin-bottom: 1rem !important;

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -371,7 +371,7 @@ function attendanceStatus(t) {
           <li class="breadcrumb-item active" aria-current="page">Сборы</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Сборы</h1>
+      <h1>Сборы</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3 ground-card">
         <div class="card-body p-2">
           <ul class="nav nav-pills nav-fill mb-0 tab-selector">
@@ -463,7 +463,7 @@ function attendanceStatus(t) {
                       :key="g.date"
                       class="mb-3 schedule-day"
                   >
-                    <h2 class="h6 mb-3">{{ formatDay(g.date) }}</h2>
+                    <h2 class="h6">{{ formatDay(g.date) }}</h2>
                     <ul class="list-unstyled mb-0">
                       <li
                           v-for="t in g.trainings"
@@ -568,7 +568,7 @@ function attendanceStatus(t) {
                     :key="g.date"
                     class="mb-3 schedule-day"
                 >
-                  <h2 class="h6 mb-3">{{ formatDay(g.date) }}</h2>
+                  <h2 class="h6">{{ formatDay(g.date) }}</h2>
                   <ul class="list-unstyled mb-0">
                     <li
                         v-for="t in g.trainings"
@@ -697,7 +697,7 @@ function attendanceStatus(t) {
                 <div
                     class="d-flex justify-content-between align-items-start mb-1"
                 >
-                  <h2 class="h6 mb-1">{{ g.ground.name }}</h2>
+                  <h2 class="h6">{{ g.ground.name }}</h2>
                   <a
                       v-if="g.ground.yandex_url"
                       :href="withHttp(g.ground.yandex_url)"

--- a/client/src/views/DocumentView.vue
+++ b/client/src/views/DocumentView.vue
@@ -77,7 +77,7 @@ onMounted(async () => {
 <template>
   <div class="py-3">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/">Главная</RouterLink>
@@ -220,9 +220,6 @@ onMounted(async () => {
     padding-bottom: 0.5rem !important;
   }
 
-  nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   h1 {
     font-size: 1.25rem;

--- a/client/src/views/DocumentView.vue
+++ b/client/src/views/DocumentView.vue
@@ -90,7 +90,7 @@ onMounted(async () => {
           </li>
         </ol>
       </nav>
-      <h1 class="mb-3">{{ config.title }}</h1>
+      <h1>{{ config.title }}</h1>
       <div v-if="loading" class="text-center my-5">
         <div class="spinner-border" role="status" aria-label="Загрузка">
           <span class="visually-hidden">Загрузка…</span>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -91,7 +91,7 @@ async function loadUpcoming() {
 <template>
   <div class="py-4">
     <div class="container">
-      <h3 class="mb-3 text-start">
+      <h3 class="text-start">
         {{ greeting }}, {{ shortName || auth.user?.phone }}!
       </h3>
       <div v-if="showUpcoming" class="card section-card mb-2 text-start">

--- a/client/src/views/Login.vue
+++ b/client/src/views/Login.vue
@@ -83,7 +83,7 @@ async function login() {
   <div class="d-flex flex-column align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
       <img :src="logo" alt="FHM" class="mx-auto d-block mb-3" style="max-height: 80px" />
-      <h2 class="mb-3 text-center">Авторизация</h2>
+      <h2 class="text-center">Авторизация</h2>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -234,7 +234,7 @@ function onFileChange(e) {
         <li class="breadcrumb-item active" aria-current="page">Медосмотр</li>
       </ol>
     </nav>
-    <h1 class="mb-3">Данные медицинских обследований</h1>
+    <h1>Данные медицинских обследований</h1>
     <div v-if="loading" class="text-center py-5">
       <div class="spinner-border" role="status" aria-label="Загрузка">
         <span class="visually-hidden">Загрузка…</span>

--- a/client/src/views/Medical.vue
+++ b/client/src/views/Medical.vue
@@ -228,7 +228,7 @@ function onFileChange(e) {
 <template>
   <div class="py-3 medical-page">
     <div class="container">
-    <nav aria-label="breadcrumb" class="mb-2">
+    <nav aria-label="breadcrumb">
       <ol class="breadcrumb mb-0">
         <li class="breadcrumb-item"><RouterLink to="/">Главная</RouterLink></li>
         <li class="breadcrumb-item active" aria-current="page">Медосмотр</li>
@@ -469,9 +469,6 @@ function onFileChange(e) {
     padding-bottom: 0.5rem !important;
   }
 
-  .medical-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .medical-page h1 {
     margin-bottom: 1rem !important;

--- a/client/src/views/Normatives.vue
+++ b/client/src/views/Normatives.vue
@@ -213,7 +213,7 @@ function thresholdText(t, zone) {
 <template>
   <div class="py-3 normatives-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/">Главная</RouterLink>
@@ -631,9 +631,6 @@ function thresholdText(t, zone) {
   white-space: nowrap;
 }
 
-.normatives-page nav[aria-label='breadcrumb'] {
-  margin-bottom: 1rem;
-}
 
 .header-controls .season-select {
   width: auto;
@@ -661,9 +658,6 @@ function thresholdText(t, zone) {
     padding-bottom: 0.5rem !important;
   }
 
-  .normatives-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/Normatives.vue
+++ b/client/src/views/Normatives.vue
@@ -224,7 +224,7 @@ function thresholdText(t, zone) {
       <div
         class="d-flex flex-wrap align-items-center justify-content-between mb-3 header-controls"
       >
-        <h1 class="mb-0 text-start">Нормативы</h1>
+        <h1 class="text-start">Нормативы</h1>
         <button
           class="btn btn-outline-secondary d-sm-none"
           @click="openSeason"
@@ -257,7 +257,7 @@ function thresholdText(t, zone) {
         class="card section-card tile fade-in shadow-sm mb-3"
       >
         <div class="card-header">
-          <h2 class="h6 mb-0">{{ g.name }}</h2>
+          <h2 class="h6">{{ g.name }}</h2>
         </div>
         <div class="card-body p-3">
           <div

--- a/client/src/views/PasswordReset.vue
+++ b/client/src/views/PasswordReset.vue
@@ -65,7 +65,7 @@ async function finish() {
 <template>
   <div class="d-flex align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
-      <h1 class="mb-3 text-center">Восстановление пароля</h1>
+      <h1 class="text-center">Восстановление пароля</h1>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>
       </transition>

--- a/client/src/views/Profile.vue
+++ b/client/src/views/Profile.vue
@@ -201,7 +201,7 @@ onMounted(() => {
 <template>
   <div class="py-3 profile-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/">Главная</RouterLink>
@@ -521,9 +521,6 @@ onMounted(() => {
     padding-bottom: 0.5rem !important;
   }
 
-  .profile-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .profile-page h1 {
     margin-bottom: 1rem !important;

--- a/client/src/views/Profile.vue
+++ b/client/src/views/Profile.vue
@@ -211,7 +211,7 @@ onMounted(() => {
           </li>
         </ol>
       </nav>
-      <h1 class="mb-3">Документы и данные</h1>
+      <h1>Документы и данные</h1>
       <div v-if="loading.user" class="text-center my-5">
         <div class="spinner-border" role="status" aria-label="Загрузка">
           <span class="visually-hidden">Загрузка…</span>

--- a/client/src/views/ProfileWizard.vue
+++ b/client/src/views/ProfileWizard.vue
@@ -371,7 +371,7 @@ async function saveStep() {
 
 <template>
   <div class="container py-5" style="max-width: 600px">
-    <h1 class="mb-3 text-center">Заполнение профиля</h1>
+    <h1 class="text-center">Заполнение профиля</h1>
     <div class="progress mb-4">
       <div class="progress-bar" role="progressbar" :style="{ width: (step / total) * 100 + '%' }"></div>
     </div>

--- a/client/src/views/Register.vue
+++ b/client/src/views/Register.vue
@@ -71,7 +71,7 @@ async function finish() {
 <template>
   <div class="d-flex flex-column align-items-center justify-content-center min-vh-100">
     <div class="card p-4 shadow login-card w-100" style="max-width: 400px;">
-      <h1 class="mb-3 text-center">Регистрация</h1>
+      <h1 class="text-center">Регистрация</h1>
       <p class="text-center mb-3">с использованием существующей учетной записи в личном кабинете судьи</p>
       <transition name="fade">
         <div v-if="error" class="alert alert-danger">{{ error }}</div>

--- a/client/src/views/Tasks.vue
+++ b/client/src/views/Tasks.vue
@@ -14,7 +14,7 @@ import { RouterLink } from 'vue-router';
           <li class="breadcrumb-item active" aria-current="page">Задачи</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Задачи</h1>
+      <h1>Задачи</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3">
         <div class="card-body">
           <TaskList />

--- a/client/src/views/Tasks.vue
+++ b/client/src/views/Tasks.vue
@@ -6,7 +6,7 @@ import { RouterLink } from 'vue-router';
 <template>
   <div class="py-3 tasks-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/">Главная</RouterLink>
@@ -35,9 +35,6 @@ import { RouterLink } from 'vue-router';
   animation: fadeIn 0.4s ease-out;
 }
 
-.tasks-page nav[aria-label='breadcrumb'] {
-  margin-bottom: 1rem;
-}
 
 @media (max-width: 575.98px) {
   .tasks-page {
@@ -45,9 +42,6 @@ import { RouterLink } from 'vue-router';
     padding-bottom: 0.5rem !important;
   }
 
-  .tasks-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/Tickets.vue
+++ b/client/src/views/Tickets.vue
@@ -99,7 +99,7 @@ async function deleteTicket(ticket) {
 <template>
   <div class="py-3 tickets-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-2">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item"><RouterLink to="/">Главная</RouterLink></li>
           <li class="breadcrumb-item active" aria-current="page">Обращения</li>
@@ -216,9 +216,6 @@ async function deleteTicket(ticket) {
   animation: fadeIn 0.4s ease-out;
 }
 
-.tickets-page nav[aria-label='breadcrumb'] {
-  margin-bottom: 1rem;
-}
 
 .tab-selector {
   gap: 0.5rem;
@@ -234,9 +231,6 @@ async function deleteTicket(ticket) {
     padding-bottom: 0.5rem !important;
   }
 
-  .tickets-page nav[aria-label='breadcrumb'] {
-    margin-bottom: 0.25rem !important;
-  }
 
   .section-card {
     margin-left: -1rem;

--- a/client/src/views/Tickets.vue
+++ b/client/src/views/Tickets.vue
@@ -105,7 +105,7 @@ async function deleteTicket(ticket) {
           <li class="breadcrumb-item active" aria-current="page">Обращения</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Мои обращения</h1>
+      <h1>Мои обращения</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3">
         <div class="card-body p-2">
           <ul class="nav nav-pills nav-fill mb-0 tab-selector">

--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -102,7 +102,7 @@ function showToast(message) {
 <template>
   <div class="py-3 training-attendance-page">
     <div class="container">
-      <nav aria-label="breadcrumb" class="mb-3">
+      <nav aria-label="breadcrumb">
         <ol class="breadcrumb mb-0">
           <li class="breadcrumb-item">
             <RouterLink to="/camps">Мои тренировки</RouterLink>

--- a/client/src/views/TrainingAttendance.vue
+++ b/client/src/views/TrainingAttendance.vue
@@ -110,7 +110,7 @@ function showToast(message) {
           <li class="breadcrumb-item active" aria-current="page">Посещаемость</li>
         </ol>
       </nav>
-      <h1 class="mb-3">Посещаемость</h1>
+      <h1>Посещаемость</h1>
       <div v-if="error" class="alert alert-danger">{{ error }}</div>
       <div v-if="loading" class="text-center my-5">
         <div class="spinner-border" role="status" aria-label="Загрузка">


### PR DESCRIPTION
## Summary
- Unify heading font sizes across the client for consistent typography
- Centralize breadcrumb font size and spacing rules, removing page-specific overrides

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68948bcc9018832dbdb3e671f9fbef02