### PR TITLE
Fix client lint step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 24
+      - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 20
           cache: 'npm'
-          cache-dependency-path: package-lock.json
+          cache-dependency-path: |
+            package-lock.json
+            client/package-lock.json
 
       - name: Install dependencies
         run: npm ci
@@ -47,13 +49,13 @@ jobs:
         working-directory: client
         run: npm ci
 
-      - name: Build client
-        working-directory: client
-        run: npm run build
-
       - name: Lint client
         working-directory: client
         run: npm run lint
+
+      - name: Build client
+        working-directory: client
+        run: npm run build
 
       - name: Set up Docker Buildx
         if: github.ref == 'refs/heads/main'

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -4,6 +4,9 @@ import prettierConfig from 'eslint-config-prettier';
 import prettierPlugin from 'eslint-plugin-prettier';
 
 export default [
+  {
+    ignores: ['dist/**', 'node_modules/**'],
+  },
   // Vue SFC rules
   ...vue.configs['flat/recommended'],
   // Disable stylistic rules that conflict with Prettier


### PR DESCRIPTION
## Summary
- ignore build artifacts in client ESLint config
- run client lint before build and use Node 20 with cache for root & client

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `npm run client:lint`


------
https://chatgpt.com/codex/tasks/task_e_68956a31be18832da685b72538dfd940