### PR TITLE
Add default props for Vue components

### DIFF
--- a/client/src/components/AddPassportModal.vue
+++ b/client/src/components/AddPassportModal.vue
@@ -4,7 +4,7 @@ import Modal from 'bootstrap/js/dist/modal';
 import { cleanPassport, suggestFmsUnit } from '../dadata.js';
 
 const props = defineProps({
-  user: Object,
+  user: { type: Object, default: null },
 });
 const emit = defineEmits(['saved']);
 

--- a/client/src/components/InfoField.vue
+++ b/client/src/components/InfoField.vue
@@ -29,12 +29,14 @@
 </template>
 
 <script setup>
+defineEmits(['copy']);
+
 defineProps({
-  id: String,
-  label: String,
-  icon: String,
-  value: [String, Number],
+  id: { type: String, required: true },
+  label: { type: String, required: true },
+  icon: { type: String, default: null },
+  value: { type: [String, Number], default: '' },
   placeholder: { type: String, default: '—' },
-  copyable: Boolean,
+  copyable: { type: Boolean, default: false },
 });
 </script>

--- a/client/src/components/InfoItem.vue
+++ b/client/src/components/InfoItem.vue
@@ -7,8 +7,8 @@
 
 <script setup>
 defineProps({
-  label: String,
-  value: [String, Number],
+  label: { type: String, required: true },
+  value: { type: [String, Number], default: '' },
   placeholder: { type: String, default: '—' },
 });
 </script>

--- a/client/src/components/PassportForm.vue
+++ b/client/src/components/PassportForm.vue
@@ -3,10 +3,10 @@ import { reactive, watch, ref, computed } from 'vue';
 import { suggestFmsUnit } from '../dadata.js';
 
 const props = defineProps({
-  modelValue: Object,
+  modelValue: { type: Object, default: () => ({}) },
   locked: { type: Boolean, default: false },
-  lockedFields: Object,
-  birthDate: String,
+  lockedFields: { type: Object, default: () => ({}) },
+  birthDate: { type: String, default: '' },
 });
 const emit = defineEmits(['update:modelValue']);
 

--- a/client/src/components/TaxationInfo.vue
+++ b/client/src/components/TaxationInfo.vue
@@ -4,7 +4,7 @@ import Modal from 'bootstrap/js/dist/modal';
 import { apiFetch } from '../api.js';
 
 const props = defineProps({
-  userId: String,
+  userId: { type: String, default: null },
   editable: { type: Boolean, default: true },
   showOkved: { type: Boolean, default: true },
   modalOnly: { type: Boolean, default: false },

--- a/client/src/components/UserForm.vue
+++ b/client/src/components/UserForm.vue
@@ -3,9 +3,9 @@ import { reactive, watch, ref } from 'vue';
 import { suggestFio, cleanFio } from '../dadata.js';
 
 const props = defineProps({
-  modelValue: Object,
-  isNew: Boolean,
-  locked: Boolean,
+  modelValue: { type: Object, default: () => ({}) },
+  isNew: { type: Boolean, default: false },
+  locked: { type: Boolean, default: false },
   sexes: { type: Array, default: () => [] },
 });
 const emit = defineEmits(['update:modelValue', 'editing-changed']);


### PR DESCRIPTION
## Summary
- add default values and required flags for Vue component props
- declare copy emit for InfoField component

## Testing
- `npm run lint`
- `npm test`
- `npm run format:check`
- `cd client && npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6895a5d0b5a4832d85b5a6920096fb18