### PR TITLE
Refactor alias generation to avoid ReDoS risk

### DIFF
--- a/src/utils/alias.js
+++ b/src/utils/alias.js
@@ -36,10 +36,8 @@ export default function generateAlias(name) {
     .split('')
     .map((c) => map[c.toLowerCase()] || c)
     .join('');
-  return translit
-    .replace(/[^0-9a-zA-Z]+/g, '_')
-    .replace(/_+/g, '_')
-    .replace(/^_+/, '')
-    .replace(/_+$/, '')
-    .toUpperCase();
+
+  const sanitized = translit.replace(/[^0-9a-zA-Z]+/g, '_');
+
+  return sanitized.split('_').filter(Boolean).join('_').toUpperCase();
 }


### PR DESCRIPTION
## Summary
- Replace repeated underscore regexes with safe split/join logic in alias generation

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68971a2f185c832d9238ae24600b1557