### PR TITLE
Handle empty training_id for normative results

### DIFF
--- a/src/validators/normativeResultValidators.js
+++ b/src/validators/normativeResultValidators.js
@@ -6,7 +6,10 @@ import { parseResultValue } from '../services/normativeTypeService.js';
 export const normativeResultCreateRules = [
   body('user_id').isUUID(),
   body('season_id').isUUID(),
-  body('training_id').optional().isUUID(),
+  body('training_id')
+    .customSanitizer((v) => (v === '' ? undefined : v))
+    .optional({ nullable: true })
+    .isUUID(),
   body('type_id').isUUID(),
   body('online').optional().isBoolean(),
   body('retake').optional().isBoolean(),
@@ -33,7 +36,10 @@ export const normativeResultCreateRules = [
 ];
 
 export const normativeResultUpdateRules = [
-  body('training_id').optional().isUUID(),
+  body('training_id')
+    .customSanitizer((v) => (v === '' ? undefined : v))
+    .optional({ nullable: true })
+    .isUUID(),
   body('value').optional().notEmpty(),
   body('online').optional().isBoolean(),
   body('retake').optional().isBoolean(),


### PR DESCRIPTION
## Summary
- sanitize empty `training_id` in normative result validators to avoid false 400 errors
- normalize empty `training_id` in service logic for create and update

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689723114568832da1e7dc4f1519e058