### PR TITLE
Show training schedule in calendar view

### DIFF
--- a/client/src/components/TrainingCalendar.vue
+++ b/client/src/components/TrainingCalendar.vue
@@ -1,0 +1,60 @@
+<script setup>
+import { computed } from 'vue';
+import TrainingCard from './TrainingCard.vue';
+
+const props = defineProps({
+  trainings: { type: Array, default: () => [] },
+});
+const emit = defineEmits(['register', 'unregister']);
+
+const groups = computed(() => {
+  const sorted = [...props.trainings].sort(
+    (a, b) => new Date(a.start_at) - new Date(b.start_at)
+  );
+  const map = new Map();
+  sorted.forEach((t) => {
+    const d = new Date(t.start_at);
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+    if (!map.has(key)) map.set(key, []);
+    map.get(key).push(t);
+  });
+  return Array.from(map.entries()).map(([date, list]) => ({ date, list }));
+});
+
+function formatDate(dateStr) {
+  const d = new Date(`${dateStr}T00:00:00`);
+  return d.toLocaleDateString('ru-RU', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'long',
+    timeZone: 'Europe/Moscow',
+  });
+}
+</script>
+
+<template>
+  <div class="training-calendar">
+    <div v-for="group in groups" :key="group.date" class="mb-4">
+      <h3 class="h6 mb-3 calendar-date">{{ formatDate(group.date) }}</h3>
+      <div class="d-flex flex-column gap-3">
+        <TrainingCard
+          v-for="t in group.list"
+          :key="t.id"
+          :training="t"
+          @register="emit('register', $event)"
+          @unregister="emit('unregister', $event)"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.calendar-date {
+  text-transform: capitalize;
+}
+
+:deep(.training-card) {
+  width: 100%;
+}
+</style>

--- a/client/src/utils/time.js
+++ b/client/src/utils/time.js
@@ -33,6 +33,16 @@ export function parseMinutesSeconds(str) {
 const MOSCOW_TZ = 'Europe/Moscow';
 const MOSCOW_OFFSET = '+03:00';
 
+export function toDayKey(iso, timeZone = MOSCOW_TZ) {
+  if (!iso) return null;
+  const date = new Date(iso);
+  const [year, month, day] = date
+    .toLocaleDateString('en-CA', { timeZone })
+    .split('-')
+    .map((v) => parseInt(v, 10));
+  return Date.UTC(year, month - 1, day);
+}
+
 export function toDateTimeLocal(iso, timeZone = MOSCOW_TZ) {
   if (!iso) return '';
   const date = new Date(iso);

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -26,6 +26,25 @@ async function loadTrainings() {
 }
 
 async function register(id) {
+  const target = trainings.value.find((t) => t.id === id);
+  if (target) {
+    const d = new Date(target.start_at);
+    const dayKey = new Date(
+      d.getFullYear(),
+      d.getMonth(),
+      d.getDate()
+    ).getTime();
+    const conflict = trainings.value.some((t) => {
+      const td = new Date(t.start_at);
+      const key = new Date(
+        td.getFullYear(),
+        td.getMonth(),
+        td.getDate()
+      ).getTime();
+      return t.id !== id && t.registered && key === dayKey;
+    });
+    if (conflict) return;
+  }
   await apiFetch(`/course-trainings/${id}/register`, { method: 'POST' });
   await loadTrainings();
 }

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -2,7 +2,7 @@
 import { ref, onMounted } from 'vue';
 import { RouterLink } from 'vue-router';
 import { apiFetch } from '../api.js';
-import TrainingCard from '../components/TrainingCard.vue';
+import TrainingCalendar from '../components/TrainingCalendar.vue';
 
 const course = ref(null);
 const error = ref('');
@@ -15,7 +15,9 @@ async function loadTrainings() {
   trainingsLoading.value = true;
   try {
     const data = await apiFetch('/course-trainings/available');
-    trainings.value = data.trainings;
+    trainings.value = (data.trainings || []).sort(
+      (a, b) => new Date(a.start_at) - new Date(b.start_at)
+    );
   } catch (err) {
     trainingsError.value = err.message;
   } finally {
@@ -107,15 +109,12 @@ onMounted(async () => {
           <div v-else-if="trainingsError" class="alert alert-danger mb-0">
             {{ trainingsError }}
           </div>
-          <div v-else-if="trainings.length" class="d-flex gap-3 overflow-auto">
-            <TrainingCard
-              v-for="t in trainings"
-              :key="t.id"
-              :training="t"
-              @register="register"
-              @unregister="unregister"
-            />
-          </div>
+          <TrainingCalendar
+            v-else-if="trainings.length"
+            :trainings="trainings"
+            @register="register"
+            @unregister="unregister"
+          />
           <div v-else class="alert alert-info mb-0">
             Нет доступных тренировок
           </div>

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -3,6 +3,7 @@ import { ref, onMounted } from 'vue';
 import { RouterLink } from 'vue-router';
 import { apiFetch } from '../api.js';
 import TrainingCalendar from '../components/TrainingCalendar.vue';
+import { toDayKey } from '../utils/time.js';
 
 const course = ref(null);
 const error = ref('');
@@ -28,21 +29,10 @@ async function loadTrainings() {
 async function register(id) {
   const target = trainings.value.find((t) => t.id === id);
   if (target) {
-    const d = new Date(target.start_at);
-    const dayKey = new Date(
-      d.getFullYear(),
-      d.getMonth(),
-      d.getDate()
-    ).getTime();
-    const conflict = trainings.value.some((t) => {
-      const td = new Date(t.start_at);
-      const key = new Date(
-        td.getFullYear(),
-        td.getMonth(),
-        td.getDate()
-      ).getTime();
-      return t.id !== id && t.registered && key === dayKey;
-    });
+    const dayKey = toDayKey(target.start_at);
+    const conflict = trainings.value.some(
+      (t) => t.id !== id && t.registered && toDayKey(t.start_at) === dayKey
+    );
     if (conflict) return;
   }
   await apiFetch(`/course-trainings/${id}/register`, { method: 'POST' });

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { RouterLink } from 'vue-router';
+import Modal from 'bootstrap/js/dist/modal';
 import { apiFetch } from '../api.js';
 import TrainingCalendar from '../components/TrainingCalendar.vue';
 import { toDayKey } from '../utils/time.js';
@@ -11,6 +12,14 @@ const loading = ref(true);
 const trainings = ref([]);
 const trainingsError = ref('');
 const trainingsLoading = ref(false);
+const curatorModalRef = ref(null);
+let curatorModal;
+
+const curatorName = computed(() => {
+  if (!course.value?.responsible) return '';
+  const r = course.value.responsible;
+  return [r.last_name, r.first_name, r.patronymic].filter(Boolean).join(' ');
+});
 
 async function loadTrainings() {
   trainingsLoading.value = true;
@@ -45,6 +54,7 @@ async function unregister(id) {
 }
 
 onMounted(async () => {
+  curatorModal = new Modal(curatorModalRef.value);
   try {
     const data = await apiFetch('/courses/me').catch((e) => {
       if (e.message === 'Курс не назначен') return null;
@@ -58,6 +68,10 @@ onMounted(async () => {
     loading.value = false;
   }
 });
+
+function openCuratorModal() {
+  curatorModal?.show();
+}
 </script>
 
 <template>
@@ -74,37 +88,57 @@ onMounted(async () => {
         </ol>
       </nav>
       <h1 class="mb-3">Повышение квалификации</h1>
-      <div class="card section-card tile fade-in shadow-sm mb-3">
-        <div class="card-body">
-          <div v-if="loading" class="text-center py-3">
-            <div class="spinner-border text-brand" role="status">
-              <span class="visually-hidden">Загрузка...</span>
+      <div class="row g-3 mb-3">
+        <div class="col-md-6">
+          <div class="card section-card tile fade-in shadow-sm h-100">
+            <div class="card-body">
+              <div v-if="loading" class="text-center py-3">
+                <div class="spinner-border text-brand" role="status">
+                  <span class="visually-hidden">Загрузка...</span>
+                </div>
+              </div>
+              <div v-else-if="error" class="alert alert-danger mb-0">
+                {{ error }}
+              </div>
+              <div v-else-if="course">
+                <h2 class="h5 mb-3">{{ course.name }}</h2>
+                <p v-if="course.description" class="mb-3">
+                  {{ course.description }}
+                </p>
+                <p v-if="course.telegram_url">
+                  <a
+                    :href="course.telegram_url"
+                    target="_blank"
+                    rel="noopener"
+                    class="link-primary"
+                    >Чат в Telegram</a
+                  >
+                </p>
+              </div>
+              <div v-else class="alert alert-info mb-0">Курс не назначен</div>
             </div>
           </div>
-          <div v-else-if="error" class="alert alert-danger mb-0">
-            {{ error }}
-          </div>
-          <div v-else-if="course">
-            <h2 class="h5 mb-3">{{ course.name }}</h2>
-            <p v-if="course.description" class="mb-3">
-              {{ course.description }}
-            </p>
-            <p v-if="course.responsible" class="mb-1">
-              <strong>Ответственный:</strong>
-              {{ course.responsible.last_name }}
-              {{ course.responsible.first_name }}
-            </p>
-            <p v-if="course.telegram_url">
-              <a
-                :href="course.telegram_url"
-                target="_blank"
-                rel="noopener"
-                class="link-primary"
-                >Чат в Telegram</a
+        </div>
+        <div v-if="course?.responsible" class="col-md-6">
+          <div
+            class="card section-card tile fade-in shadow-sm h-100 cursor-pointer"
+            role="button"
+            tabindex="0"
+            @click="openCuratorModal"
+          >
+            <div class="card-body d-flex align-items-center">
+              <div
+                class="flex-shrink-0 me-3 rounded-circle bg-light d-flex align-items-center justify-content-center"
+                style="width: 4rem; height: 4rem"
               >
-            </p>
+                <i class="bi bi-person-fill text-muted fs-2"></i>
+              </div>
+              <div>
+                <div>{{ curatorName }}</div>
+                <div class="text-muted small">Куратор курса</div>
+              </div>
+            </div>
           </div>
-          <div v-else class="alert alert-info mb-0">Курс не назначен</div>
         </div>
       </div>
       <div v-if="course" class="card section-card tile fade-in shadow-sm mb-3">
@@ -126,6 +160,38 @@ onMounted(async () => {
           />
           <div v-else class="alert alert-info mb-0">
             Нет доступных тренировок
+          </div>
+        </div>
+      </div>
+    </div>
+    <div ref="curatorModalRef" class="modal fade" tabindex="-1">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">{{ curatorName }}</h5>
+            <button
+              type="button"
+              class="btn-close"
+              data-bs-dismiss="modal"
+            ></button>
+          </div>
+          <div class="modal-body p-0">
+            <div class="list-group list-group-flush">
+              <a
+                v-if="course?.responsible?.phone"
+                :href="`tel:+${course.responsible.phone}`"
+                class="list-group-item list-group-item-action"
+              >
+                <i class="bi bi-telephone me-2"></i>Позвонить
+              </a>
+              <a
+                v-if="course?.responsible?.email"
+                :href="`mailto:${course.responsible.email}`"
+                class="list-group-item list-group-item-action"
+              >
+                <i class="bi bi-envelope me-2"></i>Написать на email
+              </a>
+            </div>
           </div>
         </div>
       </div>

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -153,46 +153,49 @@ function openContactModal(contact) {
             </div>
           </div>
         </div>
-        <div class="col-md-6 d-flex flex-column gap-3">
-          <div
-            v-if="responsibleContact"
-            class="card section-card tile fade-in shadow-sm cursor-pointer"
-            role="button"
-            tabindex="0"
-            @click="openContactModal(responsibleContact)"
-          >
-            <div class="card-body d-flex align-items-center">
+        <div class="col-md-6">
+          <div class="card section-card tile fade-in shadow-sm">
+            <div class="card-body p-0">
               <div
-                class="flex-shrink-0 me-3 rounded-circle bg-light d-flex align-items-center justify-content-center"
-                style="width: 4rem; height: 4rem"
+                v-if="responsibleContact"
+                class="d-flex align-items-center p-3 cursor-pointer"
+                role="button"
+                tabindex="0"
+                @click="openContactModal(responsibleContact)"
               >
-                <i class="bi bi-person-fill text-muted fs-2"></i>
-              </div>
-              <div>
-                <div>{{ responsibleContact.name }}</div>
-                <div class="text-muted small">
-                  {{ responsibleContact.title }}
+                <div
+                  class="flex-shrink-0 me-3 rounded-circle bg-light d-flex align-items-center justify-content-center"
+                  style="width: 3rem; height: 3rem"
+                >
+                  <i class="bi bi-person-fill text-muted fs-3"></i>
+                </div>
+                <div>
+                  <div>{{ responsibleContact.name }}</div>
+                  <div class="text-muted small">
+                    {{ responsibleContact.title }}
+                  </div>
                 </div>
               </div>
-            </div>
-          </div>
-          <div
-            class="card section-card tile fade-in shadow-sm cursor-pointer"
-            role="button"
-            tabindex="0"
-            @click="openContactModal(olenin)"
-          >
-            <div class="card-body d-flex align-items-center">
+              <template v-if="responsibleContact">
+                <hr class="my-0" />
+              </template>
               <div
-                class="flex-shrink-0 me-3 rounded-circle bg-light d-flex align-items-center justify-content-center"
-                style="width: 4rem; height: 4rem"
+                class="d-flex align-items-center p-3 cursor-pointer"
+                role="button"
+                tabindex="0"
+                @click="openContactModal(olenin)"
               >
-                <i class="bi bi-person-fill text-muted fs-2"></i>
-              </div>
-              <div>
-                <div>{{ olenin.name }}</div>
-                <div class="text-muted small">
-                  {{ olenin.title }}
+                <div
+                  class="flex-shrink-0 me-3 rounded-circle bg-light d-flex align-items-center justify-content-center"
+                  style="width: 3rem; height: 3rem"
+                >
+                  <i class="bi bi-person-fill text-muted fs-3"></i>
+                </div>
+                <div>
+                  <div>{{ olenin.name }}</div>
+                  <div class="text-muted small">
+                    {{ olenin.title }}
+                  </div>
                 </div>
               </div>
             </div>

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -124,7 +124,7 @@ function openContactModal(contact) {
       <h1 class="mb-3">Повышение квалификации</h1>
       <div class="row g-3 mb-3">
         <div class="col-md-6">
-          <div class="card section-card tile fade-in shadow-sm">
+          <div class="card section-card tile fade-in shadow-sm h-100">
             <div class="card-body">
               <div v-if="loading" class="text-center py-3">
                 <div class="spinner-border text-brand" role="status">
@@ -154,8 +154,9 @@ function openContactModal(contact) {
           </div>
         </div>
         <div class="col-md-6">
-          <div class="card section-card tile fade-in shadow-sm">
+          <div class="card section-card tile fade-in shadow-sm h-100">
             <div class="card-body p-0">
+              <h2 class="h5 mb-0 px-3 pt-3">Команда курса</h2>
               <div
                 v-if="responsibleContact"
                 class="d-flex align-items-center p-3 cursor-pointer"
@@ -177,7 +178,7 @@ function openContactModal(contact) {
                 </div>
               </div>
               <template v-if="responsibleContact">
-                <hr class="my-0" />
+                <hr class="my-0 mx-3" />
               </template>
               <div
                 class="d-flex align-items-center p-3 cursor-pointer"


### PR DESCRIPTION
## Summary
- Render upcoming qualification trainings in a calendar-style list sorted by date
- Introduce reusable TrainingCalendar component with responsive styling

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6897262525ec832d949abbde616b27b5