### PR TITLE
Track document generation date and show user documents

### DIFF
--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -61,7 +61,7 @@ onMounted(async () => {
               <th>Документ</th>
               <th>Получатель</th>
               <th>Статус</th>
-              <th>Дата</th>
+              <th>Дата документа</th>
             </tr>
           </thead>
           <tbody>
@@ -72,7 +72,7 @@ onMounted(async () => {
                 {{ d.recipient.patronymic }}
               </td>
               <td>{{ d.status?.name }}</td>
-              <td>{{ formatDateTime(d.createdAt) }}</td>
+              <td>{{ formatDateTime(d.documentDate) }}</td>
             </tr>
             <tr v-if="!documents.length">
               <td colspan="4" class="text-center">Документы отсутствуют</td>

--- a/src/migrations/20250918130000-add-document-date-to-documents.js
+++ b/src/migrations/20250918130000-add-document-date-to-documents.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('documents', 'document_date', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: Sequelize.literal('NOW()'),
+    });
+    // backfill existing records if needed
+    await queryInterface.sequelize.query(
+      'UPDATE documents SET document_date = created_at WHERE document_date IS NULL;'
+    );
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('documents', 'document_date');
+  },
+};

--- a/src/migrations/20250918140000-add-sign-created-date-to-user-sign-types.js
+++ b/src/migrations/20250918140000-add-sign-created-date-to-user-sign-types.js
@@ -1,0 +1,15 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('user_sign_types', 'sign_created_date', {
+      type: Sequelize.DATE,
+      allowNull: true,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('user_sign_types', 'sign_created_date');
+  },
+};

--- a/src/models/document.js
+++ b/src/models/document.js
@@ -18,6 +18,7 @@ Document.init(
     sign_type_id: { type: DataTypes.UUID, allowNull: false },
     name: { type: DataTypes.STRING(255), allowNull: false },
     description: { type: DataTypes.TEXT },
+    document_date: { type: DataTypes.DATE, allowNull: false },
   },
   {
     sequelize,

--- a/src/models/userSignType.js
+++ b/src/models/userSignType.js
@@ -13,6 +13,7 @@ UserSignType.init(
     },
     user_id: { type: DataTypes.UUID, allowNull: false },
     sign_type_id: { type: DataTypes.UUID, allowNull: false },
+    sign_created_date: { type: DataTypes.DATE },
   },
   {
     sequelize,

--- a/src/services/documentService.js
+++ b/src/services/documentService.js
@@ -35,6 +35,7 @@ async function create(data, userId) {
     sign_type_id: data.signTypeId,
     name: data.name,
     description: data.description,
+    document_date: data.documentDate || new Date(),
     created_by: userId,
     updated_by: userId,
   });
@@ -61,6 +62,7 @@ async function listByUser(userId) {
     id: d.id,
     name: d.name,
     description: d.description,
+    documentDate: d.document_date,
     documentType: d.DocumentType
       ? { name: d.DocumentType.name, alias: d.DocumentType.alias }
       : null,
@@ -95,6 +97,7 @@ async function listAll() {
   return docs.map((d) => ({
     id: d.id,
     name: d.name,
+    documentDate: d.document_date,
     documentType: d.DocumentType
       ? { name: d.DocumentType.name, alias: d.DocumentType.alias }
       : null,
@@ -188,6 +191,7 @@ async function generateInitial(user, signTypeId) {
       file_id: file.id,
       sign_type_id: signTypeId,
       name: consentType.name,
+      document_date: new Date(),
       created_by: user.id,
       updated_by: user.id,
     });
@@ -209,6 +213,7 @@ async function generateInitial(user, signTypeId) {
       file_id: file.id,
       sign_type_id: signTypeId,
       name: agreementType.name,
+      document_date: new Date(),
       created_by: user.id,
       updated_by: user.id,
     });

--- a/src/services/signTypeService.js
+++ b/src/services/signTypeService.js
@@ -26,7 +26,7 @@ async function getByUser(userId) {
   });
   return {
     id: record.id,
-    created_at: record.created_at,
+    selectedAt: record.created_at,
     name: record.SignType.name,
     alias: record.SignType.alias,
     inn: inn ? inn.number : null,

--- a/src/services/signTypeService.js
+++ b/src/services/signTypeService.js
@@ -14,7 +14,7 @@ async function list() {
 async function getByUser(userId) {
   const record = await UserSignType.findOne({
     where: { user_id: userId },
-    attributes: ['id', 'created_at'],
+    attributes: ['id', 'created_at', 'sign_created_date'],
     include: [{ model: SignType, attributes: ['name', 'alias'] }],
   });
   if (!record) {
@@ -27,6 +27,7 @@ async function getByUser(userId) {
   return {
     id: record.id,
     selectedAt: record.created_at,
+    signCreatedDate: record.sign_created_date,
     name: record.SignType.name,
     alias: record.SignType.alias,
     inn: inn ? inn.number : null,
@@ -48,12 +49,17 @@ async function select(user, alias, code) {
     defaults: {
       user_id: user.id,
       sign_type_id: signType.id,
+      sign_created_date: new Date(),
       created_by: user.id,
       updated_by: user.id,
     },
   });
   if (record.sign_type_id !== signType.id) {
-    await record.update({ sign_type_id: signType.id, updated_by: user.id });
+    await record.update({
+      sign_type_id: signType.id,
+      sign_created_date: new Date(),
+      updated_by: user.id,
+    });
   }
   await documentService.generateInitial(user, signType.id);
   return signType;

--- a/src/validators/documentValidators.js
+++ b/src/validators/documentValidators.js
@@ -7,6 +7,7 @@ export const createDocumentValidator = [
   body('signTypeId').isUUID(),
   body('name').isString().trim().notEmpty(),
   body('description').optional().isString(),
+  body('documentDate').optional().isISO8601(),
 ];
 
 export default { createDocumentValidator };


### PR DESCRIPTION
## Summary
- add `document_date` column and model field
- expose document generation date in services and admin/user APIs
- return sign type selection date as `selectedAt`
- display user documents with details in client documents pages

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689725b394b8832daa307cd42e989bfd