### PR TITLE
Add aria labels to icon buttons

### DIFF
--- a/client/src/components/AddPassportModal.vue
+++ b/client/src/components/AddPassportModal.vue
@@ -178,6 +178,7 @@ async function save() {
           <button
             type="button"
             class="btn-close"
+            aria-label="Закрыть"
             @click="modal.hide()"
           ></button>
         </div>

--- a/client/src/components/AdminNormativeGroups.vue
+++ b/client/src/components/AdminNormativeGroups.vue
@@ -168,11 +168,16 @@ defineExpose({ refresh });
                 <td class="text-end">
                   <button
                     class="btn btn-sm btn-secondary me-2"
+                    aria-label="Редактировать группу"
                     @click="openEdit(g)"
                   >
                     <i class="bi bi-pencil"></i>
                   </button>
-                  <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                  <button
+                    class="btn btn-sm btn-danger"
+                    aria-label="Удалить группу"
+                    @click="removeGroup(g)"
+                  >
                     <i class="bi bi-trash"></i>
                   </button>
                 </td>
@@ -198,11 +203,16 @@ defineExpose({ refresh });
               <div>
                 <button
                   class="btn btn-sm btn-secondary me-2"
+                  aria-label="Редактировать группу"
                   @click="openEdit(g)"
                 >
                   <i class="bi bi-pencil"></i>
                 </button>
-                <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                <button
+                  class="btn btn-sm btn-danger"
+                  aria-label="Удалить группу"
+                  @click="removeGroup(g)"
+                >
                   <i class="bi bi-trash"></i>
                 </button>
               </div>
@@ -237,6 +247,7 @@ defineExpose({ refresh });
               <button
                 type="button"
                 class="btn-close"
+                aria-label="Закрыть"
                 @click="modal.hide()"
               ></button>
             </div>

--- a/client/src/components/AdminNormativeResults.vue
+++ b/client/src/components/AdminNormativeResults.vue
@@ -447,6 +447,7 @@ defineExpose({ refresh });
                 <td class="text-end">
                   <button
                     class="btn btn-sm btn-secondary me-2"
+                    aria-label="Редактировать результат"
                     @click="openEdit(r)"
                   >
                     <i class="bi bi-pencil"></i>
@@ -454,6 +455,7 @@ defineExpose({ refresh });
                   <button
                     class="btn btn-sm btn-danger"
                     :disabled="deletingId === r.id"
+                    aria-label="Удалить результат"
                     @click="removeResult(r)"
                   >
                     <span
@@ -499,6 +501,7 @@ defineExpose({ refresh });
               <div class="text-end">
                 <button
                   class="btn btn-sm btn-secondary me-2"
+                  aria-label="Редактировать результат"
                   @click="openEdit(r)"
                 >
                   <i class="bi bi-pencil"></i>
@@ -506,6 +509,7 @@ defineExpose({ refresh });
                 <button
                   class="btn btn-sm btn-danger"
                   :disabled="deletingId === r.id"
+                  aria-label="Удалить результат"
                   @click="removeResult(r)"
                 >
                   <span
@@ -546,6 +550,7 @@ defineExpose({ refresh });
               <button
                 type="button"
                 class="btn-close"
+                aria-label="Закрыть"
                 @click="modal.hide()"
               ></button>
             </div>

--- a/client/src/components/AdminNormativeTypes.vue
+++ b/client/src/components/AdminNormativeTypes.vue
@@ -343,11 +343,16 @@ defineExpose({ refresh });
                 <td class="text-end">
                   <button
                     class="btn btn-sm btn-secondary me-2"
+                    aria-label="Редактировать тип"
                     @click="openEdit(t)"
                   >
                     <i class="bi bi-pencil"></i>
                   </button>
-                  <button class="btn btn-sm btn-danger" @click="removeType(t)">
+                  <button
+                    class="btn btn-sm btn-danger"
+                    aria-label="Удалить тип"
+                    @click="removeType(t)"
+                  >
                     <i class="bi bi-trash"></i>
                   </button>
                 </td>
@@ -373,11 +378,16 @@ defineExpose({ refresh });
               <div>
                 <button
                   class="btn btn-sm btn-secondary me-2"
+                  aria-label="Редактировать тип"
                   @click="openEdit(t)"
                 >
                   <i class="bi bi-pencil"></i>
                 </button>
-                <button class="btn btn-sm btn-danger" @click="removeType(t)">
+                <button
+                  class="btn btn-sm btn-danger"
+                  aria-label="Удалить тип"
+                  @click="removeType(t)"
+                >
                   <i class="bi bi-trash"></i>
                 </button>
               </div>
@@ -412,6 +422,7 @@ defineExpose({ refresh });
               <button
                 type="button"
                 class="btn-close"
+                aria-label="Закрыть"
                 @click="modal.hide()"
               ></button>
             </div>

--- a/client/src/components/BankAccountForm.vue
+++ b/client/src/components/BankAccountForm.vue
@@ -115,7 +115,12 @@ async function removeAccount() {
     <div class="card-body">
       <div class="d-flex justify-content-between mb-3">
         <h5 class="card-title mb-0">Банковский счёт</h5>
-        <button type="button" class="btn btn-link p-0" @click="open">
+        <button
+          type="button"
+          class="btn btn-link p-0"
+          aria-label="Редактировать банковский счёт"
+          @click="open"
+        >
           <i class="bi bi-pencil"></i>
         </button>
       </div>
@@ -243,6 +248,7 @@ async function removeAccount() {
             <button
               type="button"
               class="btn-close"
+              aria-label="Закрыть"
               @click="modal.hide()"
             ></button>
           </div>
@@ -352,6 +358,7 @@ async function removeAccount() {
               v-if="account"
               type="button"
               class="btn btn-danger me-auto"
+              aria-label="Удалить счёт"
               @click="removeAccount"
             >
               <i class="bi bi-trash"></i>

--- a/client/src/components/InnSnilsForm.vue
+++ b/client/src/components/InnSnilsForm.vue
@@ -149,7 +149,11 @@ async function removeItem() {
               />
               <label for="innField">ИНН</label>
             </div>
-            <button class="btn btn-outline-secondary" @click="openEdit('inn')">
+            <button
+              class="btn btn-outline-secondary"
+              :aria-label="inn ? 'Редактировать ИНН' : 'Добавить ИНН'"
+              @click="openEdit('inn')"
+            >
               <i
                 class="bi text-muted"
                 :class="inn ? 'bi-pencil' : 'bi-plus'"
@@ -172,6 +176,7 @@ async function removeItem() {
             </div>
             <button
               class="btn btn-outline-secondary"
+              :aria-label="snils ? 'Редактировать СНИЛС' : 'Добавить СНИЛС'"
               @click="openEdit('snils')"
             >
               <i
@@ -204,6 +209,7 @@ async function removeItem() {
             <button
               type="button"
               class="btn-close"
+              aria-label="Закрыть"
               @click="modal.hide()"
             ></button>
           </div>
@@ -235,6 +241,7 @@ async function removeItem() {
               v-if="(mode === 'inn' && inn) || (mode === 'snils' && snils)"
               type="button"
               class="btn btn-danger me-auto"
+              aria-label="Удалить"
               @click="removeItem"
             >
               <i class="bi bi-trash"></i>

--- a/client/src/components/RefereeGroupAssignments.vue
+++ b/client/src/components/RefereeGroupAssignments.vue
@@ -241,6 +241,7 @@ defineExpose({ refresh });
                 <td class="text-center">
                   <button
                     class="btn btn-sm btn-outline-secondary"
+                    aria-label="История посещений"
                     @click="openHistory(j)"
                   >
                     <i class="bi bi-clock-history"></i>
@@ -305,6 +306,7 @@ defineExpose({ refresh });
             <button
               type="button"
               class="btn-close"
+              aria-label="Закрыть"
               @click="historyModal.hide()"
             ></button>
           </div>

--- a/client/src/components/RefereeGroups.vue
+++ b/client/src/components/RefereeGroups.vue
@@ -158,11 +158,16 @@ defineExpose({ refresh });
                 <td class="text-end">
                   <button
                     class="btn btn-sm btn-secondary me-2"
+                    aria-label="Редактировать группу"
                     @click="openEdit(g)"
                   >
                     <i class="bi bi-pencil"></i>
                   </button>
-                  <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                  <button
+                    class="btn btn-sm btn-danger"
+                    aria-label="Удалить группу"
+                    @click="removeGroup(g)"
+                  >
                     <i class="bi bi-trash"></i>
                   </button>
                 </td>
@@ -180,11 +185,16 @@ defineExpose({ refresh });
               <div>
                 <button
                   class="btn btn-sm btn-secondary me-2"
+                  aria-label="Редактировать группу"
                   @click="openEdit(g)"
                 >
                   <i class="bi bi-pencil"></i>
                 </button>
-                <button class="btn btn-sm btn-danger" @click="removeGroup(g)">
+                <button
+                  class="btn btn-sm btn-danger"
+                  aria-label="Удалить группу"
+                  @click="removeGroup(g)"
+                >
                   <i class="bi bi-trash"></i>
                 </button>
               </div>
@@ -235,6 +245,7 @@ defineExpose({ refresh });
               <button
                 type="button"
                 class="btn-close"
+                aria-label="Закрыть"
                 @click="modal.hide()"
               ></button>
             </div>

--- a/client/src/components/TaxationInfo.vue
+++ b/client/src/components/TaxationInfo.vue
@@ -132,6 +132,7 @@ defineExpose({ openModal });
           v-if="props.editable"
           type="button"
           class="btn btn-link p-0"
+          aria-label="Обновить статус"
           @click="openModal"
         >
           <i class="bi bi-arrow-clockwise"></i>
@@ -248,6 +249,7 @@ defineExpose({ openModal });
           <button
             type="button"
             class="btn-close"
+            aria-label="Закрыть"
             @click="modal.hide()"
           ></button>
         </div>
@@ -261,7 +263,11 @@ defineExpose({ openModal });
               <i :class="statusIcon(statuses.fns)" class="me-1"></i>
               <span>ФНС - {{ statusText(statuses.fns) }}</span>
             </div>
-            <button class="btn btn-link p-0 ms-auto" @click="runCheck()">
+            <button
+              class="btn btn-link p-0 ms-auto"
+              aria-label="Проверить статус"
+              @click="runCheck()"
+            >
               <i class="bi bi-arrow-repeat"></i>
             </button>
           </div>

--- a/client/src/components/TrainingNormativeResultsModal.vue
+++ b/client/src/components/TrainingNormativeResultsModal.vue
@@ -201,7 +201,12 @@ async function removeResult(r) {
           <h2 class="modal-title h5">
             Нормативы {{ props.user.last_name }} {{ props.user.first_name }}
           </h2>
-          <button type="button" class="btn-close" @click="modal.hide()" />
+          <button
+            type="button"
+            class="btn-close"
+            aria-label="Закрыть"
+            @click="modal.hide()"
+          />
         </div>
         <div class="modal-body">
           <div v-if="error" class="alert alert-danger">{{ error }}</div>
@@ -232,12 +237,14 @@ async function removeResult(r) {
                     <td class="text-end">
                       <button
                         class="btn btn-sm btn-secondary me-2"
+                        aria-label="Редактировать результат"
                         @click="startEdit(r)"
                       >
                         <i class="bi bi-pencil" />
                       </button>
                       <button
                         class="btn btn-sm btn-danger"
+                        aria-label="Удалить результат"
                         @click="removeResult(r)"
                       >
                         <i class="bi bi-trash" />
@@ -263,12 +270,14 @@ async function removeResult(r) {
                   <div class="text-end">
                     <button
                       class="btn btn-sm btn-secondary me-2"
+                      aria-label="Редактировать результат"
                       @click="startEdit(r)"
                     >
                       <i class="bi bi-pencil" />
                     </button>
                     <button
                       class="btn btn-sm btn-danger"
+                      aria-label="Удалить результат"
                       @click="removeResult(r)"
                     >
                       <i class="bi bi-trash" />

--- a/client/src/components/UserAddressForm.vue
+++ b/client/src/components/UserAddressForm.vue
@@ -147,6 +147,9 @@ function applySuggestion(sug) {
             <button
               type="button"
               class="btn btn-link p-0"
+              :aria-label="
+                addresses[type.alias] ? 'Редактировать адрес' : 'Добавить адрес'
+              "
               @click="open(type.alias)"
             >
               <i
@@ -221,6 +224,7 @@ function applySuggestion(sug) {
               <button
                 type="button"
                 class="btn-close"
+                aria-label="Закрыть"
                 @click="modal.hide()"
               ></button>
             </div>
@@ -271,6 +275,7 @@ function applySuggestion(sug) {
                 v-if="addresses[current]"
                 type="button"
                 class="btn btn-danger me-auto"
+                aria-label="Удалить адрес"
                 @click="removeAddress"
               >
                 <i class="bi bi-trash"></i>

--- a/client/src/components/UserForm.vue
+++ b/client/src/components/UserForm.vue
@@ -165,6 +165,7 @@ defineExpose({ validate, unlock, lock, editing });
             v-if="!editing && !props.locked"
             type="button"
             class="btn btn-link p-0"
+            aria-label="Редактировать"
             @click="unlock"
           >
             <i class="bi bi-pencil"></i>


### PR DESCRIPTION
## Summary
- improve accessibility by adding aria-labels to icon-only buttons
- label modal close controls across components
- provide descriptions for edit and delete actions

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_6897e6d35f38832dbdd58bf78dc893a5