### PR TITLE
Hide Tasks section from client

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -14,7 +14,6 @@ const basePreparationSections = [
     referee: true,
   },
   { title: 'Медосмотр', icon: 'bi-heart-pulse', to: '/medical', referee: true },
-  { title: 'Задачи', icon: 'bi-list-check', to: '/tasks' },
 ];
 
 const workSections = [

--- a/client/src/views/Tasks.vue
+++ b/client/src/views/Tasks.vue
@@ -1,5 +1,4 @@
 <script setup>
-import TaskList from '../components/TaskList.vue';
 import { RouterLink } from 'vue-router';
 </script>
 
@@ -16,8 +15,8 @@ import { RouterLink } from 'vue-router';
       </nav>
       <h1 class="mb-3">Задачи</h1>
       <div class="card section-card tile fade-in shadow-sm mb-3">
-        <div class="card-body">
-          <TaskList />
+        <div class="card-body text-center py-5">
+          Раздел временно недоступен
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- remove Tasks card from home preparation sections
- show placeholder on Tasks page

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689808cad108832d8909f14f3ff5e039