### PR TITLE
Add online training URL support

### DIFF
--- a/client/src/components/TrainingCalendar.vue
+++ b/client/src/components/TrainingCalendar.vue
@@ -127,25 +127,28 @@ function canCancel(t) {
               </template>
             </div>
             <div class="d-flex align-items-center">
-              <button
+              <div
                 v-if="t.registered"
-                class="btn btn-sm btn-secondary"
-                :disabled="props.pendingId !== null || !canCancel(t)"
-                :title="
-                  !canCancel(t)
-                    ? 'Отменить можно не позднее чем за 48 часов до начала'
-                    : ''
-                "
-                @click="emit('unregister', t.id)"
+                class="d-flex align-items-center text-success small"
               >
-                <span
-                  v-if="props.pendingId === t.id"
-                  class="spinner-border spinner-border-sm me-1"
-                  role="status"
-                  aria-hidden="true"
-                ></span>
-                Отменить
-              </button>
+                <i class="bi bi-check-circle me-1" aria-hidden="true"></i>
+                <span>Вы записаны</span>
+                <button
+                  v-if="canCancel(t)"
+                  class="btn btn-link p-0 ms-2 text-danger"
+                  :disabled="props.pendingId !== null"
+                  @click="emit('unregister', t.id)"
+                >
+                  <span
+                    v-if="props.pendingId === t.id"
+                    class="spinner-border spinner-border-sm"
+                    role="status"
+                    aria-hidden="true"
+                  ></span>
+                  <i v-else class="bi bi-x-lg" aria-hidden="true"></i>
+                  <span class="visually-hidden">Отменить</span>
+                </button>
+              </div>
               <button
                 v-else
                 class="btn btn-sm btn-brand"

--- a/client/src/components/TrainingCalendar.vue
+++ b/client/src/components/TrainingCalendar.vue
@@ -91,16 +91,6 @@ function canCancel(t) {
                   }}</strong
                 >
                 <span class="ms-2">{{ t.ground?.name }}</span>
-                <a
-                  v-if="!t.type?.online && t.ground?.yandex_url"
-                  :href="withHttp(t.ground.yandex_url)"
-                  target="_blank"
-                  rel="noopener"
-                  aria-label="Открыть в Яндекс.Картах"
-                  class="ms-2"
-                >
-                  <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
-                </a>
               </div>
               <div class="text-muted small">{{ t.type?.name }}</div>
               <div v-if="t.type?.online && t.url" class="mb-1">
@@ -109,8 +99,18 @@ function canCancel(t) {
                 >
               </div>
               <template v-else>
-                <div class="text-muted small">
-                  {{ t.ground?.address?.result || '—' }}
+                <div class="text-muted small d-flex align-items-center">
+                  <a
+                    v-if="t.ground?.yandex_url"
+                    :href="withHttp(t.ground.yandex_url)"
+                    target="_blank"
+                    rel="noopener"
+                    aria-label="Открыть в Яндекс.Картах"
+                    class="me-1 flex-shrink-0"
+                  >
+                    <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
+                  </a>
+                  <span class="flex-grow-1">{{ t.ground?.address?.result || '—' }}</span>
                 </div>
                 <div
                   v-if="metroNames(t.ground?.address)"

--- a/client/src/components/TrainingCalendar.vue
+++ b/client/src/components/TrainingCalendar.vue
@@ -1,6 +1,9 @@
 <script setup>
 import { computed } from 'vue';
 import { MOSCOW_TZ, toDayKey } from '../utils/time.js';
+import { withHttp } from '../utils/url.js';
+import metroIcon from '../assets/metro.svg';
+import yandexLogo from '../assets/yandex-maps.svg';
 
 const props = defineProps({
   trainings: { type: Array, default: () => [] },
@@ -30,6 +33,16 @@ const registeredDates = computed(() => {
   });
   return set;
 });
+
+function metroNames(address) {
+  if (!address || !Array.isArray(address.metro) || !address.metro.length) {
+    return '';
+  }
+  return address.metro
+    .slice(0, 2)
+    .map((m) => m.name)
+    .join(', ');
+}
 
 function formatDay(date) {
   const text = date.toLocaleDateString('ru-RU', {
@@ -78,8 +91,40 @@ function canCancel(t) {
                   }}</strong
                 >
                 <span class="ms-2">{{ t.ground?.name }}</span>
+                <a
+                  v-if="!t.type?.online && t.ground?.yandex_url"
+                  :href="withHttp(t.ground.yandex_url)"
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Открыть в Яндекс.Картах"
+                  class="ms-2"
+                >
+                  <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
+                </a>
               </div>
               <div class="text-muted small">{{ t.type?.name }}</div>
+              <div v-if="t.type?.online && t.url" class="mb-1">
+                <a :href="withHttp(t.url)" target="_blank" rel="noopener"
+                  >Подключиться по ссылке</a
+                >
+              </div>
+              <template v-else>
+                <div class="text-muted small">
+                  {{ t.ground?.address?.result || '—' }}
+                </div>
+                <div
+                  v-if="metroNames(t.ground?.address)"
+                  class="text-muted small d-flex align-items-center"
+                >
+                  <img
+                    :src="metroIcon"
+                    alt="Метро"
+                    height="14"
+                    class="me-1"
+                  />
+                  <span>{{ metroNames(t.ground?.address) }}</span>
+                </div>
+              </template>
             </div>
             <div class="d-flex align-items-center">
               <button

--- a/client/src/components/TrainingCard.vue
+++ b/client/src/components/TrainingCard.vue
@@ -93,6 +93,11 @@ function formatDeadline(start) {
     timeZone: 'Europe/Moscow',
   });
 }
+
+function canCancel() {
+  return new Date(props.training.start_at).getTime() - Date.now() >
+    48 * 60 * 60 * 1000;
+}
 </script>
 
 <template>
@@ -131,13 +136,30 @@ function formatDeadline(start) {
           ><span v-if="i < training.equipment_managers.length - 1">, </span>
         </span>
       </p>
-      <button
+      <div
         v-if="training.registered && showCancel"
-        class="btn btn-sm btn-secondary mt-auto"
-        @click="emit('unregister', training.id)"
+        class="mt-auto d-flex align-items-center justify-content-between"
       >
-        Отменить
-      </button>
+        <div class="text-success small d-flex align-items-center">
+          <i class="bi bi-check-circle me-1" aria-hidden="true"></i>
+          <span>Вы записаны</span>
+        </div>
+        <button
+          v-if="canCancel()"
+          class="btn btn-link p-0 text-danger"
+          :disabled="loading"
+          @click="emit('unregister', training.id)"
+        >
+          <span
+            v-if="loading"
+            class="spinner-border spinner-border-sm"
+            role="status"
+            aria-hidden="true"
+          ></span>
+          <i v-else class="bi bi-x-lg" aria-hidden="true"></i>
+          <span class="visually-hidden">Отменить</span>
+        </button>
+      </div>
       <button
         v-else
         class="btn btn-sm btn-brand mt-auto"

--- a/client/src/components/UpcomingEventCard.vue
+++ b/client/src/components/UpcomingEventCard.vue
@@ -12,12 +12,18 @@ const icon = computed(() =>
 );
 const title = computed(() => (isTraining.value ? 'Тренировка' : 'Медосмотр'));
 const location = computed(() => {
+  if (isTraining.value && props.event.type?.online && props.event.url) {
+    return 'Подключиться по ссылке';
+  }
   const loc = isTraining.value
     ? props.event.ground?.address?.result
     : props.event.center?.address?.result;
   return loc || '';
 });
 const href = computed(() => {
+  if (isTraining.value && props.event.type?.online && props.event.url) {
+    return withHttp(props.event.url);
+  }
   return isTraining.value ? withHttp(props.event.ground?.yandex_url) : null;
 });
 

--- a/client/src/views/AdminCourses.vue
+++ b/client/src/views/AdminCourses.vue
@@ -39,6 +39,7 @@ const grounds = ref([]);
 const trainingForm = ref({
   type_id: '',
   ground_id: '',
+  url: '',
   start_at: '',
   end_at: '',
   capacity: '',
@@ -99,6 +100,8 @@ watch(
     }
     if (tt?.online) {
       trainingForm.value.ground_id = '';
+    } else {
+      trainingForm.value.url = '';
     }
   }
 );
@@ -161,6 +164,7 @@ function openTrainingModal(training = null) {
     trainingForm.value = {
       type_id: training.type_id || training.type?.id || '',
       ground_id: training.ground_id || '',
+      url: training.url || '',
       start_at: toDateTimeLocal(training.start_at),
       end_at: toDateTimeLocal(training.end_at),
       capacity: training.capacity || '',
@@ -171,6 +175,7 @@ function openTrainingModal(training = null) {
     trainingForm.value = {
       type_id: '',
       ground_id: '',
+      url: '',
       start_at: '',
       end_at: '',
       capacity: '',
@@ -189,9 +194,14 @@ async function saveTraining() {
       ? `/course-trainings/${editingTraining.value.id}`
       : '/course-trainings';
     const body = {
-      ...trainingForm.value,
+      type_id: trainingForm.value.type_id,
       start_at: fromDateTimeLocal(trainingForm.value.start_at),
       end_at: fromDateTimeLocal(trainingForm.value.end_at),
+      capacity: trainingForm.value.capacity || undefined,
+      courses: trainingForm.value.courses,
+      ...(selectedTrainingType.value?.online
+        ? { url: trainingForm.value.url || undefined }
+        : { ground_id: trainingForm.value.ground_id }),
     };
     await apiFetch(url, {
       method,
@@ -722,7 +732,15 @@ onMounted(() => {
                     </option>
                   </select>
                 </div>
-                <div class="mb-3" v-if="!selectedTrainingType?.online">
+                <div class="mb-3" v-if="selectedTrainingType?.online">
+                  <label class="form-label">Ссылка</label>
+                  <input
+                    v-model="trainingForm.url"
+                    type="url"
+                    class="form-control"
+                  />
+                </div>
+                <div class="mb-3" v-else>
                   <label class="form-label">Площадка</label>
                   <select v-model="trainingForm.ground_id" class="form-select">
                     <option value="">Выберите площадку</option>

--- a/client/src/views/AdminGrounds.vue
+++ b/client/src/views/AdminGrounds.vue
@@ -69,6 +69,7 @@ const refereeGroups = ref([]);
 const trainingForm = ref({
   type_id: '',
   ground_id: '',
+  url: '',
   start_at: '',
   end_at: '',
   capacity: '',
@@ -184,6 +185,8 @@ watch(
     }
     if (tt?.online) {
       trainingForm.value.ground_id = '';
+    } else {
+      trainingForm.value.url = '';
     }
   }
 );
@@ -382,6 +385,7 @@ function openCreateTraining() {
   trainingForm.value = {
     type_id: '',
     ground_id: '',
+    url: '',
     start_at: '',
     end_at: '',
     capacity: '',
@@ -456,6 +460,7 @@ function openEditTraining(t) {
   trainingForm.value = {
     type_id: t.type?.id || '',
     ground_id: t.ground?.id || '',
+    url: t.url || '',
     start_at: toInputValue(t.start_at),
     end_at: toInputValue(t.end_at),
     capacity: t.capacity || '',
@@ -474,7 +479,9 @@ async function saveTraining() {
   }
   const payload = {
     type_id: trainingForm.value.type_id,
-    ground_id: trainingForm.value.ground_id,
+    ...(selectedTrainingType.value?.online
+      ? { url: trainingForm.value.url || undefined }
+      : { ground_id: trainingForm.value.ground_id }),
     start_at: fromDateTimeLocal(trainingForm.value.start_at),
     end_at: fromDateTimeLocal(trainingForm.value.end_at),
     capacity: trainingForm.value.capacity || undefined,
@@ -1060,7 +1067,15 @@ async function toggleTrainingGroup(training, groupId, checked) {
                     </option>
                   </select>
                 </div>
-                <div class="mb-3" v-if="!selectedTrainingType?.online">
+                <div class="mb-3" v-if="selectedTrainingType?.online">
+                  <label class="form-label">Ссылка</label>
+                  <input
+                    v-model="trainingForm.url"
+                    type="url"
+                    class="form-control"
+                  />
+                </div>
+                <div class="mb-3" v-else>
                   <label class="form-label">Площадка</label>
                   <select
                     v-model="trainingForm.ground_id"

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -744,21 +744,7 @@ function attendanceStatus(t) {
               class="ground-card card section-card tile fade-in shadow-sm"
             >
               <div class="card-body ground-body">
-                <div
-                  class="d-flex justify-content-between align-items-start mb-1"
-                >
-                  <h2 class="h6 mb-1">{{ g.ground.name }}</h2>
-                  <a
-                    v-if="!g.ground.online && g.ground.yandex_url"
-                    :href="withHttp(g.ground.yandex_url)"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="Открыть в Яндекс.Картах"
-                    class="ms-2"
-                  >
-                    <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
-                  </a>
-                </div>
+                <h2 class="h6 mb-1">{{ g.ground.name }}</h2>
                 <div v-if="g.ground.online && g.ground.url" class="mb-3">
                   <a
                     :href="withHttp(g.ground.url)"
@@ -769,7 +755,17 @@ function attendanceStatus(t) {
                 </div>
                 <template v-else>
                   <p class="text-muted mb-1 small d-flex align-items-center">
-                    <span>{{ g.ground.address?.result }}</span>
+                    <a
+                      v-if="g.ground.yandex_url"
+                      :href="withHttp(g.ground.yandex_url)"
+                      target="_blank"
+                      rel="noopener"
+                      aria-label="Открыть в Яндекс.Картах"
+                      class="me-1 flex-shrink-0"
+                    >
+                      <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
+                    </a>
+                    <span class="flex-grow-1">{{ g.ground.address?.result }}</span>
                   </p>
                   <p
                     v-if="metroNames(g.ground.address)"

--- a/client/src/views/Camps.vue
+++ b/client/src/views/Camps.vue
@@ -150,6 +150,13 @@ const myTrainings = computed(() =>
 function groupDetailed(list) {
   const map = {};
   list.forEach((t) => {
+    if (t.type?.online && t.url) {
+      map[t.id] = {
+        ground: { id: t.id, name: 'Онлайн', url: t.url, online: true },
+        trainings: [t],
+      };
+      return;
+    }
     const s = t.ground;
     if (!s) return;
     if (!map[s.id]) map[s.id] = { ground: s, trainings: [] };
@@ -742,7 +749,7 @@ function attendanceStatus(t) {
                 >
                   <h2 class="h6 mb-1">{{ g.ground.name }}</h2>
                   <a
-                    v-if="g.ground.yandex_url"
+                    v-if="!g.ground.online && g.ground.yandex_url"
                     :href="withHttp(g.ground.yandex_url)"
                     target="_blank"
                     rel="noopener"
@@ -752,16 +759,26 @@ function attendanceStatus(t) {
                     <img :src="yandexLogo" alt="Яндекс.Карты" height="20" />
                   </a>
                 </div>
-                <p class="text-muted mb-1 small d-flex align-items-center">
-                  <span>{{ g.ground.address?.result }}</span>
-                </p>
-                <p
-                  v-if="metroNames(g.ground.address)"
-                  class="text-muted mb-3 small d-flex align-items-center"
-                >
-                  <img :src="metroIcon" alt="Метро" height="14" class="me-1" />
-                  <span>{{ metroNames(g.ground.address) }}</span>
-                </p>
+                <div v-if="g.ground.online && g.ground.url" class="mb-3">
+                  <a
+                    :href="withHttp(g.ground.url)"
+                    target="_blank"
+                    rel="noopener"
+                    >Подключиться по ссылке</a
+                  >
+                </div>
+                <template v-else>
+                  <p class="text-muted mb-1 small d-flex align-items-center">
+                    <span>{{ g.ground.address?.result }}</span>
+                  </p>
+                  <p
+                    v-if="metroNames(g.ground.address)"
+                    class="text-muted mb-3 small d-flex align-items-center"
+                  >
+                    <img :src="metroIcon" alt="Метро" height="14" class="me-1" />
+                    <span>{{ metroNames(g.ground.address) }}</span>
+                  </p>
+                </template>
                 <div class="date-scroll mb-3">
                   <button
                     v-for="d in g.days"

--- a/client/src/views/Qualification.vue
+++ b/client/src/views/Qualification.vue
@@ -229,7 +229,7 @@ function openContactModal(contact) {
     </div>
     <div ref="contactModalRef" class="modal fade" tabindex="-1">
       <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
+        <div class="modal-content rounded-4 overflow-hidden">
           <div class="modal-header">
             <h5 class="modal-title">{{ activeContact?.name }}</h5>
             <button

--- a/src/mappers/trainingMapper.js
+++ b/src/mappers/trainingMapper.js
@@ -8,6 +8,7 @@ function sanitize(obj) {
     end_at,
     capacity,
     ground_id,
+    url,
     season_id,
     attendance_marked,
     TrainingType,
@@ -28,6 +29,7 @@ function sanitize(obj) {
     registered: obj.user_registered,
     registered_count,
     attendance_marked,
+    url,
   };
   if (TrainingType) {
     res.type = {

--- a/src/migrations/20250918120000-add-url-to-trainings.js
+++ b/src/migrations/20250918120000-add-url-to-trainings.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.addColumn('trainings', 'url', {
+      type: Sequelize.STRING,
+      allowNull: true,
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.removeColumn('trainings', 'url');
+  },
+};

--- a/src/models/training.js
+++ b/src/models/training.js
@@ -17,6 +17,7 @@ Training.init(
     end_at: { type: DataTypes.DATE, allowNull: false },
     capacity: { type: DataTypes.INTEGER },
     ground_id: { type: DataTypes.UUID },
+    url: { type: DataTypes.STRING },
     attendance_marked: {
       type: DataTypes.BOOLEAN,
       allowNull: false,

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -231,6 +231,7 @@ async function create(data, actorId, forCamp) {
   const training = await Training.create({
     type_id: data.type_id,
     ground_id: type.online ? null : data.ground_id,
+    url: type.online ? data.url : null,
     season_id: seasonId,
     start_at: data.start_at,
     end_at: data.end_at,
@@ -294,6 +295,7 @@ async function update(id, data, actorId, forCamp) {
       ground_id: finalType.online
         ? null
         : (data.ground_id ?? training.ground_id),
+      url: finalType.online ? (data.url ?? training.url) : null,
       season_id: data.season_id ?? training.season_id,
       start_at: data.start_at ?? training.start_at,
       end_at: data.end_at ?? training.end_at,

--- a/src/validators/trainingValidators.js
+++ b/src/validators/trainingValidators.js
@@ -9,6 +9,7 @@ export const trainingCreateRules = [
     .isISO8601()
     .custom((val, { req }) => new Date(val) > new Date(req.body.start_at)),
   body('capacity').optional().isInt({ min: 0 }),
+  body('url').optional().isURL(),
   body('groups').optional().isArray(),
   body('groups.*').isUUID(),
   body('courses').optional().isArray(),
@@ -30,6 +31,7 @@ export const trainingUpdateRules = [
       return true;
     }),
   body('capacity').optional().isInt({ min: 0 }),
+  body('url').optional().isURL(),
   body('groups').optional().isArray(),
   body('groups.*').isUUID(),
   body('courses').optional().isArray(),

--- a/tests/trainingMapper.test.js
+++ b/tests/trainingMapper.test.js
@@ -49,3 +49,14 @@ test('includes training type online flag', () => {
   const res = mapper.toPublic(training);
   expect(res.type.online).toBe(true);
 });
+
+test('maps url field', () => {
+  const training = {
+    id: 't3',
+    start_at: new Date().toISOString(),
+    end_at: new Date(Date.now() + 3600000).toISOString(),
+    url: 'https://example.com',
+  };
+  const res = mapper.toPublic(training);
+  expect(res.url).toBe('https://example.com');
+});

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -126,6 +126,7 @@ test('create uses provided season', async () => {
     start_at: '2024-01-01T10:00:00Z',
     end_at: '2024-01-01T11:00:00Z',
     capacity: undefined,
+    url: null,
     created_by: 'admin',
     updated_by: 'admin',
   });
@@ -273,4 +274,25 @@ test('create allows missing ground for online type', async () => {
     'admin'
   );
   expect(createMock.mock.calls[0][0].ground_id).toBeNull();
+});
+
+test('create saves url for online type', async () => {
+  findTrainingTypeMock.mockResolvedValueOnce({
+    id: 'tp',
+    for_camp: true,
+    online: true,
+  });
+  createMock.mockResolvedValue({ id: 't5', season_id: 's1' });
+  findByPkMock.mockResolvedValue({ get: () => ({ id: 't5' }) });
+  await service.create(
+    {
+      type_id: 'tp',
+      season_id: 's1',
+      start_at: '2024-01-01T10:00:00Z',
+      end_at: '2024-01-01T11:00:00Z',
+      url: 'https://example.com',
+    },
+    'admin'
+  );
+  expect(createMock.mock.calls[0][0].url).toBe('https://example.com');
 });


### PR DESCRIPTION
## Summary
- allow trainings to store an optional URL and expose it via API
- show join link for online trainings in admin forms and schedules
- validate training URLs and add tests

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68980d4852f4832da00becd06c8531d0