### PR TITLE
Restrict user role management to administrators

### DIFF
--- a/client/src/views/AdminUserEdit.vue
+++ b/client/src/views/AdminUserEdit.vue
@@ -2,6 +2,7 @@
 import { ref, onMounted, computed } from 'vue';
 import { useRoute, useRouter, RouterLink } from 'vue-router';
 import { apiFetch } from '../api.js';
+import { auth } from '../auth.js';
 import UserForm from '../components/UserForm.vue';
 import AddPassportModal from '../components/AddPassportModal.vue';
 import InnSnilsForm from '../components/InnSnilsForm.vue';
@@ -38,6 +39,8 @@ const tabs = computed(() => [
     disabled: true,
   })),
 ]);
+
+const canManageRoles = computed(() => auth.roles.includes('ADMIN'));
 
 const editing = ref(false);
 let originalUser = null;
@@ -199,7 +202,7 @@ async function save() {
         </UserForm>
       </form>
       <UserRolesForm
-        v-if="user"
+        v-if="user && canManageRoles"
         :user-id="route.params.id"
         :user-roles="user.roles"
         @updated="(roles) => (user.roles = roles)"

--- a/src/middlewares/authorize.js
+++ b/src/middlewares/authorize.js
@@ -1,8 +1,13 @@
-import { ADMIN_ROLES, REFEREE_ROLES } from '../utils/roles.js';
+import {
+  ADMIN_ROLES,
+  REFEREE_ROLES,
+  ADMINISTRATOR_ROLES,
+} from '../utils/roles.js';
 
 const ROLE_GROUPS = {
   ADMIN: ADMIN_ROLES,
   REFEREE: REFEREE_ROLES,
+  ADMINISTRATOR: ADMINISTRATOR_ROLES,
 };
 
 export default function authorize(...aliases) {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -252,7 +252,7 @@ router.post(
 router.post(
   '/:id/roles/:roleAlias',
   auth,
-  authorize('ADMIN'),
+  authorize('ADMINISTRATOR'),
   admin.assignRole
 );
 /**
@@ -280,7 +280,7 @@ router.post(
 router.delete(
   '/:id/roles/:roleAlias',
   auth,
-  authorize('ADMIN'),
+  authorize('ADMINISTRATOR'),
   admin.removeRole
 );
 

--- a/src/utils/roles.js
+++ b/src/utils/roles.js
@@ -1,8 +1,11 @@
+export const ADMINISTRATOR_ROLES = ['ADMIN'];
+
 export const ADMIN_ROLES = [
-  'ADMIN',
+  ...ADMINISTRATOR_ROLES,
   'FIELD_REFEREE_SPECIALIST',
   'BRIGADE_REFEREE_SPECIALIST',
 ];
+
 export const REFEREE_ROLES = ['REFEREE', 'BRIGADE_REFEREE'];
 
 export function hasRole(roles, allowed) {


### PR DESCRIPTION
## Summary
- allow only users with the "Администратор" role to assign or revoke roles
- hide role management UI for non-administrator users

## Testing
- `npm test`
- `npm run lint` *(fails: existing prettier errors in unrelated client files)*
- `npm run format:check`
- `npx eslint src/views/AdminUserEdit.vue`


------
https://chatgpt.com/codex/tasks/task_e_689afb278480832d995d90e9ebbdd5af