### PR TITLE
Refactor admin events list with filters and attendance stats

### DIFF
--- a/client/src/components/RefereeGroupAssignments.vue
+++ b/client/src/components/RefereeGroupAssignments.vue
@@ -237,7 +237,7 @@ defineExpose({ refresh });
                 <th class="text-center">Дата рождения</th>
                 <th class="text-center">Группа</th>
                 <th class="text-center sortable" @click="toggleSort">
-                  Тренировки
+                  Мероприятия
                   <i
                     :class="[
                       sortOrder === 'asc'

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -146,7 +146,7 @@ const routes = [
   {
     path: '/admin/courses',
     component: AdminCourses,
-    meta: { requiresAuth: true, requiresAdmin: true, title: 'Курсы' },
+    meta: { requiresAuth: true, requiresAdmin: true, title: 'Мероприятия' },
   },
   {
     path: '/admin/normatives',

--- a/client/src/views/AdminCourses.vue
+++ b/client/src/views/AdminCourses.vue
@@ -548,7 +548,7 @@ onBeforeUnmount(() => {
                     <th class="text-center">Дата рождения</th>
                     <th class="text-center">Курс</th>
                     <th class="text-center sortable" @click="toggleSort">
-                      Тренировки
+                      Мероприятия
                       <i
                         :class="[
                           sortOrder === 'asc'
@@ -941,6 +941,7 @@ onBeforeUnmount(() => {
               <div class="col-md-4">
                 <select v-model="filter.course" class="form-select">
                   <option value="">Все курсы</option>
+                  <option value="none">Без курса</option>
                   <option v-for="c in courses" :key="c.id" :value="c.id">
                     {{ c.name }}
                   </option>

--- a/client/src/views/AdminCourses.vue
+++ b/client/src/views/AdminCourses.vue
@@ -8,7 +8,7 @@ import { toDateTimeLocal, fromDateTimeLocal } from '../utils/time.js';
 const activeTab = ref('assign');
 
 const users = ref([]); // referees with course assignments
-const allUsers = ref([]); // for responsible selector
+const allUsers = ref([]); // for responsible selector and teacher dropdown
 const courses = ref([]);
 const loadingUsers = ref(false);
 const error = ref('');
@@ -89,6 +89,18 @@ const pastTrainings = computed(() => {
 
 function fullName(u) {
   return [u.last_name, u.first_name, u.patronymic].filter(Boolean).join(' ');
+}
+
+function shortName(u) {
+  return [
+    u.last_name,
+    [u.first_name, u.patronymic]
+      .filter(Boolean)
+      .map((n) => `${n[0]}.`)
+      .join(' '),
+  ]
+    .filter(Boolean)
+    .join(' ');
 }
 
 async function loadUsers() {
@@ -222,8 +234,8 @@ async function loadTeacherRole() {
 
 async function loadTeacherOptions() {
   try {
-    const data = await apiFetch('/users?limit=1000&role=TEACHER');
-    teachers.value = data.users;
+    if (!allUsers.value.length) await loadAllUsers();
+    teachers.value = allUsers.value;
   } catch (_) {
     teachers.value = [];
   }
@@ -972,7 +984,7 @@ onBeforeUnmount(() => {
                     :key="t.id"
                     :value="t.id"
                   >
-                    {{ fullName(t) }}
+                    {{ shortName(t) }}
                   </option>
                 </select>
               </div>
@@ -1028,7 +1040,7 @@ onBeforeUnmount(() => {
                           :key="u.id"
                           :value="u.id"
                         >
-                          {{ fullName(u) }}
+                          {{ shortName(u) }}
                         </option>
                       </select>
                     </td>
@@ -1107,7 +1119,7 @@ onBeforeUnmount(() => {
                         :key="u.id"
                         :value="u.id"
                       >
-                        {{ fullName(u) }}
+                        {{ shortName(u) }}
                       </option>
                     </select>
                     <small class="text-muted d-block"
@@ -1192,7 +1204,7 @@ onBeforeUnmount(() => {
                           :key="u.id"
                           :value="u.id"
                         >
-                          {{ fullName(u) }}
+                          {{ shortName(u) }}
                         </option>
                       </select>
                     </td>
@@ -1271,7 +1283,7 @@ onBeforeUnmount(() => {
                         :key="u.id"
                         :value="u.id"
                       >
-                        {{ fullName(u) }}
+                        {{ shortName(u) }}
                       </option>
                     </select>
                     <small class="text-muted d-block"

--- a/client/src/views/AdminCourses.vue
+++ b/client/src/views/AdminCourses.vue
@@ -78,11 +78,6 @@ const selectedTrainingType = computed(() =>
 const filter = ref({ type: '', teacher: '', course: '' });
 const teachers = ref([]);
 const teacherRoleId = ref(null);
-const teacherMap = computed(() => {
-  const map = new Map();
-  teachers.value.forEach((u) => map.set(fullName(u), u.id));
-  return map;
-});
 const upcomingTrainings = computed(() => {
   const now = Date.now();
   return trainings.value.filter((t) => new Date(t.start_at).getTime() >= now);
@@ -244,7 +239,7 @@ async function loadTrainingsAdmin() {
     const data = await apiFetch(`/course-trainings?${params}`);
     trainings.value = data.trainings.map((t) => ({
       ...t,
-      teacherName: t.teacher ? fullName(t.teacher) : '',
+      teacher_id: t.teacher ? t.teacher.id : '',
     }));
   } catch (e) {
     trainingsError.value = e.message;
@@ -254,9 +249,8 @@ async function loadTrainingsAdmin() {
 }
 
 async function assignTeacher(training) {
-  const userId = teacherMap.value.get(training.teacherName) || null;
   try {
-    if (!userId) {
+    if (!training.teacher_id) {
       if (training.teacher) {
         await apiFetch(
           `/course-trainings/${training.id}/registrations/${training.teacher.id}`,
@@ -269,14 +263,15 @@ async function assignTeacher(training) {
     await apiFetch(`/course-trainings/${training.id}/registrations`, {
       method: 'POST',
       body: JSON.stringify({
-        user_id: userId,
+        user_id: training.teacher_id,
         training_role_id: teacherRoleId.value,
       }),
     });
-    training.teacher = teachers.value.find((u) => u.id === userId) || null;
+    training.teacher =
+      teachers.value.find((u) => u.id === training.teacher_id) || null;
   } catch (e) {
     alert(e.message);
-    training.teacherName = training.teacher ? fullName(training.teacher) : '';
+    training.teacher_id = training.teacher ? training.teacher.id : '';
   }
 }
 
@@ -992,14 +987,6 @@ onBeforeUnmount(() => {
               </div>
             </div>
 
-            <datalist id="teachers-list">
-              <option
-                v-for="u in teachers"
-                :key="u.id"
-                :value="fullName(u)"
-              />
-            </datalist>
-
             <h2 class="h5 mb-3">Будущие</h2>
             <div
               v-if="upcomingTrainings.length"
@@ -1030,12 +1017,20 @@ onBeforeUnmount(() => {
                     </td>
                     <td class="d-none d-md-table-cell">{{ t.type?.name }}</td>
                     <td class="d-none d-md-table-cell">
-                      <input
-                        v-model="t.teacherName"
-                        list="teachers-list"
-                        class="form-control form-control-sm"
+                      <select
+                        v-model="t.teacher_id"
+                        class="form-select form-select-sm"
                         @change="assignTeacher(t)"
-                      />
+                      >
+                        <option value="">Без преподавателя</option>
+                        <option
+                          v-for="u in teachers"
+                          :key="u.id"
+                          :value="u.id"
+                        >
+                          {{ fullName(u) }}
+                        </option>
+                      </select>
                     </td>
                     <td class="d-none d-md-table-cell">
                       {{ t.courses.map((c) => c.name).join(', ') }}
@@ -1101,12 +1096,20 @@ onBeforeUnmount(() => {
                       }}
                     </div>
                     <small class="text-muted d-block">{{ t.type?.name }}</small>
-                    <input
-                      v-model="t.teacherName"
-                      list="teachers-list"
-                      class="form-control form-control-sm mb-1"
+                    <select
+                      v-model="t.teacher_id"
+                      class="form-select form-select-sm mb-1"
                       @change="assignTeacher(t)"
-                    />
+                    >
+                      <option value="">Без преподавателя</option>
+                      <option
+                        v-for="u in teachers"
+                        :key="u.id"
+                        :value="u.id"
+                      >
+                        {{ fullName(u) }}
+                      </option>
+                    </select>
                     <small class="text-muted d-block"
                       >{{ t.courses.map((c) => c.name).join(', ') }}</small
                     >
@@ -1178,12 +1181,20 @@ onBeforeUnmount(() => {
                     </td>
                     <td class="d-none d-md-table-cell">{{ t.type?.name }}</td>
                     <td class="d-none d-md-table-cell">
-                      <input
-                        v-model="t.teacherName"
-                        list="teachers-list"
-                        class="form-control form-control-sm"
+                      <select
+                        v-model="t.teacher_id"
+                        class="form-select form-select-sm"
                         @change="assignTeacher(t)"
-                      />
+                      >
+                        <option value="">Без преподавателя</option>
+                        <option
+                          v-for="u in teachers"
+                          :key="u.id"
+                          :value="u.id"
+                        >
+                          {{ fullName(u) }}
+                        </option>
+                      </select>
                     </td>
                     <td class="d-none d-md-table-cell">
                       {{ t.courses.map((c) => c.name).join(', ') }}
@@ -1249,12 +1260,20 @@ onBeforeUnmount(() => {
                       }}
                     </div>
                     <small class="text-muted d-block">{{ t.type?.name }}</small>
-                    <input
-                      v-model="t.teacherName"
-                      list="teachers-list"
-                      class="form-control form-control-sm mb-1"
+                    <select
+                      v-model="t.teacher_id"
+                      class="form-select form-select-sm mb-1"
                       @change="assignTeacher(t)"
-                    />
+                    >
+                      <option value="">Без преподавателя</option>
+                      <option
+                        v-for="u in teachers"
+                        :key="u.id"
+                        :value="u.id"
+                      >
+                        {{ fullName(u) }}
+                      </option>
+                    </select>
                     <small class="text-muted d-block"
                       >{{ t.courses.map((c) => c.name).join(', ') }}</small
                     >

--- a/client/src/views/AdminHome.vue
+++ b/client/src/views/AdminHome.vue
@@ -11,7 +11,7 @@ const userSections = [
 const refereeSections = [
   { title: 'Сборы', icon: 'bi-building', to: '/admin/grounds' },
   { title: 'Нормативы', icon: 'bi-speedometer2', to: '/admin/normatives' },
-  { title: 'Курсы', icon: 'bi-mortarboard', to: '/admin/courses' },
+  { title: 'Мероприятия', icon: 'bi-calendar-event', to: '/admin/courses' },
 ];
 </script>
 

--- a/src/controllers/refereeGroupUserAdminController.js
+++ b/src/controllers/refereeGroupUserAdminController.js
@@ -7,11 +7,12 @@ import { sendError } from '../utils/api.js';
 
 export default {
   async list(req, res) {
-    const { search, group_id, season_id } = req.query;
+    const { search, group_id, season_id, role } = req.query;
     const judges = await refereeGroupService.listReferees({
       search,
       group_id,
       season_id,
+      role,
     });
     const data = await Promise.all(
       judges.map(async (u) => {

--- a/src/controllers/trainingAdminController.js
+++ b/src/controllers/trainingAdminController.js
@@ -13,6 +13,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
       } = req.query;
       const { rows, count } = await trainingService.listAll({
         page: parseInt(page, 10),
@@ -20,6 +22,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
         forCamp,
       });
       return res.json({ trainings: rows.map(mapper.toPublic), total: count });
@@ -32,6 +36,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
       } = req.query;
       const { rows, count } = await trainingService.listUpcoming({
         page: parseInt(page, 10),
@@ -39,6 +45,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
         forCamp,
       });
       return res.json({ trainings: rows.map(mapper.toPublic), total: count });
@@ -51,6 +59,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
       } = req.query;
       const { rows, count } = await trainingService.listPast({
         page: parseInt(page, 10),
@@ -58,6 +68,8 @@ export default function createTrainingAdminController(forCamp) {
         ground_id,
         group_id,
         course_id,
+        type_id,
+        teacher_id,
         forCamp,
       });
       return res.json({ trainings: rows.map(mapper.toPublic), total: count });

--- a/src/controllers/trainingRegistrationAdminController.js
+++ b/src/controllers/trainingRegistrationAdminController.js
@@ -2,140 +2,157 @@ import { validationResult } from 'express-validator';
 
 import trainingRegistrationService from '../services/trainingRegistrationService.js';
 import normativeResultService from '../services/normativeResultService.js';
+import courseService from '../services/courseService.js';
 import userMapper from '../mappers/userMapper.js';
 import trainingMapper from '../mappers/trainingMapper.js';
 import { sendError } from '../utils/api.js';
 
-export default {
-  async list(req, res) {
-    const { page = '1', limit = '20' } = req.query;
-    try {
-      const { rows, count } = await trainingRegistrationService.listByTraining(
-        req.params.id,
-        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
-      );
-      const counts = await normativeResultService.countByTraining(
-        req.params.id
-      );
-      const registrations = rows.map((r) => ({
-        user: userMapper.toPublic(r.User),
-        role: r.TrainingRole
-          ? {
-              id: r.TrainingRole.id,
-              name: r.TrainingRole.name,
-              alias: r.TrainingRole.alias,
-            }
-          : null,
-        present: r.present,
-        normative_count: counts[r.user_id] || 0,
-      }));
-      return res.json({ registrations, total: count });
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
+export default function createRegistrationAdminController(forCamp) {
+  return {
+    async list(req, res) {
+      const { page = '1', limit = '20' } = req.query;
+      try {
+        const { rows, count } =
+          await trainingRegistrationService.listByTraining(req.params.id, {
+            page: parseInt(page, 10),
+            limit: parseInt(limit, 10),
+          });
+        const counts = await normativeResultService.countByTraining(
+          req.params.id
+        );
+        const registrations = rows.map((r) => ({
+          user: userMapper.toPublic(r.User),
+          role: r.TrainingRole
+            ? {
+                id: r.TrainingRole.id,
+                name: r.TrainingRole.name,
+                alias: r.TrainingRole.alias,
+              }
+            : null,
+          present: r.present,
+          normative_count: counts[r.user_id] || 0,
+        }));
+        return res.json({ registrations, total: count });
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
 
-  async listForAttendance(req, res) {
-    try {
-      const { rows, training } =
-        await trainingRegistrationService.listForAttendance(
+    async listForAttendance(req, res) {
+      try {
+        const { rows, training } =
+          await trainingRegistrationService.listForAttendance(
+            req.params.id,
+            req.user.id
+          );
+        const registrations = rows.map((r) => ({
+          user: userMapper.toPublic(r.User),
+          role: r.TrainingRole
+            ? {
+                id: r.TrainingRole.id,
+                name: r.TrainingRole.name,
+                alias: r.TrainingRole.alias,
+              }
+            : null,
+          present: r.present,
+        }));
+        return res.json({
+          training: trainingMapper.toPublic(training),
+          registrations,
+        });
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
+
+    async create(req, res) {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+      }
+      try {
+        await trainingRegistrationService.add(
           req.params.id,
+          req.body.user_id,
+          req.body.training_role_id,
           req.user.id
         );
-      const registrations = rows.map((r) => ({
-        user: userMapper.toPublic(r.User),
-        role: r.TrainingRole
-          ? {
-              id: r.TrainingRole.id,
-              name: r.TrainingRole.name,
-              alias: r.TrainingRole.alias,
-            }
-          : null,
-        present: r.present,
-      }));
-      return res.json({
-        training: trainingMapper.toPublic(training),
-        registrations,
-      });
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
+        return res.status(201).end();
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
 
-  async create(req, res) {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
-    }
-    try {
-      await trainingRegistrationService.add(
-        req.params.id,
-        req.body.user_id,
-        req.body.training_role_id,
-        req.user.id
-      );
-      return res.status(201).end();
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
+    async update(req, res) {
+      const errors = validationResult(req);
+      if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() });
+      }
+      try {
+        await trainingRegistrationService.updateRole(
+          req.params.id,
+          req.params.userId,
+          req.body.training_role_id,
+          req.user.id
+        );
+        return res.status(204).end();
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
 
-  async update(req, res) {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res.status(400).json({ errors: errors.array() });
-    }
-    try {
-      await trainingRegistrationService.updateRole(
-        req.params.id,
-        req.params.userId,
-        req.body.training_role_id,
-        req.user.id
-      );
-      return res.status(204).end();
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
+    async updatePresence(req, res) {
+      try {
+        await trainingRegistrationService.updatePresence(
+          req.params.id,
+          req.params.userId,
+          req.body.present,
+          req.user.id
+        );
+        return res.status(204).end();
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
 
-  async updatePresence(req, res) {
-    try {
-      await trainingRegistrationService.updatePresence(
-        req.params.id,
-        req.params.userId,
-        req.body.present,
-        req.user.id
-      );
-      return res.status(204).end();
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
+    async history(req, res) {
+      const { page = '1', limit = '20' } = req.query;
+      try {
+        let courseId;
+        if (forCamp === false) {
+          const { course } = await courseService.getUserWithCourse(
+            req.params.userId
+          );
+          if (!course) {
+            return res.json({ trainings: [], total: 0 });
+          }
+          courseId = course.id;
+        }
+        const { rows, count } =
+          await trainingRegistrationService.listPastByUser(
+            req.params.userId,
+            { page: parseInt(page, 10), limit: parseInt(limit, 10) },
+            forCamp,
+            courseId
+          );
+        const trainings = rows.map(trainingMapper.toPublic);
+        return res.json({ trainings, total: count });
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
 
-  async history(req, res) {
-    const { page = '1', limit = '20' } = req.query;
-    try {
-      const { rows, count } = await trainingRegistrationService.listPastByUser(
-        req.params.userId,
-        { page: parseInt(page, 10), limit: parseInt(limit, 10) }
-      );
-      const trainings = rows.map(trainingMapper.toPublic);
-      return res.json({ trainings, total: count });
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
-
-  async remove(req, res) {
-    try {
-      await trainingRegistrationService.remove(
-        req.params.id,
-        req.params.userId,
-        req.user.id
-      );
-      return res.status(204).end();
-    } catch (err) {
-      return sendError(res, err, 404);
-    }
-  },
-};
+    async remove(req, res) {
+      try {
+        await trainingRegistrationService.remove(
+          req.params.id,
+          req.params.userId,
+          req.user.id
+        );
+        return res.status(204).end();
+      } catch (err) {
+        return sendError(res, err, 404);
+      }
+    },
+  };
+}

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -145,6 +145,14 @@ Season.hasMany(RefereeGroup, { foreignKey: 'season_id' });
 RefereeGroup.belongsTo(Season, { foreignKey: 'season_id' });
 Training.hasMany(TrainingRegistration, { foreignKey: 'training_id' });
 TrainingRegistration.belongsTo(Training, { foreignKey: 'training_id' });
+Training.hasMany(TrainingRegistration, {
+  foreignKey: 'training_id',
+  as: 'TeacherRegistrations',
+});
+TrainingRegistration.belongsTo(Training, {
+  foreignKey: 'training_id',
+  as: 'TeacherTraining',
+});
 User.hasMany(TrainingRegistration, { foreignKey: 'user_id' });
 TrainingRegistration.belongsTo(User, { foreignKey: 'user_id' });
 TrainingRole.hasMany(TrainingRegistration, { foreignKey: 'training_role_id' });

--- a/src/routes/campTrainings.js
+++ b/src/routes/campTrainings.js
@@ -4,7 +4,7 @@ import auth from '../middlewares/auth.js';
 import authorize from '../middlewares/authorize.js';
 import createAdminController from '../controllers/trainingAdminController.js';
 import createSelfController from '../controllers/trainingSelfController.js';
-import registrationsController from '../controllers/trainingRegistrationAdminController.js';
+import createRegistrationsController from '../controllers/trainingRegistrationAdminController.js';
 import {
   trainingCreateRules,
   trainingUpdateRules,
@@ -18,6 +18,7 @@ import { updateAttendanceRules } from '../validators/trainingValidators.js';
 
 const controller = createAdminController(true);
 const selfController = createSelfController(true);
+const registrationsController = createRegistrationsController(true);
 const router = express.Router();
 
 router.get('/', auth, authorize('ADMIN'), controller.list);

--- a/src/routes/courseTrainings.js
+++ b/src/routes/courseTrainings.js
@@ -4,7 +4,7 @@ import auth from '../middlewares/auth.js';
 import authorize from '../middlewares/authorize.js';
 import createAdminController from '../controllers/trainingAdminController.js';
 import createSelfController from '../controllers/trainingSelfController.js';
-import registrationsController from '../controllers/trainingRegistrationAdminController.js';
+import createRegistrationsController from '../controllers/trainingRegistrationAdminController.js';
 import {
   trainingCreateRules,
   trainingUpdateRules,
@@ -18,6 +18,7 @@ import {
 
 const controller = createAdminController(false);
 const selfController = createSelfController(false);
+const registrationsController = createRegistrationsController(false);
 const router = express.Router();
 
 router.get('/', auth, authorize('ADMIN'), controller.list);

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -4,6 +4,7 @@ import {
   UserCourse,
   Training,
   TrainingRegistration,
+  TrainingType,
 } from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 
@@ -136,6 +137,7 @@ async function getTrainingStats(userId, courseId) {
               where: { id: courseId },
               required: true,
             },
+            { model: TrainingType, where: { for_camp: false }, required: true },
           ],
         },
       ],
@@ -148,6 +150,7 @@ async function getTrainingStats(userId, courseId) {
           where: { id: courseId },
           required: true,
         },
+        { model: TrainingType, where: { for_camp: false }, required: true },
       ],
     }),
   ]);

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -123,6 +123,7 @@ async function getUserWithCourse(userId) {
 }
 
 async function getTrainingStats(userId, courseId) {
+  const { Op } = await import('sequelize');
   const [visited, total] = await Promise.all([
     TrainingRegistration.count({
       where: { user_id: userId, present: true },
@@ -130,6 +131,7 @@ async function getTrainingStats(userId, courseId) {
         {
           model: Training,
           required: true,
+          where: { start_at: { [Op.lte]: new Date() } },
           include: [
             {
               model: Course,

--- a/src/services/courseService.js
+++ b/src/services/courseService.js
@@ -1,4 +1,10 @@
-import { Course, User, UserCourse } from '../models/index.js';
+import {
+  Course,
+  User,
+  UserCourse,
+  Training,
+  TrainingRegistration,
+} from '../models/index.js';
 import ServiceError from '../errors/ServiceError.js';
 
 async function listAll(options = {}) {
@@ -115,6 +121,39 @@ async function getUserWithCourse(userId) {
   return { user, course };
 }
 
+async function getTrainingStats(userId, courseId) {
+  const [visited, total] = await Promise.all([
+    TrainingRegistration.count({
+      where: { user_id: userId, present: true },
+      include: [
+        {
+          model: Training,
+          required: true,
+          include: [
+            {
+              model: Course,
+              through: { attributes: [] },
+              where: { id: courseId },
+              required: true,
+            },
+          ],
+        },
+      ],
+    }),
+    Training.count({
+      include: [
+        {
+          model: Course,
+          through: { attributes: [] },
+          where: { id: courseId },
+          required: true,
+        },
+      ],
+    }),
+  ]);
+  return { visited, total };
+}
+
 export default {
   listAll,
   getById,
@@ -124,4 +163,5 @@ export default {
   setUserCourse,
   removeUser,
   getUserWithCourse,
+  getTrainingStats,
 };

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -118,6 +118,7 @@ async function listReferees(options = {}) {
 }
 
 async function getTrainingStats(userId, groupId, seasonId) {
+  const { Op } = await import('sequelize');
   const [visited, total] = await Promise.all([
     TrainingRegistration.count({
       where: { user_id: userId, present: true },
@@ -125,7 +126,7 @@ async function getTrainingStats(userId, groupId, seasonId) {
         {
           model: Training,
           required: true,
-          where: { season_id: seasonId },
+          where: { season_id: seasonId, start_at: { [Op.lte]: new Date() } },
           include: [
             {
               model: RefereeGroup,

--- a/src/services/refereeGroupService.js
+++ b/src/services/refereeGroupService.js
@@ -96,11 +96,14 @@ async function listReferees(options = {}) {
   } else if (options.season_id) {
     groupInclude.include[0].where = { season_id: options.season_id };
   }
+  const roleWhere = options.role
+    ? { alias: options.role }
+    : { alias: REFEREE_ROLES };
   return User.findAll({
     include: [
       {
         model: Role,
-        where: { alias: REFEREE_ROLES },
+        where: roleWhere,
         through: { attributes: [] },
         required: true,
       },

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -265,7 +265,7 @@ async function add(trainingId, userId, roleId, actorId) {
   if (!training) throw new ServiceError('training_not_found', 404);
   if (!user) throw new ServiceError('user_not_found', 404);
   if (!role) throw new ServiceError('training_role_not_found', 404);
-  if (!hasRefereeRole(user.Roles)) {
+  if (!hasRefereeRole(user.Roles) && role.alias !== 'TEACHER') {
     throw new ServiceError('user_not_referee');
   }
 

--- a/src/services/trainingRegistrationService.js
+++ b/src/services/trainingRegistrationService.js
@@ -455,7 +455,7 @@ async function listUpcomingByUser(userId, options = {}, forCamp) {
   };
 }
 
-async function listPastByUser(userId, options = {}, forCamp) {
+async function listPastByUser(userId, options = {}, forCamp, courseId) {
   const { Op } = await import('sequelize');
   const page = Math.max(1, parseInt(options.page || 1, 10));
   const limit = Math.max(1, parseInt(options.limit || 20, 10));
@@ -469,6 +469,11 @@ async function listPastByUser(userId, options = {}, forCamp) {
       },
       { model: Ground, include: [Address] },
       { model: Season, where: { active: true }, required: true },
+      {
+        model: Course,
+        through: { attributes: [] },
+        ...(courseId ? { where: { id: courseId }, required: true } : {}),
+      },
       {
         model: TrainingRegistration,
         include: [User, TrainingRole],

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -87,7 +87,12 @@ async function listAll(options = {}) {
   });
   return {
     rows: rows.map((t) => {
-      const registeredCount = t.TrainingRegistrations?.length || 0;
+      const roleAlias = options.forCamp ? 'PARTICIPANT' : 'LISTENER';
+      const registeredCount = t.TrainingRegistrations
+        ? t.TrainingRegistrations.filter(
+            (r) => r.TrainingRole?.alias === roleAlias
+          ).length
+        : 0;
       return {
         ...t.get(),
         registration_open: isRegistrationOpen(t, registeredCount),
@@ -159,7 +164,12 @@ async function listUpcoming(options = {}) {
   });
   return {
     rows: rows.map((t) => {
-      const registeredCount = t.TrainingRegistrations?.length || 0;
+      const roleAlias = options.forCamp ? 'PARTICIPANT' : 'LISTENER';
+      const registeredCount = t.TrainingRegistrations
+        ? t.TrainingRegistrations.filter(
+            (r) => r.TrainingRole?.alias === roleAlias
+          ).length
+        : 0;
       return {
         ...t.get(),
         registration_open: isRegistrationOpen(t, registeredCount),
@@ -231,7 +241,12 @@ async function listPast(options = {}) {
   });
   return {
     rows: rows.map((t) => {
-      const registeredCount = t.TrainingRegistrations?.length || 0;
+      const roleAlias = options.forCamp ? 'PARTICIPANT' : 'LISTENER';
+      const registeredCount = t.TrainingRegistrations
+        ? t.TrainingRegistrations.filter(
+            (r) => r.TrainingRole?.alias === roleAlias
+          ).length
+        : 0;
       return {
         ...t.get(),
         registration_open: isRegistrationOpen(t, registeredCount),

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -35,28 +35,44 @@ async function listAll(options = {}) {
   if (options.ground_id) {
     where.ground_id = options.ground_id;
   }
+  if (options.type_id) {
+    where.type_id = options.type_id;
+  }
+  const include = [
+    {
+      model: TrainingType,
+      ...(options.forCamp !== undefined
+        ? { where: { for_camp: options.forCamp } }
+        : {}),
+    },
+    { model: Ground, include: [Address] },
+    { model: Season, where: { active: true }, required: true },
+    {
+      model: RefereeGroup,
+      through: { attributes: [] },
+      ...(options.group_id ? { where: { id: options.group_id } } : {}),
+    },
+    {
+      model: Course,
+      through: { attributes: [] },
+      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+    },
+    { model: TrainingRegistration, include: [User, TrainingRole] },
+  ];
+  if (options.teacher_id) {
+    include.push({
+      model: TrainingRegistration,
+      as: 'TeacherRegistrations',
+      required: true,
+      where: { user_id: options.teacher_id },
+      include: [
+        { model: TrainingRole, where: { alias: 'TEACHER' }, required: true },
+      ],
+      duplicating: false,
+    });
+  }
   const { rows, count } = await Training.findAndCountAll({
-    include: [
-      {
-        model: TrainingType,
-        ...(options.forCamp !== undefined
-          ? { where: { for_camp: options.forCamp } }
-          : {}),
-      },
-      { model: Ground, include: [Address] },
-      { model: Season, where: { active: true }, required: true },
-      {
-        model: RefereeGroup,
-        through: { attributes: [] },
-        ...(options.group_id ? { where: { id: options.group_id } } : {}),
-      },
-      {
-        model: Course,
-        through: { attributes: [] },
-        ...(options.course_id ? { where: { id: options.course_id } } : {}),
-      },
-      { model: TrainingRegistration, include: [User, TrainingRole] },
-    ],
+    include,
     distinct: true,
     order: [['start_at', 'ASC']],
     where,
@@ -85,28 +101,44 @@ async function listUpcoming(options = {}) {
   if (options.ground_id) {
     where.ground_id = options.ground_id;
   }
+  if (options.type_id) {
+    where.type_id = options.type_id;
+  }
+  const include = [
+    {
+      model: TrainingType,
+      ...(options.forCamp !== undefined
+        ? { where: { for_camp: options.forCamp } }
+        : {}),
+    },
+    { model: Ground, include: [Address] },
+    { model: Season, where: { active: true }, required: true },
+    {
+      model: RefereeGroup,
+      through: { attributes: [] },
+      ...(options.group_id ? { where: { id: options.group_id } } : {}),
+    },
+    {
+      model: Course,
+      through: { attributes: [] },
+      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+    },
+    { model: TrainingRegistration, include: [User, TrainingRole] },
+  ];
+  if (options.teacher_id) {
+    include.push({
+      model: TrainingRegistration,
+      as: 'TeacherRegistrations',
+      required: true,
+      where: { user_id: options.teacher_id },
+      include: [
+        { model: TrainingRole, where: { alias: 'TEACHER' }, required: true },
+      ],
+      duplicating: false,
+    });
+  }
   const { rows, count } = await Training.findAndCountAll({
-    include: [
-      {
-        model: TrainingType,
-        ...(options.forCamp !== undefined
-          ? { where: { for_camp: options.forCamp } }
-          : {}),
-      },
-      { model: Ground, include: [Address] },
-      { model: Season, where: { active: true }, required: true },
-      {
-        model: RefereeGroup,
-        through: { attributes: [] },
-        ...(options.group_id ? { where: { id: options.group_id } } : {}),
-      },
-      {
-        model: Course,
-        through: { attributes: [] },
-        ...(options.course_id ? { where: { id: options.course_id } } : {}),
-      },
-      { model: TrainingRegistration, include: [User, TrainingRole] },
-    ],
+    include,
     distinct: true,
     order: [['start_at', 'ASC']],
     where,
@@ -135,28 +167,44 @@ async function listPast(options = {}) {
   if (options.ground_id) {
     where.ground_id = options.ground_id;
   }
+  if (options.type_id) {
+    where.type_id = options.type_id;
+  }
+  const include = [
+    {
+      model: TrainingType,
+      ...(options.forCamp !== undefined
+        ? { where: { for_camp: options.forCamp } }
+        : {}),
+    },
+    { model: Ground, include: [Address] },
+    { model: Season, where: { active: true }, required: true },
+    {
+      model: RefereeGroup,
+      through: { attributes: [] },
+      ...(options.group_id ? { where: { id: options.group_id } } : {}),
+    },
+    {
+      model: Course,
+      through: { attributes: [] },
+      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+    },
+    { model: TrainingRegistration, include: [User, TrainingRole] },
+  ];
+  if (options.teacher_id) {
+    include.push({
+      model: TrainingRegistration,
+      as: 'TeacherRegistrations',
+      required: true,
+      where: { user_id: options.teacher_id },
+      include: [
+        { model: TrainingRole, where: { alias: 'TEACHER' }, required: true },
+      ],
+      duplicating: false,
+    });
+  }
   const { rows, count } = await Training.findAndCountAll({
-    include: [
-      {
-        model: TrainingType,
-        ...(options.forCamp !== undefined
-          ? { where: { for_camp: options.forCamp } }
-          : {}),
-      },
-      { model: Ground, include: [Address] },
-      { model: Season, where: { active: true }, required: true },
-      {
-        model: RefereeGroup,
-        through: { attributes: [] },
-        ...(options.group_id ? { where: { id: options.group_id } } : {}),
-      },
-      {
-        model: Course,
-        through: { attributes: [] },
-        ...(options.course_id ? { where: { id: options.course_id } } : {}),
-      },
-      { model: TrainingRegistration, include: [User, TrainingRole] },
-    ],
+    include,
     distinct: true,
     order: [['start_at', 'DESC']],
     where,

--- a/src/services/trainingService.js
+++ b/src/services/trainingService.js
@@ -38,6 +38,9 @@ async function listAll(options = {}) {
   if (options.type_id) {
     where.type_id = options.type_id;
   }
+  if (options.course_id === 'none') {
+    where['$Courses.id$'] = null;
+  }
   const include = [
     {
       model: TrainingType,
@@ -55,7 +58,10 @@ async function listAll(options = {}) {
     {
       model: Course,
       through: { attributes: [] },
-      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+      required: options.course_id ? options.course_id !== 'none' : false,
+      ...(options.course_id && options.course_id !== 'none'
+        ? { where: { id: options.course_id } }
+        : {}),
     },
     { model: TrainingRegistration, include: [User, TrainingRole] },
   ];
@@ -104,6 +110,9 @@ async function listUpcoming(options = {}) {
   if (options.type_id) {
     where.type_id = options.type_id;
   }
+  if (options.course_id === 'none') {
+    where['$Courses.id$'] = null;
+  }
   const include = [
     {
       model: TrainingType,
@@ -121,7 +130,10 @@ async function listUpcoming(options = {}) {
     {
       model: Course,
       through: { attributes: [] },
-      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+      required: options.course_id ? options.course_id !== 'none' : false,
+      ...(options.course_id && options.course_id !== 'none'
+        ? { where: { id: options.course_id } }
+        : {}),
     },
     { model: TrainingRegistration, include: [User, TrainingRole] },
   ];
@@ -170,6 +182,9 @@ async function listPast(options = {}) {
   if (options.type_id) {
     where.type_id = options.type_id;
   }
+  if (options.course_id === 'none') {
+    where['$Courses.id$'] = null;
+  }
   const include = [
     {
       model: TrainingType,
@@ -187,7 +202,10 @@ async function listPast(options = {}) {
     {
       model: Course,
       through: { attributes: [] },
-      ...(options.course_id ? { where: { id: options.course_id } } : {}),
+      required: options.course_id ? options.course_id !== 'none' : false,
+      ...(options.course_id && options.course_id !== 'none'
+        ? { where: { id: options.course_id } }
+        : {}),
     },
     { model: TrainingRegistration, include: [User, TrainingRole] },
   ];

--- a/tests/courseService.test.js
+++ b/tests/courseService.test.js
@@ -44,6 +44,8 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
     findOne: userCourseFindOneMock,
     create: userCourseCreateMock,
   },
+  Training: {},
+  TrainingRegistration: {},
 }));
 
 const { default: service } = await import('../src/services/courseService.js');

--- a/tests/courseService.test.js
+++ b/tests/courseService.test.js
@@ -98,12 +98,14 @@ test('removeUser destroys link when exists', async () => {
   expect(userCourseDestroyMock).toHaveBeenCalled();
 });
 
-test('getTrainingStats filters non-camp trainings', async () => {
+test('getTrainingStats filters past non-camp trainings', async () => {
   regCountMock.mockResolvedValue(1);
   trainingCountMock.mockResolvedValue(2);
   await service.getTrainingStats('u1', 'c1');
-  const regInclude = regCountMock.mock.calls[0][0].include[0].include;
+  const regCall = regCountMock.mock.calls[0][0];
+  const regInclude = regCall.include[0].include;
   expect(regInclude.some((i) => i.where?.for_camp === false)).toBe(true);
+  expect(regCall.include[0].where).toHaveProperty('start_at');
   const totalInclude = trainingCountMock.mock.calls[0][0].include;
   expect(totalInclude.some((i) => i.where?.for_camp === false)).toBe(true);
 });

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -75,6 +75,7 @@ beforeEach(() => {
   findUserMock.mockReset();
   findRegMock.mockReset();
   destroyMock.mockReset();
+  findTrainingRoleMock.mockReset();
   findRoleMock.mockReset();
   countMock.mockReset();
   updateTrainingMock.mockReset();
@@ -256,6 +257,24 @@ test('add replaces existing teacher', async () => {
   expect(createRegMock).toHaveBeenCalledWith({
     training_id: 't1',
     user_id: 'uNew',
+    training_role_id: 'tRole',
+    created_by: 'admin',
+    updated_by: 'admin',
+  });
+});
+
+test('add allows non-referee as teacher', async () => {
+  findTrainingMock.mockResolvedValue({
+    ...training,
+    TrainingRegistrations: [],
+    update: updateTrainingMock,
+  });
+  findUserMock.mockResolvedValue({ id: 'u3', email: 'e3', Roles: [] });
+  findTrainingRoleMock.mockResolvedValueOnce({ id: 'tRole', alias: 'TEACHER' });
+  await service.add('t1', 'u3', 'tRole', 'admin');
+  expect(createRegMock).toHaveBeenCalledWith({
+    training_id: 't1',
+    user_id: 'u3',
     training_role_id: 'tRole',
     created_by: 'admin',
     updated_by: 'admin',

--- a/tests/trainingRegistrationService.test.js
+++ b/tests/trainingRegistrationService.test.js
@@ -412,6 +412,13 @@ test('listPastByUser returns unmarked trainings', async () => {
   expect(res.rows[0].attendance_marked).toBe(false);
 });
 
+test('listPastByUser filters by course', async () => {
+  findAndCountAllMock.mockResolvedValueOnce({ rows: [], count: 0 });
+  await service.listPastByUser('u1', {}, false, 'c1');
+  const include = findAndCountAllMock.mock.calls[0][0].include;
+  expect(include.some((i) => i.where?.id === 'c1')).toBe(true);
+});
+
 test('updatePresence updates value for admin', async () => {
   const updateMock = jest.fn();
   findRegMock.mockResolvedValueOnce({ update: updateMock });

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -204,6 +204,15 @@ test('listAll returns trainings ordered by start date', async () => {
   );
 });
 
+test('listAll filters trainings without course', async () => {
+  findAndCountAllMock.mockResolvedValue({ rows: [], count: 0 });
+  await service.listAll({ course_id: 'none' });
+  const args = findAndCountAllMock.mock.calls[0][0];
+  expect(args.where['$Courses.id$']).toBeNull();
+  const courseInclude = args.include.filter((i) => i.through)[1];
+  expect(courseInclude.required).toBe(false);
+});
+
 test('setAttendanceMarked updates for admin', async () => {
   findByPkMock.mockResolvedValue({ update: updateMock });
   findUserMock.mockResolvedValue({ Roles: [{ alias: 'ADMIN' }] });


### PR DESCRIPTION
## Summary
- rename course admin section to events
- show teacher separately and add filters for type, teacher, course
- split upcoming and past trainings with registration and attendance info

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689b1398b774832d870ff5fd4e068881