### PR TITLE
Refine document signing UI

### DIFF
--- a/client/src/components/DocumentUploadModal.vue
+++ b/client/src/components/DocumentUploadModal.vue
@@ -1,0 +1,125 @@
+<script setup>
+import { ref, onMounted } from 'vue';
+import Modal from 'bootstrap/js/dist/modal';
+import { apiUpload } from '../api.js';
+
+const emit = defineEmits(['uploaded']);
+
+const modalRef = ref(null);
+const fileInput = ref(null);
+let modal;
+const progress = ref(0);
+const uploading = ref(false);
+const error = ref('');
+const doc = ref(null);
+
+function open(d) {
+  doc.value = d;
+  error.value = '';
+  progress.value = 0;
+  uploading.value = false;
+  if (fileInput.value) fileInput.value.value = '';
+  modal.show();
+}
+
+function close() {
+  if (!uploading.value) modal.hide();
+}
+
+async function startUpload() {
+  if (!doc.value) return;
+  const file = fileInput.value?.files?.[0];
+  if (!file) return;
+  const form = new FormData();
+  form.append('file', file);
+  uploading.value = true;
+  error.value = '';
+  try {
+    const res = await apiUpload(`/documents/${doc.value.id}/file`, form, {
+      onProgress: (p) => {
+        progress.value = Math.round(p * 100);
+      },
+    });
+    doc.value.status = res.status;
+    doc.value.file = res.file;
+    emit('uploaded', doc.value);
+    modal.hide();
+  } catch (e) {
+    error.value = e.message;
+  } finally {
+    uploading.value = false;
+  }
+}
+
+onMounted(() => {
+  modal = new Modal(modalRef.value);
+});
+
+defineExpose({ open });
+</script>
+
+<template>
+  <div ref="modalRef" class="modal fade" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Загрузить подписанный документ</h5>
+          <button
+            type="button"
+            class="btn-close"
+            :disabled="uploading"
+            aria-label="Close"
+            @click="close"
+          ></button>
+        </div>
+        <div class="modal-body">
+          <div v-if="error" class="alert alert-danger" role="alert">
+            {{ error }}
+          </div>
+          <input
+            ref="fileInput"
+            type="file"
+            class="form-control mb-3"
+            :disabled="uploading"
+          />
+          <div v-if="uploading" class="progress">
+            <div
+              class="progress-bar"
+              role="progressbar"
+              :style="{ width: progress + '%' }"
+              :aria-valuenow="progress"
+              aria-valuemin="0"
+              aria-valuemax="100"
+            >
+              {{ progress }}%
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button
+            type="button"
+            class="btn btn-secondary"
+            :disabled="uploading"
+            @click="close"
+          >
+            Отмена
+          </button>
+          <button
+            type="button"
+            class="btn btn-primary"
+            :disabled="uploading"
+            @click="startUpload"
+          >
+            Загрузить
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.progress {
+  height: 20px;
+}
+</style>

--- a/client/src/views/AdminDocuments.vue
+++ b/client/src/views/AdminDocuments.vue
@@ -1,7 +1,8 @@
 <script setup>
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { RouterLink, useRoute, useRouter } from 'vue-router';
 import { apiFetch } from '../api.js';
+import DocumentUploadModal from '../components/DocumentUploadModal.vue';
 
 const route = useRoute();
 const router = useRouter();
@@ -10,6 +11,13 @@ const tab = ref(route.query.tab === 'signatures' ? 'signatures' : 'documents');
 const documents = ref([]);
 const documentsLoading = ref(false);
 const documentsError = ref('');
+
+const search = ref('');
+const signTypeFilter = ref('');
+const statusFilter = ref('');
+const numberSearch = ref('');
+
+const uploadModal = ref(null);
 
 const users = ref([]);
 const usersLoading = ref(false);
@@ -79,6 +87,63 @@ async function requestSignature(doc) {
     actionId.value = '';
   }
 }
+
+async function regenerateDocument(doc) {
+  if (actionId.value) return;
+  actionId.value = doc.id;
+  actionError.value = '';
+  try {
+    const res = await apiFetch(`/documents/${doc.id}/regenerate`, {
+      method: 'POST',
+    });
+    doc.file = res.file;
+  } catch (e) {
+    actionError.value = e.message;
+  } finally {
+    actionId.value = '';
+  }
+}
+
+const filteredDocuments = computed(() => {
+  return documents.value.filter((d) => {
+    if (search.value) {
+      const q = search.value.toLowerCase();
+      const fio =
+        `${d.recipient.lastName} ${d.recipient.firstName} ${d.recipient.patronymic}`.toLowerCase();
+      if (!fio.includes(q)) return false;
+    }
+    if (numberSearch.value && !String(d.number).includes(numberSearch.value)) {
+      return false;
+    }
+    if (signTypeFilter.value && d.signType?.alias !== signTypeFilter.value) {
+      return false;
+    }
+    if (statusFilter.value && d.status?.alias !== statusFilter.value) {
+      return false;
+    }
+    return true;
+  });
+});
+
+const signTypes = computed(() => {
+  const map = new Map();
+  documents.value.forEach((d) => {
+    if (d.signType?.alias) map.set(d.signType.alias, d.signType.name);
+  });
+  return Array.from(map, ([alias, name]) => ({ alias, name }));
+});
+
+const statuses = computed(() => {
+  const map = new Map();
+  documents.value.forEach((d) => {
+    if (d.status?.alias) map.set(d.status.alias, d.status.name);
+  });
+  return Array.from(map, ([alias, name]) => ({ alias, name }));
+});
+
+function openUpload(doc) {
+  uploadModal.value.open(doc);
+}
 </script>
 
 <template>
@@ -131,10 +196,65 @@ async function requestSignature(doc) {
         </div>
         <div class="card section-card tile fade-in shadow-sm">
           <div class="card-body">
+            <div
+              class="row row-cols-1 row-cols-sm-2 row-cols-md-4 g-2 mb-3 align-items-end"
+            >
+              <div class="col">
+                <label for="doc-search" class="form-label">Получатель</label>
+                <input
+                  id="doc-search"
+                  v-model="search"
+                  type="search"
+                  class="form-control"
+                  placeholder="ФИО"
+                />
+              </div>
+              <div class="col">
+                <label for="number-search" class="form-label">Номер</label>
+                <input
+                  id="number-search"
+                  v-model="numberSearch"
+                  type="search"
+                  class="form-control"
+                  placeholder="25.08/1"
+                />
+              </div>
+              <div class="col">
+                <label for="sign-type" class="form-label">Тип подписи</label>
+                <select
+                  id="sign-type"
+                  v-model="signTypeFilter"
+                  class="form-select"
+                >
+                  <option value="">Все</option>
+                  <option
+                    v-for="st in signTypes"
+                    :key="st.alias"
+                    :value="st.alias"
+                  >
+                    {{ st.name }}
+                  </option>
+                </select>
+              </div>
+              <div class="col">
+                <label for="status-filter" class="form-label">Статус</label>
+                <select
+                  id="status-filter"
+                  v-model="statusFilter"
+                  class="form-select"
+                >
+                  <option value="">Все</option>
+                  <option v-for="s in statuses" :key="s.alias" :value="s.alias">
+                    {{ s.name }}
+                  </option>
+                </select>
+              </div>
+            </div>
             <div class="table-responsive d-none d-sm-block">
               <table class="table mb-0">
                 <thead>
                   <tr>
+                    <th>Номер</th>
                     <th>Документ</th>
                     <th>Получатель</th>
                     <th>Тип подписи</th>
@@ -144,7 +264,8 @@ async function requestSignature(doc) {
                   </tr>
                 </thead>
                 <tbody>
-                  <tr v-for="d in documents" :key="d.id">
+                  <tr v-for="d in filteredDocuments" :key="d.id">
+                    <td>{{ d.number }}</td>
                     <td>{{ d.name }}</td>
                     <td>
                       {{ d.recipient.lastName }} {{ d.recipient.firstName }}
@@ -154,37 +275,85 @@ async function requestSignature(doc) {
                     <td>{{ d.status?.name }}</td>
                     <td>{{ formatDateTime(d.documentDate) }}</td>
                     <td>
-                      <button
-                        v-if="
-                          ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
-                            d.signType?.alias
-                          ) && d.status?.alias === 'CREATED'
-                        "
-                        class="btn btn-sm btn-primary"
-                        :disabled="actionId === d.id"
-                        @click="requestSignature(d)"
-                      >
-                        <span
-                          v-if="actionId === d.id"
-                          class="spinner-border spinner-border-sm me-1"
-                          aria-hidden="true"
-                        ></span>
-                        Отправить
-                      </button>
+                      <div class="d-flex flex-wrap gap-2">
+                        <a
+                          v-if="d.file"
+                          :href="d.file.url"
+                          class="btn btn-sm btn-outline-secondary"
+                          target="_blank"
+                          rel="noopener"
+                          title="Скачать"
+                        >
+                          <i class="bi bi-download" aria-hidden="true"></i>
+                        </a>
+                        <button
+                          v-if="
+                            d.documentType?.generated &&
+                            ['CREATED', 'AWAITING_SIGNATURE'].includes(
+                              d.status?.alias
+                            )
+                          "
+                          class="btn btn-sm btn-outline-secondary"
+                          :disabled="actionId === d.id"
+                          title="Перегенерировать"
+                          @click="regenerateDocument(d)"
+                        >
+                          <span
+                            v-if="actionId === d.id"
+                            class="spinner-border spinner-border-sm"
+                            aria-hidden="true"
+                          ></span>
+                          <i
+                            v-else
+                            class="bi bi-arrow-clockwise"
+                            aria-hidden="true"
+                          ></i>
+                        </button>
+                        <button
+                          v-if="
+                            ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
+                              d.signType?.alias
+                            ) && d.status?.alias === 'AWAITING_SIGNATURE'
+                          "
+                          class="btn btn-sm btn-primary"
+                          title="Загрузить подписанный файл"
+                          @click="openUpload(d)"
+                        >
+                          <i class="bi bi-upload" aria-hidden="true"></i>
+                        </button>
+                        <button
+                          v-else-if="
+                            ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
+                              d.signType?.alias
+                            ) && d.status?.alias === 'CREATED'
+                          "
+                          class="btn btn-sm btn-primary"
+                          :disabled="actionId === d.id"
+                          @click="requestSignature(d)"
+                        >
+                          <span
+                            v-if="actionId === d.id"
+                            class="spinner-border spinner-border-sm me-1"
+                            aria-hidden="true"
+                          ></span>
+                          Отправить
+                        </button>
+                      </div>
                     </td>
                   </tr>
-                  <tr v-if="!documents.length">
-                    <td colspan="6" class="text-center">
+                  <tr v-if="!filteredDocuments.length">
+                    <td colspan="7" class="text-center">
                       Документы отсутствуют
                     </td>
                   </tr>
                 </tbody>
               </table>
             </div>
-            <div v-if="documents.length" class="d-block d-sm-none">
-              <div v-for="d in documents" :key="d.id" class="card mb-2">
+            <div v-if="filteredDocuments.length" class="d-block d-sm-none">
+              <div v-for="d in filteredDocuments" :key="d.id" class="card mb-2">
                 <div class="card-body p-2">
                   <h3 class="h6 mb-1">{{ d.name }}</h3>
+                  <p class="mb-1 small">№ {{ d.number }}</p>
                   <p class="mb-1 small">
                     {{ d.recipient.lastName }} {{ d.recipient.firstName }}
                     {{ d.recipient.patronymic }}
@@ -196,23 +365,70 @@ async function requestSignature(doc) {
                   <p class="mb-2 small">
                     Дата: {{ formatDateTime(d.documentDate) }}
                   </p>
-                  <button
-                    v-if="
-                      ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
-                        d.signType?.alias
-                      ) && d.status?.alias === 'CREATED'
-                    "
-                    class="btn btn-sm btn-primary"
-                    :disabled="actionId === d.id"
-                    @click="requestSignature(d)"
-                  >
-                    <span
-                      v-if="actionId === d.id"
-                      class="spinner-border spinner-border-sm me-1"
-                      aria-hidden="true"
-                    ></span>
-                    Отправить
-                  </button>
+                  <div class="d-flex flex-wrap gap-2">
+                    <a
+                      v-if="d.file"
+                      :href="d.file.url"
+                      class="btn btn-sm btn-outline-secondary"
+                      target="_blank"
+                      rel="noopener"
+                      title="Скачать"
+                    >
+                      <i class="bi bi-download" aria-hidden="true"></i>
+                    </a>
+                    <button
+                      v-if="
+                        d.documentType?.generated &&
+                        ['CREATED', 'AWAITING_SIGNATURE'].includes(
+                          d.status?.alias
+                        )
+                      "
+                      class="btn btn-sm btn-outline-secondary"
+                      :disabled="actionId === d.id"
+                      title="Перегенерировать"
+                      @click="regenerateDocument(d)"
+                    >
+                      <span
+                        v-if="actionId === d.id"
+                        class="spinner-border spinner-border-sm"
+                        aria-hidden="true"
+                      ></span>
+                      <i
+                        v-else
+                        class="bi bi-arrow-clockwise"
+                        aria-hidden="true"
+                      ></i>
+                    </button>
+                    <button
+                      v-if="
+                        ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
+                          d.signType?.alias
+                        ) && d.status?.alias === 'AWAITING_SIGNATURE'
+                      "
+                      class="btn btn-sm btn-primary"
+                      title="Загрузить подписанный файл"
+                      @click="openUpload(d)"
+                    >
+                      <i class="bi bi-upload" aria-hidden="true"></i>
+                    </button>
+                    <button
+                      v-else-if="
+                        ['HANDWRITTEN', 'KONTUR_SIGN'].includes(
+                          d.signType?.alias
+                        ) && d.status?.alias === 'CREATED'
+                      "
+                      class="btn btn-sm btn-primary"
+                      :disabled="actionId === d.id"
+                      @click="requestSignature(d)"
+                    >
+                      <span
+                        v-if="actionId === d.id"
+                        class="spinner-border spinner-border-sm me-1"
+                        aria-hidden="true"
+                      ></span>
+                      Отправить
+                    </button>
+                  </div>
                 </div>
               </div>
             </div>
@@ -267,6 +483,7 @@ async function requestSignature(doc) {
       </div>
     </div>
   </div>
+  <DocumentUploadModal ref="uploadModal" />
 </template>
 
 <style scoped>

--- a/client/src/views/Documents.vue
+++ b/client/src/views/Documents.vue
@@ -124,23 +124,22 @@ async function submit() {
                     <h2 class="h6 mb-3">Ваш способ подписания</h2>
                     <template v-if="current.alias === 'HANDWRITTEN'">
                       <p class="mb-2">Собственноручная подпись</p>
-                      <p class="text-muted mb-0">
-                        Дата выбора подписи:
-                        {{ formatDate(current.selectedAt) }}
+                      <p class="text-muted mb-0 small">
+                        Ожидаем Вас в офисе в будние дни с 10:00 до 17:00
                       </p>
                     </template>
                     <template v-else-if="current.alias === 'KONTUR_SIGN'">
                       <p class="mb-2">Подписание через Контур.Сайн</p>
                       <p class="mb-1">ИНН: {{ current.inn }}</p>
                       <p class="mb-1">Эмитент сертификата: СКБ Контур</p>
-                      <p class="text-muted mb-1">
-                        Дата выбора подписи:
-                        {{ formatDate(current.selectedAt) }}
-                      </p>
-                      <p class="text-muted mb-0">
-                        Дата создания подписи:
-                        {{ formatDate(current.signCreatedDate) }}
-                      </p>
+                      <a
+                        href="https://sign.kontur.ru"
+                        target="_blank"
+                        rel="noopener"
+                        class="btn btn-sm btn-kontur mt-2"
+                      >
+                        Перейти в Контур.Сайн
+                      </a>
                     </template>
                     <template v-else-if="current.alias === 'SIMPLE_ELECTRONIC'">
                       <p class="mb-2">Простая электронная подпись</p>
@@ -163,40 +162,77 @@ async function submit() {
                 <div class="card section-card tile fade-in shadow-sm">
                   <div class="card-body">
                     <h2 class="h6 mb-3">Ваши документы</h2>
-                    <div class="table-responsive">
+                    <div class="table-responsive d-none d-sm-block">
                       <table class="table align-middle mb-0">
                         <thead>
                           <tr>
+                            <th scope="col">Номер</th>
                             <th scope="col">Название</th>
                             <th scope="col">Дата</th>
+                            <th scope="col">Тип подписи</th>
                             <th scope="col">Статус</th>
                             <th scope="col" class="text-end">Файл</th>
                           </tr>
                         </thead>
                         <tbody>
                           <tr v-for="d in documents" :key="d.id">
+                            <td>{{ d.number }}</td>
                             <td>{{ d.name }}</td>
                             <td>{{ formatDate(d.documentDate) }}</td>
+                            <td>{{ d.signType?.name || '-' }}</td>
                             <td>{{ d.status?.name || '-' }}</td>
                             <td class="text-end">
                               <a
                                 v-if="d.file"
-                                class="btn btn-sm btn-outline-primary"
+                                class="btn btn-sm btn-outline-secondary"
                                 :href="d.file.url"
                                 target="_blank"
                                 rel="noopener"
+                                title="Скачать"
                               >
-                                Скачать
+                                <i
+                                  class="bi bi-download"
+                                  aria-hidden="true"
+                                ></i>
                               </a>
                             </td>
                           </tr>
                           <tr v-if="!documents.length">
-                            <td colspan="4" class="text-center text-muted">
+                            <td colspan="6" class="text-center text-muted">
                               Документы отсутствуют
                             </td>
                           </tr>
                         </tbody>
                       </table>
+                    </div>
+                    <div v-if="documents.length" class="d-block d-sm-none">
+                      <div v-for="d in documents" :key="d.id" class="card mb-2">
+                        <div class="card-body p-2">
+                          <h3 class="h6 mb-1">{{ d.name }}</h3>
+                          <p class="mb-1 small">№ {{ d.number }}</p>
+                          <p class="mb-1 small">
+                            Дата: {{ formatDate(d.documentDate) }}
+                          </p>
+                          <p class="mb-1 small">
+                            Подпись: {{ d.signType?.name || '—' }}
+                          </p>
+                          <p class="mb-1 small">
+                            Статус: {{ d.status?.name || '—' }}
+                          </p>
+                          <div class="d-flex flex-wrap gap-2 mt-2">
+                            <a
+                              v-if="d.file"
+                              :href="d.file.url"
+                              class="btn btn-sm btn-outline-secondary"
+                              target="_blank"
+                              rel="noopener"
+                              title="Скачать"
+                            >
+                              <i class="bi bi-download" aria-hidden="true"></i>
+                            </a>
+                          </div>
+                        </div>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -205,7 +241,7 @@ async function submit() {
           </div>
           <div v-else>
             <p class="mb-3">Выберите способ подписания первичных документов</p>
-            <div class="row row-cols-1 row-cols-md-2 g-3">
+            <div class="row row-cols-1 row-cols-md-2 gx-3 gy-4">
               <div v-for="t in signTypes" :key="t.alias" class="col">
                 <div class="card section-card tile fade-in h-100 shadow-sm">
                   <div class="card-body d-flex flex-column">
@@ -334,5 +370,17 @@ async function submit() {
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+.btn-kontur {
+  color: #fff;
+  background-color: #17b490;
+  border-color: #17b490;
+}
+.btn-kontur:hover,
+.btn-kontur:focus {
+  color: #fff;
+  background-color: #139e84;
+  border-color: #139e84;
 }
 </style>

--- a/src/controllers/documentAdminController.js
+++ b/src/controllers/documentAdminController.js
@@ -36,4 +36,27 @@ export default {
       sendError(res, err);
     }
   },
+  async uploadSigned(req, res) {
+    try {
+      const result = await documentService.uploadSignedFile(
+        req.params.id,
+        req.file,
+        req.user.id
+      );
+      res.json(result);
+    } catch (err) {
+      sendError(res, err);
+    }
+  },
+  async regenerate(req, res) {
+    try {
+      const result = await documentService.regenerate(
+        req.params.id,
+        req.user.id
+      );
+      res.json(result);
+    } catch (err) {
+      sendError(res, err);
+    }
+  },
 };

--- a/src/migrations/20250918140000-add-number-to-documents.js
+++ b/src/migrations/20250918140000-add-number-to-documents.js
@@ -1,0 +1,46 @@
+'use strict';
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('documents', 'number', {
+      type: Sequelize.STRING(20),
+      allowNull: true,
+    });
+    await queryInterface.addConstraint('documents', {
+      fields: ['number'],
+      type: 'unique',
+      name: 'documents_number_unique',
+    });
+    await queryInterface.sequelize.query(
+      'CREATE SEQUENCE IF NOT EXISTS documents_number_seq START WITH 1'
+    );
+    await queryInterface.sequelize.query(`
+      WITH ordered AS (
+        SELECT id, document_date,
+               ROW_NUMBER() OVER (ORDER BY created_at) AS seq
+        FROM documents
+      )
+      UPDATE documents d
+      SET number =
+        to_char(o.document_date, 'YY.MM') || '/' || o.seq::text
+      FROM ordered o
+      WHERE d.id = o.id;
+    `);
+    await queryInterface.sequelize.query(
+      // eslint-disable-next-line quotes
+      "SELECT setval('documents_number_seq', (SELECT COUNT(*) FROM documents))"
+    );
+    await queryInterface.changeColumn('documents', 'number', {
+      type: Sequelize.STRING(20),
+      allowNull: false,
+    });
+  },
+
+  down: async (queryInterface) => {
+    await queryInterface.removeColumn('documents', 'number');
+    await queryInterface.sequelize.query(
+      'DROP SEQUENCE IF EXISTS documents_number_seq'
+    );
+  },
+};

--- a/src/models/document.js
+++ b/src/models/document.js
@@ -1,4 +1,4 @@
-import { DataTypes, Model } from 'sequelize';
+import { DataTypes, Model, QueryTypes } from 'sequelize';
 
 import sequelize from '../config/database.js';
 
@@ -19,6 +19,7 @@ Document.init(
     name: { type: DataTypes.STRING(255), allowNull: false },
     description: { type: DataTypes.TEXT },
     document_date: { type: DataTypes.DATE, allowNull: false },
+    number: { type: DataTypes.STRING(20), allowNull: false, unique: true },
   },
   {
     sequelize,
@@ -28,5 +29,17 @@ Document.init(
     underscored: true,
   }
 );
+
+Document.addHook('beforeCreate', async (doc) => {
+  const [{ nextval }] = await sequelize.query(
+    // eslint-disable-next-line quotes
+    "SELECT nextval('documents_number_seq') AS nextval",
+    { type: QueryTypes.SELECT }
+  );
+  const date = doc.document_date || new Date();
+  const yy = String(date.getFullYear()).slice(-2);
+  const mm = String(date.getMonth() + 1).padStart(2, '0');
+  doc.number = `${yy}.${mm}/${nextval}`;
+});
 
 export default Document;

--- a/src/routes/documents.js
+++ b/src/routes/documents.js
@@ -1,10 +1,13 @@
 import express from 'express';
+import multer from 'multer';
 
 import auth from '../middlewares/auth.js';
 import authorize from '../middlewares/authorize.js';
 import controller from '../controllers/documentAdminController.js';
 import documentController from '../controllers/documentController.js';
 import { createDocumentValidator } from '../validators/documentValidators.js';
+
+const upload = multer();
 
 const router = express.Router();
 
@@ -31,6 +34,16 @@ router.post(
   auth,
   authorize('ADMIN'),
   controller.requestSignature
+);
+
+router.post('/:id/regenerate', auth, authorize('ADMIN'), controller.regenerate);
+
+router.post(
+  '/:id/file',
+  auth,
+  authorize('ADMIN'),
+  upload.single('file'),
+  controller.uploadSigned
 );
 
 export default router;

--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -28,6 +28,9 @@ import { renderNormativeResultUpdatedEmail } from '../templates/normativeResultU
 import { renderNormativeResultRemovedEmail } from '../templates/normativeResultRemovedEmail.js';
 import { renderSignTypeSelectionEmail } from '../templates/signTypeSelectionEmail.js';
 import { renderDocumentAwaitingSignatureEmail } from '../templates/documentAwaitingSignatureEmail.js';
+import { renderDocumentCreatedEmail } from '../templates/documentCreatedEmail.js';
+import { renderDocumentSignedEmail } from '../templates/documentSignedEmail.js';
+import { renderDocumentRejectedEmail } from '../templates/documentRejectedEmail.js';
 
 export const isEmailConfigured = Boolean(SMTP_HOST);
 
@@ -175,6 +178,21 @@ export async function sendNormativeResultRemovedEmail(user, result) {
   await sendMail(user.email, subject, text, html);
 }
 
+export async function sendDocumentCreatedEmail(user, document) {
+  const { subject, text, html } = renderDocumentCreatedEmail(document);
+  await sendMail(user.email, subject, text, html);
+}
+
+export async function sendDocumentSignedEmail(user, document) {
+  const { subject, text, html } = renderDocumentSignedEmail(document);
+  await sendMail(user.email, subject, text, html);
+}
+
+export async function sendDocumentRejectedEmail(user, document) {
+  const { subject, text, html } = renderDocumentRejectedEmail(document);
+  await sendMail(user.email, subject, text, html);
+}
+
 export async function sendDocumentAwaitingSignatureEmail(user, document) {
   const { subject, text, html } =
     renderDocumentAwaitingSignatureEmail(document);
@@ -202,5 +220,8 @@ export default {
   sendNormativeResultAddedEmail,
   sendNormativeResultUpdatedEmail,
   sendNormativeResultRemovedEmail,
+  sendDocumentCreatedEmail,
+  sendDocumentSignedEmail,
+  sendDocumentRejectedEmail,
   sendDocumentAwaitingSignatureEmail,
 };

--- a/src/services/fileService.js
+++ b/src/services/fileService.js
@@ -1,6 +1,10 @@
 import path from 'path';
 
-import { PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
+import {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+} from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -234,6 +238,61 @@ async function removeTicketFile(id, actorId = null) {
   await attachment.File.destroy();
 }
 
+async function uploadDocument(file, actorId) {
+  if (isTestEnvWithoutS3() || !getS3Bucket()) {
+    throw new ServiceError('s3_not_configured', 500);
+  }
+  const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+  const ALLOWED_TYPES = ['application/pdf', 'image/jpeg', 'image/png'];
+  if (file.size > MAX_FILE_SIZE) {
+    throw new ServiceError('file_too_large', 400);
+  }
+  if (!ALLOWED_TYPES.includes(file.mimetype)) {
+    throw new ServiceError('invalid_file_type', 400);
+  }
+  const key = `documents/${uuidv4()}${path.extname(file.originalname)}`;
+  try {
+    await s3.send(
+      new PutObjectCommand({
+        Bucket: getS3Bucket(),
+        Key: key,
+        Body: file.buffer,
+        ContentType: file.mimetype,
+      })
+    );
+  } catch (err) {
+    console.error('S3 upload failed', err);
+    throw new ServiceError('s3_upload_failed');
+  }
+  const dbFile = await File.create({
+    key,
+    original_name: file.originalname,
+    mime_type: file.mimetype,
+    size: file.size,
+    created_by: actorId,
+    updated_by: actorId,
+  });
+  return dbFile;
+}
+
+async function removeFile(id) {
+  const file = await File.findByPk(id);
+  if (!file) return;
+  if (!isTestEnvWithoutS3() && getS3Bucket()) {
+    try {
+      await s3.send(
+        new DeleteObjectCommand({
+          Bucket: getS3Bucket(),
+          Key: file.key,
+        })
+      );
+    } catch (err) {
+      console.error('S3 delete failed', err);
+    }
+  }
+  await file.destroy();
+}
+
 async function saveGeneratedPdf(buffer, name, actorId) {
   if (isTestEnvWithoutS3() || !getS3Bucket()) {
     throw new ServiceError('s3_not_configured', 500);
@@ -272,5 +331,7 @@ export default {
   uploadForNormativeTicket,
   listForTicket,
   removeTicketFile,
+  uploadDocument,
+  removeFile,
   saveGeneratedPdf,
 };

--- a/src/templates/documentAwaitingSignatureEmail.js
+++ b/src/templates/documentAwaitingSignatureEmail.js
@@ -1,11 +1,11 @@
 export function renderDocumentAwaitingSignatureEmail(document) {
-  const subject = 'Документ ожидает подписи';
-  const text = `Документ "${document.name}" ожидает вашей подписи.`;
+  const subject = `Документ №${document.number} ожидает подписи`;
+  const text = `Документ "${document.name}" (№${document.number}) ожидает вашей подписи.`;
   const html = `
     <div style="font-family: Arial, sans-serif; color: #333;">
       <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
       <p style="font-size:16px;margin:0;">
-        Документ <strong>${document.name}</strong> ожидает вашей подписи.
+        Документ <strong>${document.name}</strong> (№${document.number}) ожидает вашей подписи.
         Пожалуйста, войдите в систему для подписания.
       </p>
     </div>`;

--- a/src/templates/documentCreatedEmail.js
+++ b/src/templates/documentCreatedEmail.js
@@ -1,0 +1,14 @@
+export function renderDocumentCreatedEmail(document) {
+  const subject = `Документ №${document.number} создан`;
+  const text = `Документ "${document.name}" (№${document.number}) создан.`;
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0;">
+        Документ <strong>${document.name}</strong> (№${document.number}) создан и доступен в системе.
+      </p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderDocumentCreatedEmail };

--- a/src/templates/documentRejectedEmail.js
+++ b/src/templates/documentRejectedEmail.js
@@ -1,0 +1,14 @@
+export function renderDocumentRejectedEmail(document) {
+  const subject = `Документ №${document.number} отклонен`;
+  const text = `Документ "${document.name}" (№${document.number}) отклонен.`;
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0;">
+        Документ <strong>${document.name}</strong> (№${document.number}) отклонен.
+      </p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderDocumentRejectedEmail };

--- a/src/templates/documentSignedEmail.js
+++ b/src/templates/documentSignedEmail.js
@@ -1,0 +1,14 @@
+export function renderDocumentSignedEmail(document) {
+  const subject = `Документ №${document.number} подписан`;
+  const text = `Документ "${document.name}" (№${document.number}) подписан.`;
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0;">
+        Документ <strong>${document.name}</strong> (№${document.number}) подписан.
+      </p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderDocumentSignedEmail };

--- a/tests/documentService.test.js
+++ b/tests/documentService.test.js
@@ -1,0 +1,180 @@
+import { jest, expect, test, beforeEach } from '@jest/globals';
+
+const createMock = jest.fn();
+const findByPkMock = jest.fn();
+const findOneStatusMock = jest.fn();
+const countMock = jest.fn();
+const findOneSignMock = jest.fn();
+const createSignMock = jest.fn();
+const findUserByPkMock = jest.fn();
+const findUserSignTypeMock = jest.fn();
+const uploadDocumentMock = jest.fn();
+const getDownloadUrlMock = jest.fn();
+const removeFileMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  Document: { create: createMock, findByPk: findByPkMock },
+  DocumentStatus: { findOne: findOneStatusMock },
+  DocumentUserSign: { count: countMock, findOne: findOneSignMock, create: createSignMock },
+  UserSignType: { findOne: findUserSignTypeMock },
+  User: { findByPk: findUserByPkMock },
+  SignType: {},
+  DocumentType: {},
+  File: {},
+  MedicalCertificate: {},
+  MedicalCertificateFile: {},
+  MedicalCertificateType: {},
+}));
+
+const sendCreatedEmailMock = jest.fn();
+const sendSignedEmailMock = jest.fn();
+const sendAwaitingEmailMock = jest.fn();
+
+jest.unstable_mockModule('../src/services/emailService.js', () => ({
+  __esModule: true,
+  default: {
+    sendDocumentCreatedEmail: sendCreatedEmailMock,
+    sendDocumentSignedEmail: sendSignedEmailMock,
+    sendDocumentAwaitingSignatureEmail: sendAwaitingEmailMock,
+  },
+}));
+
+jest.unstable_mockModule('../src/services/fileService.js', () => ({
+  __esModule: true,
+  default: {
+    uploadDocument: uploadDocumentMock,
+    getDownloadUrl: getDownloadUrlMock,
+    removeFile: removeFileMock,
+    saveGeneratedPdf: jest.fn(),
+  },
+}));
+
+const { default: service } = await import('../src/services/documentService.js');
+
+beforeEach(() => {
+  createMock.mockReset();
+  findByPkMock.mockReset();
+  findOneStatusMock.mockReset();
+  countMock.mockReset();
+  findOneSignMock.mockReset();
+  createSignMock.mockReset();
+  findUserByPkMock.mockReset();
+  findUserSignTypeMock.mockReset();
+  sendCreatedEmailMock.mockReset();
+  sendSignedEmailMock.mockReset();
+  sendAwaitingEmailMock.mockReset();
+  findOneStatusMock.mockImplementation(({ where: { alias } }) =>
+    Promise.resolve({ id: alias, name: alias, alias })
+  );
+  findUserByPkMock.mockResolvedValue({
+    id: 'u1',
+    email: 'user@example.com',
+    last_name: 'L',
+    first_name: 'F',
+    patronymic: 'P',
+  });
+});
+
+test('create sends document created email to recipient', async () => {
+  createMock.mockResolvedValue({
+    id: 'd1',
+    name: 'Doc',
+    recipient_id: 'u1',
+    number: '25.08/1',
+  });
+
+  await service.create(
+    { recipientId: 'u1', documentTypeId: 't1', signTypeId: 's1', name: 'Doc' },
+    'adm'
+  );
+
+  expect(sendCreatedEmailMock).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'user@example.com' }),
+    expect.objectContaining({ id: 'd1', name: 'Doc', number: '25.08/1' })
+  );
+});
+
+test('sign sends document signed email', async () => {
+  findByPkMock.mockResolvedValue({
+    id: 'd1',
+    sign_type_id: 's1',
+    recipient_id: 'u1',
+    update: jest.fn(),
+    number: '25.08/1',
+  });
+  countMock.mockResolvedValue(0);
+  findOneSignMock.mockResolvedValue(null);
+  findUserSignTypeMock.mockResolvedValue({ user_id: 'u1', sign_type_id: 's1' });
+  createSignMock.mockResolvedValue({});
+
+  await service.sign({ id: 'u1' }, 'd1');
+
+  expect(sendSignedEmailMock).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'user@example.com' }),
+    expect.objectContaining({ id: 'd1', number: '25.08/1' })
+  );
+});
+
+test('create skips email when recipient missing address', async () => {
+  findUserByPkMock.mockResolvedValueOnce({ id: 'u1' });
+  createMock.mockResolvedValueOnce({
+    id: 'd2',
+    name: 'Doc2',
+    recipient_id: 'u1',
+     number: '25.08/2',
+  });
+
+  await service.create(
+    { recipientId: 'u1', documentTypeId: 't1', signTypeId: 's1', name: 'Doc2' },
+    'adm'
+  );
+
+  expect(sendCreatedEmailMock).not.toHaveBeenCalled();
+});
+
+test('requestSignature sends awaiting signature email', async () => {
+  findByPkMock.mockResolvedValueOnce({
+    id: 'd1',
+    SignType: { alias: 'HANDWRITTEN', name: 'Hand' },
+    recipient: {
+      email: 'user@example.com',
+      last_name: 'L',
+      first_name: 'F',
+      patronymic: 'P',
+    },
+    DocumentStatus: { alias: 'CREATED' },
+    update: jest.fn(),
+    number: '25.08/3',
+  });
+
+  await service.requestSignature('d1', 'adm');
+
+  expect(sendAwaitingEmailMock).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'user@example.com' }),
+    expect.objectContaining({ id: 'd1', number: '25.08/3' })
+  );
+});
+
+test('uploadSignedFile updates document and notifies recipient', async () => {
+  findByPkMock.mockResolvedValueOnce({
+    id: 'd1',
+    SignType: { alias: 'HANDWRITTEN' },
+    DocumentStatus: { alias: 'AWAITING_SIGNATURE' },
+    recipient_id: 'u1',
+    file_id: 'old',
+    update: jest.fn(),
+    number: '25.08/4',
+  });
+  uploadDocumentMock.mockResolvedValue({ id: 'new' });
+  getDownloadUrlMock.mockResolvedValue('url');
+
+  await service.uploadSignedFile('d1', { path: 'f.pdf' }, 'adm');
+
+  expect(uploadDocumentMock).toHaveBeenCalled();
+  expect(removeFileMock).toHaveBeenCalledWith('old');
+  expect(sendSignedEmailMock).toHaveBeenCalledWith(
+    expect.objectContaining({ email: 'user@example.com' }),
+    expect.objectContaining({ id: 'd1', number: '25.08/4' })
+  );
+});

--- a/tests/fileService.test.js
+++ b/tests/fileService.test.js
@@ -31,6 +31,9 @@ jest.unstable_mockModule('@aws-sdk/client-s3', () => ({
   GetObjectCommand: function GetObjectCommand(args) {
     this.args = args;
   },
+  DeleteObjectCommand: function DeleteObjectCommand(args) {
+    this.args = args;
+  },
 }));
 
 jest.unstable_mockModule('@aws-sdk/s3-request-presigner', () => ({


### PR DESCRIPTION
## Summary
- add cross-system document numbering with migration and auto-sequence
- display document numbers in admin and user document lists
- include document numbers in status notification emails
- fix numbering migration to qualify document date column
- generate document numbers without leading zeros
- add number search and drop date filter on admin document page
- unify document table layouts for desktop and mobile with icon actions
- remove signature selection date and introduce mobile-friendly cards on user documents page

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689b12a81c48832d83b86ecfc9861e3b