### PR TITLE
Expand service test coverage

### DIFF
--- a/src/services/normativeTypeService.js
+++ b/src/services/normativeTypeService.js
@@ -345,6 +345,7 @@ export {
   parseResultValue,
   stepForUnit,
   determineZone,
+  buildZones,
   recalcResults,
 };
 export default { listAll, getById, create, update, remove };

--- a/tests/legacyUserService.test.js
+++ b/tests/legacyUserService.test.js
@@ -1,17 +1,54 @@
-import { describe, expect, jest, test } from '@jest/globals';
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 
 const queryMock = jest.fn();
+const isAvailableMock = jest.fn();
 jest.unstable_mockModule('../src/config/legacyDatabase.js', () => ({
   default: { query: queryMock },
-  isLegacyDbAvailable: jest.fn(() => false),
+  isLegacyDbAvailable: isAvailableMock,
 }));
 
-const { findByEmail } = await import('../src/services/legacyUserService.js');
+const loggerErrorMock = jest.fn();
+jest.unstable_mockModule('../logger.js', () => ({ default: { error: loggerErrorMock } }));
+
+const { findByEmail, findById } = await import(
+  '../src/services/legacyUserService.js'
+);
+
+beforeEach(() => {
+  queryMock.mockReset();
+  isAvailableMock.mockReset();
+  loggerErrorMock.mockReset();
+});
 
 describe('legacyUserService', () => {
   test('returns null when legacy DB unavailable', async () => {
+    isAvailableMock.mockReturnValue(false);
     const result = await findByEmail('test@example.com');
     expect(result).toBeNull();
     expect(queryMock).not.toHaveBeenCalled();
   });
+
+  test('findByEmail returns row when available', async () => {
+    isAvailableMock.mockReturnValue(true);
+    queryMock.mockResolvedValue([[{ id: 1 }]]);
+    const res = await findByEmail('a@b');
+    expect(res).toEqual({ id: 1 });
+    expect(queryMock).toHaveBeenCalled();
+  });
+
+  test('findByEmail logs and returns null on error', async () => {
+    isAvailableMock.mockReturnValue(true);
+    queryMock.mockRejectedValue(new Error('db fail'));
+    const res = await findByEmail('a@b');
+    expect(res).toBeNull();
+    expect(loggerErrorMock).toHaveBeenCalled();
+  });
+
+  test('findById mirrors findByEmail', async () => {
+    isAvailableMock.mockReturnValue(true);
+    queryMock.mockResolvedValue([[{ id: 2 }]]);
+    const res = await findById('2');
+    expect(res).toEqual({ id: 2 });
+  });
 });
+

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,0 +1,72 @@
+import { jest, expect, test, beforeEach } from '@jest/globals';
+import { setImmediate as setImmediateAsync } from 'node:timers';
+
+const createMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/log.js', () => ({
+  __esModule: true,
+  default: { create: createMock },
+}));
+
+const { default: logger } = await import('../logger.js');
+const stream = logger.transports[0]._stream;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('persists valid combined log line with response time', async () => {
+  const line =
+    '123.123.123.123 - - [10/Oct/2000:13:55:36 +0000] "GET /test HTTP/1.1" 200 123 "-" "Agent" 10ms';
+
+  await new Promise((resolve) => stream.write({ message: line }, null, resolve));
+
+  expect(createMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      ip: '123.123.123.123',
+      method: 'GET',
+      path: '/test',
+      status_code: 200,
+      user_agent: 'Agent',
+      response_time: 10,
+    })
+  );
+});
+
+test('persists log line without response time', async () => {
+  const line =
+    '123.123.123.123 - - [10/Oct/2000:13:55:36 +0000] "POST /foo HTTP/1.1" 201 123 "-" "Agent"';
+
+  await new Promise((resolve) => stream.write({ message: line }, null, resolve));
+
+  expect(createMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      method: 'POST',
+      path: '/foo',
+      status_code: 201,
+      response_time: null,
+    })
+  );
+});
+
+test('ignores unparsable log lines', async () => {
+  await new Promise((resolve) => stream.write({ message: 'not a combined line' }, null, resolve));
+  expect(createMock).not.toHaveBeenCalled();
+});
+
+test('warns when persistence fails', async () => {
+  const line =
+    '123.123.123.123 - - [10/Oct/2000:13:55:36 +0000] "GET /err HTTP/1.1" 500 123 "-" "Agent" 1ms';
+  createMock.mockRejectedValueOnce(new Error('fail'));
+  const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+
+  await new Promise((resolve) => stream.write({ message: line }, null, resolve));
+
+  expect(warnSpy).toHaveBeenCalledWith('DB log persistence failed:', 'fail');
+});
+
+test('pretty format handles simple messages', async () => {
+  logger.info('hello');
+  await new Promise((resolve) => setImmediateAsync(resolve));
+  expect(createMock).not.toHaveBeenCalled();
+});

--- a/tests/normativeTypeService.test.js
+++ b/tests/normativeTypeService.test.js
@@ -1,10 +1,43 @@
-import { expect, test, describe } from '@jest/globals';
 import {
+  beforeEach,
+  describe,
+  expect,
+  jest,
+  test,
+} from '@jest/globals';
+
+const zoneFindAllMock = jest.fn();
+const typeFindByPkMock = jest.fn();
+const resultFindAllMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  NormativeZone: { findAll: zoneFindAllMock },
+  NormativeType: { findByPk: typeFindByPkMock },
+  NormativeResult: { findAll: resultFindAllMock },
+  User: {},
+  MeasurementUnit: {},
+  NormativeTypeZone: {},
+  NormativeGroupType: {},
+  NormativeValueType: {},
+  NormativeGroup: {},
+  Season: {},
+}));
+
+const {
   parseValue,
   parseResultValue,
   stepForUnit,
   determineZone,
-} from '../src/services/normativeTypeService.js';
+  buildZones,
+  recalcResults,
+} = await import('../src/services/normativeTypeService.js');
+
+beforeEach(() => {
+  zoneFindAllMock.mockReset();
+  typeFindByPkMock.mockReset();
+  resultFindAllMock.mockReset();
+});
 
 describe('normativeTypeService helpers', () => {
   test('parseValue parses MIN_SEC', () => {
@@ -59,3 +92,78 @@ describe('normativeTypeService helpers', () => {
     expect(parseResultValue('205', unit)).toBe(125);
   });
 });
+
+describe('buildZones', () => {
+  test('constructs zones for MORE_BETTER', async () => {
+    zoneFindAllMock.mockResolvedValueOnce([
+      { id: 1, alias: 'GREEN' },
+      { id: 2, alias: 'YELLOW' },
+      { id: 3, alias: 'RED' },
+    ]);
+    const res = await buildZones({
+      zones: [
+        { zone_id: 1, sex_id: 1, min_value: '10' },
+        { zone_id: 2, sex_id: 1, min_value: '5' },
+      ],
+      unit: { alias: 'REPS', fractional: false },
+      valueType: { alias: 'MORE_BETTER' },
+      seasonId: 1,
+      typeId: 2,
+      actorId: 3,
+    });
+    expect(res).toHaveLength(3);
+    expect(res[0]).toMatchObject({
+      zone_id: 1,
+      min_value: 10,
+    });
+    expect(res[1]).toMatchObject({ zone_id: 2, min_value: 5, max_value: 9 });
+    expect(res[2]).toMatchObject({ zone_id: 3, max_value: 4 });
+  });
+
+  test('constructs zones for LESS_BETTER', async () => {
+    zoneFindAllMock.mockResolvedValueOnce([
+      { id: 1, alias: 'GREEN' },
+      { id: 2, alias: 'YELLOW' },
+      { id: 3, alias: 'RED' },
+    ]);
+    const res = await buildZones({
+      zones: [
+        { zone_id: 1, sex_id: 2, max_value: '10' },
+        { zone_id: 2, sex_id: 2, max_value: '15' },
+      ],
+      unit: { alias: 'SECONDS', fractional: false },
+      valueType: { alias: 'LESS_BETTER' },
+      seasonId: 1,
+      typeId: 2,
+      actorId: 3,
+    });
+    expect(res).toHaveLength(3);
+    expect(res[0]).toMatchObject({ zone_id: 1, max_value: 10 });
+    expect(res[1]).toMatchObject({ zone_id: 2, min_value: 11, max_value: 15 });
+    expect(res[2]).toMatchObject({ zone_id: 3, min_value: 16 });
+  });
+});
+
+describe('recalcResults', () => {
+  test('updates results with new zones', async () => {
+    typeFindByPkMock.mockResolvedValue({
+      NormativeTypeZones: [{ min_value: 0, max_value: 10, zone_id: 1, sex_id: null }],
+    });
+    const update1 = jest.fn();
+    const update2 = jest.fn();
+    resultFindAllMock.mockResolvedValue([
+      { value: 5, User: {}, update: update1 },
+      { value: 20, User: {}, update: update2 },
+    ]);
+    await recalcResults(1);
+    expect(update1).toHaveBeenCalledWith({ zone_id: 1 }, { returning: false });
+    expect(update2).toHaveBeenCalledWith({ zone_id: null }, { returning: false });
+  });
+
+  test('returns when type not found', async () => {
+    typeFindByPkMock.mockResolvedValue(null);
+    await recalcResults(1);
+    expect(resultFindAllMock).not.toHaveBeenCalled();
+  });
+});
+

--- a/tests/trainingService.test.js
+++ b/tests/trainingService.test.js
@@ -305,3 +305,16 @@ test('create saves url for online type', async () => {
   );
   expect(createMock.mock.calls[0][0].url).toBe('https://example.com');
 });
+
+test('isRegistrationOpen respects window and capacity', () => {
+  const training = { start_at: '2024-01-15T12:00:00Z', capacity: 2 };
+  jest.useFakeTimers().setSystemTime(new Date('2024-01-08T12:00:00Z'));
+  expect(service.isRegistrationOpen(training, 1)).toBe(true);
+  jest.setSystemTime(new Date('2024-01-07T11:59:59Z'));
+  expect(service.isRegistrationOpen(training, 0)).toBe(false);
+  jest.setSystemTime(new Date('2024-01-15T11:20:00Z'));
+  expect(service.isRegistrationOpen(training, 0)).toBe(false);
+  jest.setSystemTime(new Date('2024-01-10T12:00:00Z'));
+  expect(service.isRegistrationOpen(training, 2)).toBe(false);
+  jest.useRealTimers();
+});

--- a/tests/vehicleService.test.js
+++ b/tests/vehicleService.test.js
@@ -1,13 +1,21 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findOneMock = jest.fn();
-const destroyMock = jest.fn();
+const findAllMock = jest.fn();
+const countMock = jest.fn();
+const createMock = jest.fn();
 const updateMock = jest.fn();
+const destroyMock = jest.fn();
+const vehicleUpdateMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
   __esModule: true,
   Vehicle: {
     findOne: findOneMock,
+    findAll: findAllMock,
+    count: countMock,
+    create: createMock,
+    update: updateMock,
   },
 }));
 
@@ -15,8 +23,12 @@ const { default: service } = await import('../src/services/vehicleService.js');
 
 beforeEach(() => {
   findOneMock.mockReset();
-  destroyMock.mockReset();
+  findAllMock.mockReset();
+  countMock.mockReset();
+  createMock.mockReset();
   updateMock.mockReset();
+  destroyMock.mockReset();
+  vehicleUpdateMock.mockReset();
 });
 
 test('removing active vehicle activates another if available', async () => {
@@ -43,4 +55,52 @@ test('removeForUser throws when vehicle not found', async () => {
   await expect(service.removeForUser('u1', 'v1', 'actor')).rejects.toThrow(
     'vehicle_not_found'
   );
+});
+
+test('listForUser delegates to model', async () => {
+  findAllMock.mockResolvedValue([]);
+  await service.listForUser('user');
+  expect(findAllMock).toHaveBeenCalledWith({
+    where: { user_id: 'user' },
+    order: [['created_at', 'ASC']],
+  });
+});
+
+test('createForUser enforces limit and sets active on first', async () => {
+  countMock.mockResolvedValueOnce(0);
+  createMock.mockResolvedValue({ id: 'v1' });
+  const data = { plate: '123' };
+  await service.createForUser('u1', data, 'actor');
+  expect(createMock).toHaveBeenCalledWith({
+    user_id: 'u1',
+    plate: '123',
+    created_by: 'actor',
+    updated_by: 'actor',
+    is_active: true,
+  });
+  countMock.mockResolvedValueOnce(3);
+  await expect(
+    service.createForUser('u1', data, 'actor')
+  ).rejects.toThrow('vehicle_limit');
+});
+
+test('updateForUser toggles active flag', async () => {
+  const vehicle = { update: vehicleUpdateMock };
+  findOneMock.mockResolvedValueOnce(vehicle);
+  await service.updateForUser('u1', 'v1', { is_active: true }, 'actor');
+  expect(updateMock).toHaveBeenCalledWith(
+    { is_active: false, updated_by: 'actor' },
+    { where: { user_id: 'u1' } }
+  );
+  expect(vehicleUpdateMock).toHaveBeenCalledWith({
+    is_active: true,
+    updated_by: 'actor',
+  });
+});
+
+test('updateForUser throws when vehicle missing', async () => {
+  findOneMock.mockResolvedValueOnce(null);
+  await expect(
+    service.updateForUser('u1', 'v1', {}, 'actor')
+  ).rejects.toThrow('vehicle_not_found');
 });


### PR DESCRIPTION
## Summary
- expose `buildZones` helper from normative type service
- add broad tests for normative type, vehicle, legacy user and training services
- lift overall test coverage closer to corporate targets

## Testing
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_689c32bc8640832d84a888b9cf8eae20