### PR TITLE
Restore ruble icon on home page

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -20,7 +20,7 @@ const workSections = [
   { title: 'Мои назначения', icon: 'bi-calendar-check' },
   { title: 'Прошедшие матчи', icon: 'bi-clock-history' },
   { title: 'Рапорты', icon: 'bi-file-earmark-text' },
-  { title: 'Доходы', icon: 'ruble-icon' },
+  { title: 'Доходы', icon: 'bi-currency-ruble' },
   {
     title: 'Повышение квалификации',
     icon: 'bi-mortarboard',


### PR DESCRIPTION
## Summary
- use Bootstrap ruble icon for the "Доходы" tile on the home page

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm --prefix client run lint`


------
https://chatgpt.com/codex/tasks/task_e_689c4e8ee024832d87fa499147d06d56