### PR TITLE
Restrict roles for camp trainings

### DIFF
--- a/client/src/views/AdminCamps.vue
+++ b/client/src/views/AdminCamps.vue
@@ -768,7 +768,7 @@ async function toggleTrainingGroup(training, groupId, checked) {
                   <div class="mb-3">
                     <label class="form-label">Тип</label>
                     <select
-                      v-model.number="trainingForm.type_id"
+                      v-model="trainingForm.type_id"
                       class="form-select"
                       required
                     >

--- a/client/src/views/AdminCourses.vue
+++ b/client/src/views/AdminCourses.vue
@@ -224,7 +224,7 @@ async function loadGrounds() {
 
 async function loadTeacherRole() {
   try {
-    const data = await apiFetch('/training-roles');
+    const data = await apiFetch('/training-roles?forCamp=false');
     const role = data.roles.find((r) => r.alias === 'TEACHER');
     teacherRoleId.value = role ? role.id : null;
   } catch (_) {

--- a/client/src/views/AdminTrainingRegistrations.vue
+++ b/client/src/views/AdminTrainingRegistrations.vue
@@ -133,7 +133,7 @@ async function loadJudges() {
 
 async function loadTrainingRoles() {
   try {
-    const data = await apiFetch('/training-roles');
+    const data = await apiFetch('/training-roles?forCamp=true');
     trainingRoles.value = data.roles.slice().sort((a, b) => {
       const i1 = ROLE_ORDER.indexOf(a.alias);
       const i2 = ROLE_ORDER.indexOf(b.alias);


### PR DESCRIPTION
## Summary
- disallow selecting Listener or Teacher roles for camp trainings
- filter training roles by camp type in admin interfaces
- add tests for role restrictions

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689c5bcd5d24832d925d5ebe75e64ec3