### PR TITLE
Show event registrations in upcoming events

### DIFF
--- a/client/src/components/UpcomingEventCard.vue
+++ b/client/src/components/UpcomingEventCard.vue
@@ -7,24 +7,34 @@ const props = defineProps({
 });
 
 const isTraining = computed(() => props.event.kind === 'training');
-const icon = computed(() =>
-  isTraining.value ? 'bi-people-fill' : 'bi-heart-pulse'
+const isExam = computed(() => props.event.kind === 'exam');
+const icon = computed(() => {
+  if (isTraining.value) return 'bi-people-fill';
+  if (isExam.value) return 'bi-heart-pulse';
+  return 'bi-calendar-event';
+});
+const title = computed(() => {
+  if (isTraining.value) return 'Тренировка';
+  if (isExam.value) return 'Медосмотр';
+  return 'Мероприятие';
+});
+const isOnline = computed(
+  () => (isTraining.value || !isExam.value) && props.event.type?.online && props.event.url
 );
-const title = computed(() => (isTraining.value ? 'Тренировка' : 'Медосмотр'));
 const location = computed(() => {
-  if (isTraining.value && props.event.type?.online && props.event.url) {
+  if (isOnline.value) {
     return 'Подключиться по ссылке';
   }
-  const loc = isTraining.value
-    ? props.event.ground?.address?.result
-    : props.event.center?.address?.result;
+  const loc = isExam.value
+    ? props.event.center?.address?.result
+    : props.event.ground?.address?.result;
   return loc || '';
 });
 const href = computed(() => {
-  if (isTraining.value && props.event.type?.online && props.event.url) {
+  if (isOnline.value) {
     return withHttp(props.event.url);
   }
-  return isTraining.value ? withHttp(props.event.ground?.yandex_url) : null;
+  return isExam.value ? null : withHttp(props.event.ground?.yandex_url);
 });
 
 function formatStart(date) {

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -97,13 +97,18 @@ onMounted(loadUpcoming);
 async function loadUpcoming() {
   loadingUpcoming.value = true;
   try {
-    const [trainingData, examData] = await Promise.all([
+    const [trainingData, examData, eventData] = await Promise.all([
       apiFetch('/camp-trainings/me/upcoming?limit=100'),
       apiFetch('/medical-exams/me/upcoming?limit=100'),
+      apiFetch('/course-trainings/me/upcoming?limit=100').catch(() => ({ trainings: [] })),
     ]);
     const trainings = (trainingData.trainings || []).map((t) => ({
       ...t,
       kind: 'training',
+    }));
+    const events = (eventData.trainings || []).map((e) => ({
+      ...e,
+      kind: 'event',
     }));
     const exams = (examData.exams || [])
       .filter(
@@ -117,7 +122,7 @@ async function loadUpcoming() {
       }));
     const now = new Date();
     const end = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
-    upcoming.value = [...trainings, ...exams]
+    upcoming.value = [...trainings, ...events, ...exams]
       .filter((e) => {
         const start = new Date(e.start_at);
         return start >= now && start < end;


### PR DESCRIPTION
## Summary
- show course event registrations in "Upcoming events" section
- support rendering events in `UpcomingEventCard`

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689c5c646ac4832db11863e224f3da0e