### PR TITLE
Add scheduled taxation update job

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -14,6 +14,7 @@ import { connectToDatabase } from '../src/config/database.js';
 import { connectLegacyDatabase } from '../src/config/legacyDatabase.js';
 import { connectRedis } from '../src/config/redis.js';
 import validateEnv from '../src/config/validateEnv.js';
+import startTaxationCron from '../src/jobs/taxationCron.js';
 
 const debug = debugLib('fhmoscow-pulse:server');
 
@@ -63,6 +64,7 @@ if (process.env.SSL_CERT_PATH && process.env.SSL_KEY_PATH) {
   await connectToDatabase();
   await connectRedis();
   await connectLegacyDatabase(); // continue even if legacy DB is unreachable
+  startTaxationCron();
   server.listen(port);
 })();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "morgan": "~1.10.1",
         "multer": "^2.0.2",
         "mysql2": "^3.14.3",
+        "node-cron": "^3.0.3",
         "nodemailer": "^7.0.5",
         "on-finished": "^2.4.1",
         "pdfkit": "^0.17.1",
@@ -7949,6 +7950,27 @@
       "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/node-cron/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/node-int64": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "morgan": "~1.10.1",
     "multer": "^2.0.2",
     "mysql2": "^3.14.3",
+    "node-cron": "^3.0.3",
     "nodemailer": "^7.0.5",
     "on-finished": "^2.4.1",
     "pdfkit": "^0.17.1",

--- a/tests/taxationCron.test.js
+++ b/tests/taxationCron.test.js
@@ -1,0 +1,40 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const findOneMock = jest.fn();
+const updateByInnMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  User: { findOne: findOneMock },
+  Inn: {},
+  Taxation: {},
+}));
+
+jest.unstable_mockModule('../src/services/taxationService.js', () => ({
+  __esModule: true,
+  default: { updateByInn: updateByInnMock },
+}));
+
+jest.unstable_mockModule('../logger.js', () => ({
+  __esModule: true,
+  default: { info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const { runTaxationCheck } = await import('../src/jobs/taxationCron.js');
+
+beforeEach(() => {
+  findOneMock.mockReset();
+  updateByInnMock.mockReset();
+});
+
+test('updates taxation for next user with inn', async () => {
+  findOneMock.mockResolvedValue({ id: 'u1', Inn: { number: '123' } });
+  await runTaxationCheck();
+  expect(updateByInnMock).toHaveBeenCalledWith('u1', '123', null);
+});
+
+test('does nothing when no user found', async () => {
+  findOneMock.mockResolvedValue(null);
+  await runTaxationCheck();
+  expect(updateByInnMock).not.toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- schedule taxation status check for users with INN every 4 minutes (15/hour)
- wire cron startup into server
- cover taxation cron job with unit tests

## Testing
- `npm run format:check`
- `npm run lint`
- `npm test` *(fails: Module node_modules/jest-circus/build/runner.js in the testRunner option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c87bbef48832d88c7c8a29ac35613