### PR TITLE
Notify course members about seminar and webinar availability

### DIFF
--- a/src/services/emailService.js
+++ b/src/services/emailService.js
@@ -16,6 +16,7 @@ import { renderTrainingRegistrationEmail } from '../templates/trainingRegistrati
 import { renderTrainingRegistrationCancelledEmail } from '../templates/trainingRegistrationCancelledEmail.js';
 import { renderTrainingRegistrationSelfCancelledEmail } from '../templates/trainingRegistrationSelfCancelledEmail.js';
 import { renderTrainingRoleChangedEmail } from '../templates/trainingRoleChangedEmail.js';
+import { renderTrainingInvitationEmail } from '../templates/trainingInvitationEmail.js';
 import { renderMedicalExamRegistrationCreatedEmail } from '../templates/medicalExamRegistrationCreatedEmail.js';
 import { renderMedicalExamRegistrationApprovedEmail } from '../templates/medicalExamRegistrationApprovedEmail.js';
 import { renderMedicalExamRegistrationCancelledEmail } from '../templates/medicalExamRegistrationCancelledEmail.js';
@@ -140,6 +141,11 @@ export async function sendTrainingRoleChangedEmail(
   await sendMail(user.email, subject, text, html);
 }
 
+export async function sendTrainingInvitationEmail(user, training) {
+  const { subject, text, html } = renderTrainingInvitationEmail(training);
+  await sendMail(user.email, subject, text, html);
+}
+
 export async function sendMedicalExamRegistrationCreatedEmail(
   user,
   exam,
@@ -236,6 +242,7 @@ export default {
   sendTrainingRegistrationCancelledEmail,
   sendTrainingRegistrationSelfCancelledEmail,
   sendTrainingRoleChangedEmail,
+  sendTrainingInvitationEmail,
   sendMedicalExamRegistrationCreatedEmail,
   sendMedicalExamRegistrationApprovedEmail,
   sendMedicalExamRegistrationCancelledEmail,

--- a/src/templates/trainingInvitationEmail.js
+++ b/src/templates/trainingInvitationEmail.js
@@ -1,0 +1,55 @@
+export function renderTrainingInvitationEmail(training) {
+  const typeName = training.TrainingType?.name || 'мероприятие';
+  const subject = `Приглашение на ${typeName}`;
+  const date = new Date(training.start_at)
+    .toLocaleString('ru-RU', {
+      timeZone: 'Europe/Moscow',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+    .replace(',', '');
+  const isOnline = training.TrainingType?.online;
+  const ground = training.Ground || training.ground || {};
+  const address = ground.Address?.result || ground.address?.result;
+  const yandexUrl = ground.yandex_url;
+  const url = training.url;
+
+  let text = `Вы приглашены на ${typeName.toLowerCase()} которое состоится ${date}`;
+  if (isOnline && url) {
+    text += `. Онлайн по ссылке: ${url}.`;
+  } else if (address) {
+    text += `. Место проведения: ${address}`;
+    if (yandexUrl) text += ` (${yandexUrl})`;
+    text += '.';
+  } else {
+    text += '.';
+  }
+  text +=
+    '\nПожалуйста, подтвердите свое присутствие в разделе "Повышение квалификации", нажав кнопку "Записаться". Обращаем Ваше внимание, что количество мест ограничено.';
+
+  const htmlLocation =
+    isOnline && url
+      ? `<p style="font-size:16px;margin:0 0 16px;">Онлайн по ссылке: <a href="${url}" target="_blank">${url}</a>.</p>`
+      : address
+        ? `<p style="font-size:16px;margin:0 0 16px;">Место проведения: ${address}${
+            yandexUrl
+              ? ` (<a href="${yandexUrl}" target="_blank">Яндекс.Карты</a>)`
+              : ''
+          }.</p>`
+        : '';
+
+  const html = `
+    <div style="font-family: Arial, sans-serif; color: #333;">
+      <p style="font-size:16px;margin:0 0 16px;">Здравствуйте!</p>
+      <p style="font-size:16px;margin:0 0 16px;">Вы приглашены на ${typeName.toLowerCase()} ${date} (МСК).</p>
+      ${htmlLocation}
+      <p style="font-size:16px;margin:0 0 16px;">Пожалуйста, подтвердите свое присутствие в разделе «Повышение квалификации», нажав кнопку «Записаться».</p>
+      <p style="font-size:16px;margin:0;">Обращаем Ваше внимание, что количество мест ограничено.</p>
+    </div>`;
+  return { subject, text, html };
+}
+
+export default { renderTrainingInvitationEmail };


### PR DESCRIPTION
## Summary
- email course participants when a seminar or webinar is created or assigned to their course
- centralize seminar/webinar invitation email template and service sender
- cover training creation with invitation email test

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c874c9db4832d9ebb9c204b7062d4