### PR TITLE
Update taxation cron to require successful API calls

### DIFF
--- a/src/services/taxationService.js
+++ b/src/services/taxationService.js
@@ -58,16 +58,16 @@ async function fetchByInn(inn, opts = { dadata: true, fns: true }) {
   };
 }
 
-async function updateByInn(userId, inn, actorId) {
-  const data = await fetchByInn(inn);
+async function updateByInn(userId, inn, actorId, data) {
+  const fetched = data || (await fetchByInn(inn));
 
   let taxation = await Taxation.findOne({ where: { user_id: userId } });
   const payload = {
-    taxation_type_id: data.TaxationType.id,
-    check_date: data.check_date,
-    registration_date: data.registration_date,
-    ogrn: data.ogrn,
-    okved: data.okved,
+    taxation_type_id: fetched.TaxationType.id,
+    check_date: fetched.check_date,
+    registration_date: fetched.registration_date,
+    ogrn: fetched.ogrn,
+    okved: fetched.okved,
   };
   if (!taxation) {
     taxation = await Taxation.create({
@@ -101,6 +101,7 @@ async function updateForUser(userId, actorId) {
 
 export default {
   getByUser,
+  fetchByInn,
   updateByInn,
   removeByUser,
   previewForUser,

--- a/tests/taxationCron.test.js
+++ b/tests/taxationCron.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findOneMock = jest.fn();
+const fetchByInnMock = jest.fn();
 const updateByInnMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/index.js', () => ({
@@ -12,29 +13,47 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
 
 jest.unstable_mockModule('../src/services/taxationService.js', () => ({
   __esModule: true,
-  default: { updateByInn: updateByInnMock },
+  default: { fetchByInn: fetchByInnMock, updateByInn: updateByInnMock },
 }));
 
 jest.unstable_mockModule('../logger.js', () => ({
   __esModule: true,
-  default: { info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  default: { info: jest.fn(), error: jest.fn(), debug: jest.fn(), warn: jest.fn() },
 }));
 
 const { runTaxationCheck } = await import('../src/jobs/taxationCron.js');
 
 beforeEach(() => {
   findOneMock.mockReset();
+  fetchByInnMock.mockReset();
   updateByInnMock.mockReset();
 });
 
-test('updates taxation for next user with inn', async () => {
+test('updates taxation for next user with inn when APIs succeed', async () => {
   findOneMock.mockResolvedValue({ id: 'u1', Inn: { number: '123' } });
+  const data = {
+    TaxationType: { id: 1 },
+    check_date: '2024-01-01',
+    registration_date: null,
+    ogrn: null,
+    okved: null,
+    statuses: { dadata: 200, fns: 200 },
+  };
+  fetchByInnMock.mockResolvedValue(data);
   await runTaxationCheck();
-  expect(updateByInnMock).toHaveBeenCalledWith('u1', '123', null);
+  expect(updateByInnMock).toHaveBeenCalledWith('u1', '123', null, data);
+});
+
+test('skips update when any API fails', async () => {
+  findOneMock.mockResolvedValue({ id: 'u1', Inn: { number: '123' } });
+  fetchByInnMock.mockResolvedValue({ statuses: { dadata: 500, fns: 200 } });
+  await runTaxationCheck();
+  expect(updateByInnMock).not.toHaveBeenCalled();
 });
 
 test('does nothing when no user found', async () => {
   findOneMock.mockResolvedValue(null);
   await runTaxationCheck();
+  expect(fetchByInnMock).not.toHaveBeenCalled();
   expect(updateByInnMock).not.toHaveBeenCalled();
 });


### PR DESCRIPTION
## Summary
- Update taxation cron to verify DaData and FNS API responses before persisting
- Expose `fetchByInn` and allow `updateByInn` to reuse pre-fetched data
- Expand cron tests for API failure handling

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_689c920bb0e0832d948f993b077beb11