### PR TITLE
Move qualification section to top of work services

### DIFF
--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -48,7 +48,7 @@ async function checkCourse() {
 
 const workSections = computed(() =>
   hasCourse.value
-    ? [...baseWorkSections, qualificationSection]
+    ? [qualificationSection, ...baseWorkSections]
     : baseWorkSections
 );
 


### PR DESCRIPTION
## Summary
- Show "Повышение квалификации" first in the Work Services section when available

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a0b8af01b4832d9b5ec726da60e1d0