### PR TITLE
Reset modules per test and ignore PDF util in coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,11 @@
 export default {
   testEnvironment: 'node',
   transform: {},
+  // Ensure each test file gets a fresh module registry to prevent
+  // "module is already linked" errors when using `unstable_mockModule`.
+  resetModules: true,
+  clearMocks: true,
+  restoreMocks: true,
   collectCoverage: true,
   coverageDirectory: 'coverage',
   coverageThreshold: {

--- a/src/utils/pdf.js
+++ b/src/utils/pdf.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 import fs from 'fs';
 
 import { PDF_FONTS, PDF_LOGOS, PDF_META } from '../config/pdf.js';

--- a/tests/documentModel.test.js
+++ b/tests/documentModel.test.js
@@ -1,10 +1,11 @@
-import { jest, expect, test } from '@jest/globals';
+import { beforeEach, jest, expect, test } from '@jest/globals';
 
 import sequelize from '../src/config/database.js';
 import Document from '../src/models/document.js';
 
-// Mock sequence generation
-jest.spyOn(sequelize, 'query').mockResolvedValue([{ nextval: 7 }]);
+beforeEach(() => {
+  jest.spyOn(sequelize, 'query').mockResolvedValue([{ nextval: 7 }]);
+});
 
 test('generates document number before validation', async () => {
   const doc = Document.build({

--- a/tests/innService.test.js
+++ b/tests/innService.test.js
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test } from '@jest/globals';
 
 const findOneMock = jest.fn();
 const createMock = jest.fn();
@@ -18,7 +18,11 @@ jest.unstable_mockModule('../src/services/taxationService.js', () => ({
   default: { removeByUser: jest.fn() },
 }));
 
-const { default: service } = await import('../src/services/innService.js');
+let service;
+beforeEach(async () => {
+  jest.clearAllMocks();
+  ({ default: service } = await import('../src/services/innService.js'));
+});
 
 test('create throws when duplicate exists', async () => {
   findOneMock.mockResolvedValueOnce({ id: 'd' });


### PR DESCRIPTION
## Summary
- reset and clear mocks automatically between tests for consistent isolation
- ignore heavy PDF utility with an Istanbul directive instead of global config
- re-import inn service and document model mocks after each reset

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`
- `npm run test:coverage`


------
https://chatgpt.com/codex/tasks/task_e_68a0bd62038c832d962aef1a7d9e3674