### PR TITLE
Ensure serial Jest runs and cover cookie domain

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 export default {
   testEnvironment: 'node',
   transform: {},
+  // Run tests sequentially to avoid concurrent ESM linking issues
+  maxWorkers: 1,
   // Ensure each test file gets a fresh module registry to prevent
   // "module is already linked" errors when using `unstable_mockModule`.
   resetModules: true,

--- a/tests/cookie.test.js
+++ b/tests/cookie.test.js
@@ -1,20 +1,21 @@
-import {expect, test, jest} from '@jest/globals';
+/* global process */
+import { expect, test, jest } from '@jest/globals';
 import { setRefreshCookie, clearRefreshCookie } from '../src/utils/cookie.js';
 
- test('setRefreshCookie calls res.cookie with options', () => {
+test('setRefreshCookie calls res.cookie with options', () => {
   const res = { cookie: jest.fn() };
   setRefreshCookie(res, 'token');
-    expect(res.cookie).toHaveBeenCalledWith(
-      'refresh_token',
-      'token',
-      expect.objectContaining({
-        httpOnly: true,
-        sameSite: 'strict',
-        secure: false,
-        maxAge: expect.any(Number),
-        path: '/',
-      })
-    );
+  expect(res.cookie).toHaveBeenCalledWith(
+    'refresh_token',
+    'token',
+    expect.objectContaining({
+      httpOnly: true,
+      sameSite: 'strict',
+      secure: false,
+      maxAge: expect.any(Number),
+      path: '/',
+    })
+  );
 });
 
 test('clearRefreshCookie calls res.clearCookie with options', () => {
@@ -31,4 +32,25 @@ test('clearRefreshCookie calls res.clearCookie with options', () => {
   );
   const options = res.clearCookie.mock.calls[0][1];
   expect(options).not.toHaveProperty('maxAge');
+});
+
+test('refresh cookie respects configured domain', async () => {
+  jest.resetModules();
+  process.env.COOKIE_DOMAIN = 'example.com';
+  const { setRefreshCookie: setCookie, clearRefreshCookie: clearCookie } = await import(
+    '../src/utils/cookie.js'
+  );
+  const res = { cookie: jest.fn(), clearCookie: jest.fn() };
+  setCookie(res, 'tok');
+  clearCookie(res);
+  expect(res.cookie).toHaveBeenCalledWith(
+    'refresh_token',
+    'tok',
+    expect.objectContaining({ domain: 'example.com' })
+  );
+  expect(res.clearCookie).toHaveBeenCalledWith(
+    'refresh_token',
+    expect.objectContaining({ domain: 'example.com' })
+  );
+  delete process.env.COOKIE_DOMAIN;
 });


### PR DESCRIPTION
## Summary
- run tests sequentially via `maxWorkers: 1` to avoid ESM linking errors
- test cookie helpers with configured domain to exercise all branches

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0cb6227e0832d88957cfde8f3f56d