### PR TITLE
Ensure Jest tests reset module cache

### DIFF
--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,4 +1,7 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
+import jwt from 'jsonwebtoken';
+
+jest.resetModules();
 
 const store = new Map();
 jest.unstable_mockModule('../src/config/redis.js', () => ({
@@ -50,7 +53,6 @@ jest.unstable_mockModule('bcryptjs', () => ({
 process.env.JWT_SECRET = 'secret';
 const { default: authService } = await import('../src/services/authService.js');
 const attemptStore = await import('../src/services/loginAttempts.js');
-import jwt from 'jsonwebtoken';
 
 const updateMock = jest.fn(async function (data) {
   Object.assign(user, data);

--- a/tests/documentModel.test.js
+++ b/tests/documentModel.test.js
@@ -1,7 +1,14 @@
-import { beforeEach, jest, expect, test } from '@jest/globals';
+import { beforeEach, jest, expect, test, beforeAll } from '@jest/globals';
 
-import sequelize from '../src/config/database.js';
-import Document from '../src/models/document.js';
+jest.resetModules();
+
+let sequelize;
+let Document;
+
+beforeAll(async () => {
+  sequelize = (await import('../src/config/database.js')).default;
+  Document = (await import('../src/models/document.js')).default;
+});
 
 beforeEach(() => {
   jest.spyOn(sequelize, 'query').mockResolvedValue([{ nextval: 7 }]);

--- a/tests/emailVerificationService.test.js
+++ b/tests/emailVerificationService.test.js
@@ -1,4 +1,6 @@
-import { beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test, beforeAll } from '@jest/globals';
+
+jest.resetModules();
 
 const createMock = jest.fn();
 const destroyMock = jest.fn();
@@ -17,10 +19,14 @@ jest.unstable_mockModule('../src/services/emailService.js', () => ({
   default: { sendVerificationEmail: sendEmailMock },
 }));
 
+let attemptStore;
+let sendCode;
+let verifyCode;
 
-import * as attemptStore from '../src/services/emailCodeAttempts.js';
-
-const { sendCode, verifyCode } = await import('../src/services/emailVerificationService.js');
+beforeAll(async () => {
+  attemptStore = await import('../src/services/emailCodeAttempts.js');
+  ({ sendCode, verifyCode } = await import('../src/services/emailVerificationService.js'));
+});
 
 beforeEach(() => {
   createMock.mockClear();

--- a/tests/fileService.test.js
+++ b/tests/fileService.test.js
@@ -3,6 +3,8 @@ import { expect, jest, test, beforeEach } from '@jest/globals';
 import { Buffer } from 'buffer';
 import { MAX_NORMATIVE_FILE_SIZE } from '../src/config/fileLimits.js';
 
+jest.resetModules();
+
 const sendMock = jest.fn();
 const findByPkMock = jest.fn();
 const findOneMock = jest.fn();

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -1,6 +1,8 @@
 import { jest, expect, test, beforeEach } from '@jest/globals';
 import { setImmediate as setImmediateAsync } from 'node:timers';
 
+jest.resetModules();
+
 const createMock = jest.fn();
 
 jest.unstable_mockModule('../src/models/log.js', () => ({

--- a/tests/normativeResultMapper.test.js
+++ b/tests/normativeResultMapper.test.js
@@ -1,10 +1,20 @@
-import { describe, test, expect } from '@jest/globals';
-import mapper from '../src/mappers/normativeResultMapper.js';
+import { describe, test, expect, beforeAll, jest } from '@jest/globals';
 
-const zoneMapper = await import('../src/mappers/normativeZoneMapper.js');
-const groupMapper = await import('../src/mappers/normativeGroupMapper.js');
-const userMapper = await import('../src/mappers/userMapper.js');
-const trainingMapper = await import('../src/mappers/trainingMapper.js');
+jest.resetModules();
+
+let mapper;
+let zoneMapper;
+let groupMapper;
+let userMapper;
+let trainingMapper;
+
+beforeAll(async () => {
+  ({ default: mapper } = await import('../src/mappers/normativeResultMapper.js'));
+  ({ default: zoneMapper } = await import('../src/mappers/normativeZoneMapper.js'));
+  ({ default: groupMapper } = await import('../src/mappers/normativeGroupMapper.js'));
+  ({ default: userMapper } = await import('../src/mappers/userMapper.js'));
+  ({ default: trainingMapper } = await import('../src/mappers/trainingMapper.js'));
+});
 
 const zone = { alias: 'GREEN', name: 'Green' };
 const group = { id: 'g1', name: 'Group1' };
@@ -42,10 +52,10 @@ describe('normativeResultMapper', () => {
       online: false,
       retake: false,
       value: 10,
-      zone: zoneMapper.default.toPublic(zone),
-      group: groupMapper.default.toPublic(group),
-      user: userMapper.default.toPublic({ id: 'u1', first_name: 'John' }),
-      training: trainingMapper.default.toPublic({
+      zone: zoneMapper.toPublic(zone),
+      group: groupMapper.toPublic(group),
+      user: userMapper.toPublic({ id: 'u1', first_name: 'John' }),
+      training: trainingMapper.toPublic({
         id: 't1',
         start_at: '2025-07-18T10:00:00Z',
       }),

--- a/tests/passwordResetService.test.js
+++ b/tests/passwordResetService.test.js
@@ -1,4 +1,6 @@
-import { beforeEach, expect, jest, test } from '@jest/globals';
+import { beforeEach, expect, jest, test, beforeAll } from '@jest/globals';
+
+jest.resetModules();
 
 const createMock = jest.fn();
 const destroyMock = jest.fn();
@@ -15,9 +17,14 @@ jest.unstable_mockModule('../src/services/emailService.js', () => ({
   default: { sendPasswordResetEmail: sendEmailMock },
 }));
 
-import * as attemptStore from '../src/services/emailCodeAttempts.js';
+let attemptStore;
+let sendCode;
+let verifyCode;
 
-const { sendCode, verifyCode } = await import('../src/services/passwordResetService.js');
+beforeAll(async () => {
+  attemptStore = await import('../src/services/emailCodeAttempts.js');
+  ({ sendCode, verifyCode } = await import('../src/services/passwordResetService.js'));
+});
 
 beforeEach(() => {
   createMock.mockClear();

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -1,5 +1,7 @@
 import { expect, jest, test } from '@jest/globals';
 
+jest.resetModules();
+
 let validationOk = true;
 
 jest.unstable_mockModule('express-validator', () => ({


### PR DESCRIPTION
## Summary
- reset Jest module registry in tests to avoid `module is already linked` errors
- refactor mapper and model tests to import modules after cache reset for isolation

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a0e93bfa8c832da9e33527de76217a