### PR TITLE
Ensure Jest tests reset module cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node ./bin/www",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest --maxWorkers=50%",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
     "test:coverage": "npm test -- --coverage --coverageReporters=text-summary",
     "format": "prettier --write \"./{src,routes,controllers,services,models,public,scripts,test}/**/*.{js,jsx,ts,tsx,json,css,md}\"",
     "format:check": "prettier --check \"./{src,routes,controllers,services,models,public,scripts,test}/**/*.{js,jsx,ts,tsx,json,css,md}\"",

--- a/tests/authService.test.js
+++ b/tests/authService.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, expect, jest, test } from '@jest/globals';
+import jwt from 'jsonwebtoken';
 
 const store = new Map();
 jest.unstable_mockModule('../src/config/redis.js', () => ({
@@ -48,9 +49,9 @@ jest.unstable_mockModule('bcryptjs', () => ({
 
 // eslint-disable-next-line no-undef
 process.env.JWT_SECRET = 'secret';
-const { default: authService } = await import('../src/services/authService.js');
-const attemptStore = await import('../src/services/loginAttempts.js');
-import jwt from 'jsonwebtoken';
+
+let authService;
+let attemptStore;
 
 const updateMock = jest.fn(async function (data) {
   Object.assign(user, data);
@@ -71,6 +72,9 @@ const user = {
 };
 
 beforeEach(async () => {
+  jest.resetModules();
+  ({ default: authService } = await import('../src/services/authService.js'));
+  attemptStore = await import('../src/services/loginAttempts.js');
   updateMock.mockClear();
   incrementMock.mockClear();
   reloadMock.mockClear();

--- a/tests/documentModel.test.js
+++ b/tests/documentModel.test.js
@@ -1,9 +1,12 @@
 import { beforeEach, jest, expect, test } from '@jest/globals';
 
-import sequelize from '../src/config/database.js';
-import Document from '../src/models/document.js';
+let sequelize;
+let Document;
 
-beforeEach(() => {
+beforeEach(async () => {
+  jest.resetModules();
+  sequelize = (await import('../src/config/database.js')).default;
+  Document = (await import('../src/models/document.js')).default;
   jest.spyOn(sequelize, 'query').mockResolvedValue([{ nextval: 7 }]);
 });
 

--- a/tests/emailVerificationService.test.js
+++ b/tests/emailVerificationService.test.js
@@ -17,12 +17,14 @@ jest.unstable_mockModule('../src/services/emailService.js', () => ({
   default: { sendVerificationEmail: sendEmailMock },
 }));
 
+let attemptStore;
+let sendCode;
+let verifyCode;
 
-import * as attemptStore from '../src/services/emailCodeAttempts.js';
-
-const { sendCode, verifyCode } = await import('../src/services/emailVerificationService.js');
-
-beforeEach(() => {
+beforeEach(async () => {
+  jest.resetModules();
+  attemptStore = await import('../src/services/emailCodeAttempts.js');
+  ({ sendCode, verifyCode } = await import('../src/services/emailVerificationService.js'));
   createMock.mockClear();
   destroyMock.mockClear();
   findOneMock.mockClear();

--- a/tests/fileService.test.js
+++ b/tests/fileService.test.js
@@ -61,6 +61,7 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
 }));
 
 beforeEach(() => {
+  jest.resetModules();
   sendMock.mockClear();
   findByPkMock.mockClear();
   findOneMock.mockClear();

--- a/tests/logger.test.js
+++ b/tests/logger.test.js
@@ -8,10 +8,13 @@ jest.unstable_mockModule('../src/models/log.js', () => ({
   default: { create: createMock },
 }));
 
-const { default: logger } = await import('../logger.js');
-const stream = logger.transports[0]._stream;
+let logger;
+let stream;
 
-beforeEach(() => {
+beforeEach(async () => {
+  jest.resetModules();
+  ({ default: logger } = await import('../logger.js'));
+  stream = logger.transports[0]._stream;
   jest.clearAllMocks();
 });
 

--- a/tests/normativeResultMapper.test.js
+++ b/tests/normativeResultMapper.test.js
@@ -1,10 +1,19 @@
-import { describe, test, expect } from '@jest/globals';
-import mapper from '../src/mappers/normativeResultMapper.js';
+import { describe, test, expect, beforeEach, jest } from '@jest/globals';
 
-const zoneMapper = await import('../src/mappers/normativeZoneMapper.js');
-const groupMapper = await import('../src/mappers/normativeGroupMapper.js');
-const userMapper = await import('../src/mappers/userMapper.js');
-const trainingMapper = await import('../src/mappers/trainingMapper.js');
+let mapper;
+let zoneMapper;
+let groupMapper;
+let userMapper;
+let trainingMapper;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ default: mapper } = await import('../src/mappers/normativeResultMapper.js'));
+  ({ default: zoneMapper } = await import('../src/mappers/normativeZoneMapper.js'));
+  ({ default: groupMapper } = await import('../src/mappers/normativeGroupMapper.js'));
+  ({ default: userMapper } = await import('../src/mappers/userMapper.js'));
+  ({ default: trainingMapper } = await import('../src/mappers/trainingMapper.js'));
+});
 
 const zone = { alias: 'GREEN', name: 'Green' };
 const group = { id: 'g1', name: 'Group1' };
@@ -42,10 +51,10 @@ describe('normativeResultMapper', () => {
       online: false,
       retake: false,
       value: 10,
-      zone: zoneMapper.default.toPublic(zone),
-      group: groupMapper.default.toPublic(group),
-      user: userMapper.default.toPublic({ id: 'u1', first_name: 'John' }),
-      training: trainingMapper.default.toPublic({
+      zone: zoneMapper.toPublic(zone),
+      group: groupMapper.toPublic(group),
+      user: userMapper.toPublic({ id: 'u1', first_name: 'John' }),
+      training: trainingMapper.toPublic({
         id: 't1',
         start_at: '2025-07-18T10:00:00Z',
       }),

--- a/tests/passwordResetService.test.js
+++ b/tests/passwordResetService.test.js
@@ -15,11 +15,14 @@ jest.unstable_mockModule('../src/services/emailService.js', () => ({
   default: { sendPasswordResetEmail: sendEmailMock },
 }));
 
-import * as attemptStore from '../src/services/emailCodeAttempts.js';
+let attemptStore;
+let sendCode;
+let verifyCode;
 
-const { sendCode, verifyCode } = await import('../src/services/passwordResetService.js');
-
-beforeEach(() => {
+beforeEach(async () => {
+  jest.resetModules();
+  attemptStore = await import('../src/services/emailCodeAttempts.js');
+  ({ sendCode, verifyCode } = await import('../src/services/passwordResetService.js'));
   createMock.mockClear();
   destroyMock.mockClear();
   findOneMock.mockClear();

--- a/tests/registrationController.test.js
+++ b/tests/registrationController.test.js
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals';
+import { expect, jest, test, beforeEach } from '@jest/globals';
 
 let validationOk = true;
 
@@ -96,9 +96,14 @@ jest.unstable_mockModule('../src/models/index.js', () => ({
   UserExternalId: { create: createExtMock },
 }));
 
-const { default: controller } = await import(
-  '../src/controllers/registrationController.js'
-);
+let controller;
+
+beforeEach(async () => {
+  jest.resetModules();
+  ({ default: controller } = await import('../src/controllers/registrationController.js'));
+  jest.clearAllMocks();
+  validationOk = true;
+});
 
 function createRes() {
   return { status: jest.fn().mockReturnThis(), json: jest.fn() };


### PR DESCRIPTION
## Summary
- reset module registry in each Jest suite to avoid `module is already linked` errors
- re-import services and mappers after cache reset for clean test isolation
- run Jest sequentially so CI doesn't hit ESM linking race conditions

## Testing
- `npm test`
- `npm run lint`
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_e_68a0e93bfa8c832da9e33527de76217a