### PR TITLE
Add user availability management

### DIFF
--- a/client/src/router.js
+++ b/client/src/router.js
@@ -86,7 +86,7 @@ const routes = [
   {
     path: '/availability',
     component: Availability,
-    meta: { requiresAuth: true, title: 'Моя занятость' },
+    meta: { requiresAuth: true, requiresReferee: true, title: 'Моя занятость' },
   },
   {
     path: '/normatives',

--- a/client/src/router.js
+++ b/client/src/router.js
@@ -11,6 +11,7 @@ import Documents from './views/Documents.vue';
 import Medical from './views/Medical.vue';
 import Camps from './views/Camps.vue';
 import Tasks from './views/Tasks.vue';
+import Availability from './views/Availability.vue';
 import Normatives from './views/Normatives.vue';
 import AdminUsers from './views/AdminUsers.vue';
 import AdminHome from './views/AdminHome.vue';
@@ -81,6 +82,11 @@ const routes = [
     path: '/tasks',
     component: Tasks,
     meta: { requiresAuth: true, title: 'Задачи' },
+  },
+  {
+    path: '/availability',
+    component: Availability,
+    meta: { requiresAuth: true, title: 'Моя занятость' },
   },
   {
     path: '/normatives',

--- a/client/src/views/Availability.vue
+++ b/client/src/views/Availability.vue
@@ -1,0 +1,96 @@
+<script setup>
+import { ref, onMounted, watch } from 'vue';
+import { apiFetch } from '../api.js';
+
+const days = ref([]);
+const loading = ref(true);
+const statuses = [
+  { value: 'FREE', label: 'Свободен' },
+  { value: 'PARTIAL', label: 'Частично' },
+  { value: 'BUSY', label: 'Занят' },
+];
+
+async function load() {
+  loading.value = true;
+  try {
+    const data = await apiFetch('/availabilities');
+    days.value = data.days || [];
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function save() {
+  await apiFetch('/availabilities', {
+    method: 'PUT',
+    body: JSON.stringify({ days: days.value }),
+  });
+}
+
+watch(
+  () => days.value,
+  (list) => {
+    for (const d of list) {
+      if (d.status !== 'PARTIAL') {
+        d.from_time = null;
+        d.to_time = null;
+      }
+    }
+  },
+  { deep: true }
+);
+
+onMounted(load);
+</script>
+
+<template>
+  <div class="py-3">
+    <h2 class="h5 mb-3">Моя занятость</h2>
+    <div v-if="loading" class="text-center py-3">
+      <div class="spinner-border" role="status" aria-label="Загрузка">
+        <span class="visually-hidden">Загрузка…</span>
+      </div>
+    </div>
+    <div v-else>
+      <table class="table align-middle">
+        <thead>
+          <tr>
+            <th>Дата</th>
+            <th>Статус</th>
+            <th>С</th>
+            <th>До</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="d in days" :key="d.date">
+            <td>{{ new Date(d.date).toLocaleDateString('ru-RU') }}</td>
+            <td>
+              <select v-model="d.status" class="form-select">
+                <option v-for="s in statuses" :key="s.value" :value="s.value">
+                  {{ s.label }}
+                </option>
+              </select>
+            </td>
+            <td>
+              <input
+                v-if="d.status === 'PARTIAL'"
+                v-model="d.from_time"
+                type="time"
+                class="form-control"
+              />
+            </td>
+            <td>
+              <input
+                v-if="d.status === 'PARTIAL'"
+                v-model="d.to_time"
+                type="time"
+                class="form-control"
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+      <button class="btn btn-primary" @click="save">Сохранить</button>
+    </div>
+  </div>
+</template>

--- a/client/src/views/Home.vue
+++ b/client/src/views/Home.vue
@@ -17,6 +17,12 @@ const basePreparationSections = [
 ];
 
 const baseWorkSections = [
+  {
+    title: 'Моя занятость',
+    icon: 'bi-calendar-week',
+    to: '/availability',
+    referee: true,
+  },
   { title: 'Мои назначения', icon: 'bi-calendar-check' },
   { title: 'Прошедшие матчи', icon: 'bi-clock-history' },
   { title: 'Рапорты', icon: 'bi-file-earmark-text' },
@@ -47,9 +53,10 @@ async function checkCourse() {
 }
 
 const workSections = computed(() =>
-  hasCourse.value
+  (hasCourse.value
     ? [qualificationSection, ...baseWorkSections]
     : baseWorkSections
+  ).filter((s) => !s.referee || isReferee.value)
 );
 
 const docsSections = [

--- a/src/controllers/userAvailabilityController.js
+++ b/src/controllers/userAvailabilityController.js
@@ -1,0 +1,42 @@
+import userAvailabilityService from '../services/userAvailabilityService.js';
+
+function formatDate(d) {
+  return d.toISOString().slice(0, 10);
+}
+
+export default {
+  async list(req, res) {
+    const today = new Date();
+    const start = formatDate(today);
+    const end = new Date(today);
+    end.setDate(end.getDate() + (7 - end.getDay()) + 7);
+    const endStr = formatDate(end);
+    const records = await userAvailabilityService.listForUser(
+      req.user.id,
+      start,
+      endStr
+    );
+    const map = new Map(records.map((r) => [r.date, r]));
+    const days = [];
+    for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+      const key = formatDate(d);
+      const rec = map.get(key);
+      days.push({
+        date: key,
+        status: rec?.AvailabilityType?.alias ?? 'FREE',
+        from_time: rec?.from_time ?? null,
+        to_time: rec?.to_time ?? null,
+      });
+    }
+    res.json({ days });
+  },
+
+  async set(req, res) {
+    await userAvailabilityService.setForUser(
+      req.user.id,
+      req.body.days || [],
+      req.user.id
+    );
+    res.status(204).end();
+  },
+};

--- a/src/migrations/20250919000000-create-availability-types.js
+++ b/src/migrations/20250919000000-create-availability-types.js
@@ -1,0 +1,40 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('availability_types', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      name: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      alias: { type: Sequelize.STRING(100), allowNull: false, unique: true },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('availability_types');
+  },
+};

--- a/src/migrations/20250920000000-create-user-availabilities.js
+++ b/src/migrations/20250920000000-create-user-availabilities.js
@@ -1,0 +1,55 @@
+'use strict';
+
+module.exports = {
+  async up(queryInterface, Sequelize) {
+    await queryInterface.createTable('user_availabilities', {
+      id: {
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal('uuid_generate_v4()'),
+        primaryKey: true,
+      },
+      user_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'CASCADE',
+      },
+      date: { type: Sequelize.DATEONLY, allowNull: false },
+      type_id: {
+        type: Sequelize.UUID,
+        allowNull: false,
+        references: { model: 'availability_types', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'RESTRICT',
+      },
+      from_time: { type: Sequelize.TIME },
+      to_time: { type: Sequelize.TIME },
+      created_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      updated_by: {
+        type: Sequelize.UUID,
+        references: { model: 'users', key: 'id' },
+        onUpdate: 'CASCADE',
+        onDelete: 'SET NULL',
+      },
+      created_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      updated_at: {
+        type: Sequelize.DATE,
+        defaultValue: Sequelize.literal('NOW()'),
+      },
+      deleted_at: { type: Sequelize.DATE },
+    });
+  },
+
+  async down(queryInterface) {
+    await queryInterface.dropTable('user_availabilities');
+  },
+};

--- a/src/models/availabilityType.js
+++ b/src/models/availabilityType.js
@@ -1,0 +1,26 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class AvailabilityType extends Model {}
+
+AvailabilityType.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    name: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+    alias: { type: DataTypes.STRING(100), allowNull: false, unique: true },
+  },
+  {
+    sequelize,
+    modelName: 'AvailabilityType',
+    tableName: 'availability_types',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default AvailabilityType;

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -64,6 +64,8 @@ import TicketType from './ticketType.js';
 import TicketStatus from './ticketStatus.js';
 import Ticket from './ticket.js';
 import TicketFile from './ticketFile.js';
+import AvailabilityType from './availabilityType.js';
+import UserAvailability from './userAvailability.js';
 
 /* 1-ко-многим: статус → пользователи */
 UserStatus.hasMany(User, { foreignKey: 'status_id' });
@@ -92,6 +94,10 @@ User.hasOne(BankAccount, { foreignKey: 'user_id' });
 BankAccount.belongsTo(User, { foreignKey: 'user_id' });
 User.hasMany(Vehicle, { foreignKey: 'user_id' });
 Vehicle.belongsTo(User, { foreignKey: 'user_id' });
+User.hasMany(UserAvailability, { foreignKey: 'user_id' });
+UserAvailability.belongsTo(User, { foreignKey: 'user_id' });
+AvailabilityType.hasMany(UserAvailability, { foreignKey: 'type_id' });
+UserAvailability.belongsTo(AvailabilityType, { foreignKey: 'type_id' });
 User.hasOne(MedicalCertificate, { foreignKey: 'user_id' });
 MedicalCertificate.belongsTo(User, { foreignKey: 'user_id' });
 MedicalCertificate.hasMany(MedicalCertificateFile, {
@@ -409,6 +415,8 @@ export {
   TicketFile,
   Course,
   UserCourse,
+  AvailabilityType,
+  UserAvailability,
   NormativeValueType,
   MeasurementUnit,
   NormativeZone,

--- a/src/models/userAvailability.js
+++ b/src/models/userAvailability.js
@@ -1,0 +1,38 @@
+import { DataTypes, Model } from 'sequelize';
+
+import sequelize from '../config/database.js';
+
+class UserAvailability extends Model {}
+
+UserAvailability.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      defaultValue: DataTypes.UUIDV4,
+      primaryKey: true,
+    },
+    user_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    date: {
+      type: DataTypes.DATEONLY,
+      allowNull: false,
+    },
+    type_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    from_time: { type: DataTypes.TIME },
+    to_time: { type: DataTypes.TIME },
+  },
+  {
+    sequelize,
+    modelName: 'UserAvailability',
+    tableName: 'user_availabilities',
+    paranoid: true,
+    underscored: true,
+  }
+);
+
+export default UserAvailability;

--- a/src/routes/availabilities.js
+++ b/src/routes/availabilities.js
@@ -2,11 +2,12 @@ import express from 'express';
 
 import auth from '../middlewares/auth.js';
 import requireActive from '../middlewares/requireActive.js';
+import authorize from '../middlewares/authorize.js';
 import controller from '../controllers/userAvailabilityController.js';
 
 const router = express.Router();
 
-router.get('/', auth, requireActive, controller.list);
-router.put('/', auth, requireActive, controller.set);
+router.get('/', auth, requireActive, authorize('REFEREE'), controller.list);
+router.put('/', auth, requireActive, authorize('REFEREE'), controller.set);
 
 export default router;

--- a/src/routes/availabilities.js
+++ b/src/routes/availabilities.js
@@ -1,0 +1,12 @@
+import express from 'express';
+
+import auth from '../middlewares/auth.js';
+import requireActive from '../middlewares/requireActive.js';
+import controller from '../controllers/userAvailabilityController.js';
+
+const router = express.Router();
+
+router.get('/', auth, requireActive, controller.list);
+router.put('/', auth, requireActive, controller.set);
+
+export default router;

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -32,6 +32,7 @@ import sexesRouter from './sexes.js';
 import documentsRouter from './documents.js';
 import ticketsRouter from './tickets.js';
 import tasksRouter from './tasks.js';
+import availabilitiesRouter from './availabilities.js';
 import signTypesRouter from './signTypes.js';
 import normativeTypesRouter from './normativeTypes.js';
 import normativeGroupsRouter from './normativeGroups.js';
@@ -93,6 +94,7 @@ router.use('/normative-tickets', normativeTicketsRouter);
 router.use('/courses', coursesRouter);
 router.use('/course-users', courseUsersRouter);
 router.use('/tasks', tasksRouter);
+router.use('/availabilities', availabilitiesRouter);
 router.use('/tickets', ticketsRouter);
 router.use('/vehicles', vehiclesRouter);
 

--- a/src/seeders/20250919000000-create-availability-types.js
+++ b/src/seeders/20250919000000-create-availability-types.js
@@ -1,0 +1,47 @@
+'use strict';
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { v4: uuidv4 } = require('uuid');
+
+module.exports = {
+  async up(queryInterface) {
+    const now = new Date();
+    const [existing] = await queryInterface.sequelize.query(
+      // eslint-disable-next-line
+      "SELECT COUNT(*) AS cnt FROM availability_types WHERE alias IN ('FREE','PARTIAL','BUSY');"
+    );
+    if (Number(existing[0].cnt) > 0) return;
+    await queryInterface.bulkInsert(
+      'availability_types',
+      [
+        {
+          id: uuidv4(),
+          name: 'Свободен',
+          alias: 'FREE',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Частично занят',
+          alias: 'PARTIAL',
+          created_at: now,
+          updated_at: now,
+        },
+        {
+          id: uuidv4(),
+          name: 'Занят',
+          alias: 'BUSY',
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      { ignoreDuplicates: true }
+    );
+  },
+
+  async down(queryInterface) {
+    await queryInterface.bulkDelete('availability_types', {
+      alias: ['FREE', 'PARTIAL', 'BUSY'],
+    });
+  },
+};

--- a/src/services/userAvailabilityService.js
+++ b/src/services/userAvailabilityService.js
@@ -1,0 +1,49 @@
+import { Op } from 'sequelize';
+
+import { AvailabilityType, User, UserAvailability } from '../models/index.js';
+import ServiceError from '../errors/ServiceError.js';
+
+async function listForUser(userId, startDate, endDate) {
+  return UserAvailability.findAll({
+    where: {
+      user_id: userId,
+      date: { [Op.between]: [startDate, endDate] },
+    },
+    order: [['date', 'ASC']],
+    include: [{ model: AvailabilityType, attributes: ['alias'] }],
+  });
+}
+
+async function setForUser(userId, days, actorId) {
+  const user = await User.findByPk(userId);
+  if (!user) throw new ServiceError('user_not_found', 404);
+  const types = await AvailabilityType.findAll({ attributes: ['id', 'alias'] });
+  const typeMap = new Map(types.map((t) => [t.alias, t.id]));
+  const results = [];
+  for (const day of days) {
+    const typeId = typeMap.get(day.status);
+    if (!typeId) throw new ServiceError('invalid_status', 400);
+    const [record, created] = await UserAvailability.findOrCreate({
+      where: { user_id: userId, date: day.date },
+      defaults: {
+        type_id: typeId,
+        from_time: day.from_time ?? null,
+        to_time: day.to_time ?? null,
+        created_by: actorId,
+        updated_by: actorId,
+      },
+    });
+    if (!created) {
+      await record.update({
+        type_id: typeId,
+        from_time: day.from_time ?? null,
+        to_time: day.to_time ?? null,
+        updated_by: actorId,
+      });
+    }
+    results.push(record);
+  }
+  return results;
+}
+
+export default { listForUser, setForUser };

--- a/tests/userAvailabilityService.test.js
+++ b/tests/userAvailabilityService.test.js
@@ -1,0 +1,64 @@
+import { beforeEach, expect, jest, test } from '@jest/globals';
+
+const findAllMock = jest.fn();
+const findOrCreateMock = jest.fn();
+const userFindMock = jest.fn();
+const availabilityTypeFindAllMock = jest.fn();
+
+jest.unstable_mockModule('../src/models/index.js', () => ({
+  __esModule: true,
+  UserAvailability: { findAll: findAllMock, findOrCreate: findOrCreateMock },
+  User: { findByPk: userFindMock },
+  AvailabilityType: { findAll: availabilityTypeFindAllMock },
+}));
+
+const servicePath = '../src/services/userAvailabilityService.js';
+
+beforeEach(() => {
+  jest.resetModules();
+  findAllMock.mockReset();
+  findOrCreateMock.mockReset();
+  userFindMock.mockReset();
+  availabilityTypeFindAllMock.mockReset();
+});
+
+test('listForUser returns records', async () => {
+  findAllMock.mockResolvedValue([{ id: 1 }]);
+  const service = (await import(servicePath)).default;
+  const res = await service.listForUser('u', '2025-01-01', '2025-01-02');
+  expect(res).toEqual([{ id: 1 }]);
+  expect(findAllMock).toHaveBeenCalled();
+});
+
+test('setForUser throws when user not found', async () => {
+  userFindMock.mockResolvedValue(null);
+  const service = (await import(servicePath)).default;
+  await expect(service.setForUser('u', [], 'a')).rejects.toThrow(
+    'user_not_found'
+  );
+});
+
+test('setForUser creates and updates records', async () => {
+  userFindMock.mockResolvedValue({});
+  const updateMock = jest.fn();
+  findOrCreateMock
+    .mockResolvedValueOnce([{ update: updateMock }, false])
+    .mockResolvedValueOnce([{ id: 'new' }, true]);
+  availabilityTypeFindAllMock.mockResolvedValue([
+    { id: 'free-id', alias: 'FREE' },
+    { id: 'busy-id', alias: 'BUSY' },
+  ]);
+  const service = (await import(servicePath)).default;
+  await service.setForUser(
+    'u',
+    [
+      { date: '2025-01-01', status: 'FREE' },
+      { date: '2025-01-02', status: 'BUSY' },
+    ],
+    'a'
+  );
+  expect(updateMock).toHaveBeenCalled();
+  expect(findOrCreateMock).toHaveBeenCalledTimes(2);
+  expect(availabilityTypeFindAllMock).toHaveBeenCalled();
+  expect(findOrCreateMock.mock.calls[0][0].defaults.type_id).toBe('free-id');
+});


### PR DESCRIPTION
## Summary
- allow users to mark availability for current and next week
- expose `/availabilities` API for listing and updating availability
- add basic UI to manage day availability
- move availability statuses into `availability_types` table with name and alias

## Testing
- `npm run lint`
- `npm run format:check`
- `npm test`
- `cd client && npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a367f85430832db31b07191cfb02c1